### PR TITLE
Table processing

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,7 +37,7 @@ const getCourseSectionFromFeatureUrl = courseFeature => {
   const urlParts = courseFeature["ocw_feature_url"]
     .replace(/\/index.htm?l/, "/")
     .split("/")
-  return urlParts[urlParts.length - 1]
+  return urlParts[urlParts.length - 1].split("#")[0]
 }
 
 const getCourseCollectionText = courseCollection => {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -44,8 +44,8 @@ turndownService.addRule("table", {
      */
     content = content
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
-      .replace(/\r?\n|\r/g, "<br>")
-      .replace(/\|<br>\|/g, "|\n|")
+      .replace(/\r?\n|\r/g, "{{< br >}}")
+      .replace(/\|{{< br >}}\|/g, "|\n|")
       .replace(/REPLACETHISWITHAPIPE/g, "&#124;")
     // Only do this if header lines are found
     if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n|\r)/g)) {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -23,10 +23,10 @@ turndownService.addRule("table", {
     // then reintroduce them between rows
     content = content
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
-      .replace(/\r?\n|\r/g, "")
-      .replace(/\|\|/g, "|\r\n|")
+      .replace(/\r?\n|\r/g, "{{<br>}}")
+      .replace(/\|{{<br>}}\|/g, "|\r\n|")
     // Only do this if header lines are found
-    if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n)/g)) {
+    if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n|\r)/g)) {
       // Get the amount of columns
       content.split("\n").forEach(line => {
         if (line.indexOf("---") !== -1) {
@@ -37,7 +37,7 @@ turndownService.addRule("table", {
       return content
         .replace(/\| \*\*/g, "\r\n**")
         .replace(
-          /\*\* \|\r?\n/g,
+          /\*\* \|\r?\n|\r/g,
           `**\r\n\r\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
         )
         .replace(/\|\|/g, "|\r\n|")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -17,13 +17,30 @@ turndownService.use(tables)
  **/
 turndownService.addRule("table", {
   filter:      ["table"],
-  replacement: content => {
-    // Get the bounds of the table, remove all line breaks,
-    // then reintroduce them between rows
+  replacement: (content, node, options) => {
+    // Interate the HTML node and replace all pipes inside table
+    // cells with a marker we'll use later
+    for (let i = 0; i < node.rows.length; i++) {
+      const cells = node.rows[i].cells
+      for (let j = 0; j < cells.length; j++) {
+        cells[j].innerHTML = cells[j].innerHTML.replace(
+          /\|/g,
+          "REPLACETHISWITHAPIPE"
+        )
+      }
+    }
+    // Regenerate markdown for this table with cell edits
+    content = turndownService.turndown(node)
+    /**
+     * Get the bounds of the table, remove all line breaks, then
+     * from earlier with the HTML character entity for a pipe
+     * reintroduce them between rows, replacing our pipe marker
+     */
     content = content
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
       .replace(/\r?\n|\r/g, "<br>")
       .replace(/\|<br>\|/g, "|\n|")
+      .replace(/REPLACETHISWITHAPIPE/g, "&#124;")
     // Only do this if header lines are found
     if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n|\r)/g)) {
       // Get the amount of columns

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -14,8 +14,10 @@ turndownService.use(tables)
 turndownService.addRule("table", {
   filter:      ["table"],
   replacement: content => {
-    content = content.replace("\n", "<br>")
-    return content.substring(content.indexOf("|"), content.lastIndexOf("|"))
+    return content
+      .substring(content.indexOf("|"), content.lastIndexOf("|"))
+      .replace(/\r?\n|\r/g, "")
+      .replace(/\|\|/g, "|\n|")
   }
 })
 const helpers = require("./helpers")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -4,29 +4,19 @@ const yaml = require("js-yaml")
 const markdown = require("markdown-builder")
 const titleCase = require("title-case")
 const TurndownService = require("turndown")
+const turndownPluginGfm = require('turndown-plugin-gfm')
+const gfm = turndownPluginGfm.gfm
+const tables = turndownPluginGfm.tables
 const turndownService = new TurndownService()
+turndownService.use(gfm)
+turndownService.use(tables)
+
 turndownService.addRule("table", {
   filter:      ["table"],
   replacement: content => {
-    return `{{< rawhtml >}}<table>${content}</table>{{< /rawhtml >}}`
-  }
-})
-turndownService.addRule("th", {
-  filter:      ["th"],
-  replacement: content => {
-    return `<th>${content}</th>`
-  }
-})
-turndownService.addRule("tr", {
-  filter:      ["tr"],
-  replacement: content => {
-    return `<tr>${content}</tr>`
-  }
-})
-turndownService.addRule("td", {
-  filter:      ["td"],
-  replacement: content => {
-    return `<td>${content}</td>`
+    content = content.replace('\n', '<br>')
+    table = content.substring(content.indexOf("|"), content.lastIndexOf("|"))
+    return table;
   }
 })
 const helpers = require("./helpers")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -82,8 +82,8 @@ turndownService.addRule("refshortcode", {
     const ref = turndownService.escape(
       node
         .getAttribute("href")
-        .replace(REFSHORTCODESTART, '{{< ref "')
-        .replace(REFSHORTCODEEND, '" >}}')
+        .replace(REFSHORTCODESTART, '{{% ref "')
+        .replace(REFSHORTCODEEND, '" %}}')
     )
     return `[${content}](${ref})`
   }
@@ -220,12 +220,20 @@ const generateCourseFeatures = courseData => {
     Generate markdown for the "Course Features" section of the home page
     */
   const courseFeaturesHeader = markdown.headers.hX(5, "Course Features")
-  const courseFeatures = courseData["course_features"].map(courseFeature => {
-    return markdown.misc.link(
-      courseFeature["ocw_feature"],
-      helpers.getCourseSectionFromFeatureUrl(courseFeature)
-    )
-  })
+  const courseFeatures = courseData["course_features"]
+    .map(courseFeature => {
+      const section = helpers.getCourseSectionFromFeatureUrl(courseFeature)
+      const matchingSectionsWithText = courseData["course_pages"].filter(
+        coursePage => coursePage["text"] && coursePage["short_url"] == section
+      )
+      if (section && matchingSectionsWithText.length > 0) {
+        return markdown.misc.link(
+          courseFeature["ocw_feature"],
+          `{{% ref "sections/${section}" %}}`
+        )
+      } else return null
+    })
+    .filter(courseFeature => courseFeature)
   return `${courseFeaturesHeader}\n${markdown.lists.ul(courseFeatures)}`
 }
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -12,6 +12,10 @@ const turndownService = new TurndownService()
 turndownService.use(gfm)
 turndownService.use(tables)
 
+const REPLACETHISWITHAPIPE = "REPLACETHISWITHAPIPE"
+const REFSHORTCODESTART = "REFSHORTCODESTART"
+const REFSHORTCODEEND = "REFSHORTCODEEND"
+
 /**
  * Sanitize markdown table content
  **/
@@ -27,7 +31,7 @@ turndownService.addRule("table", {
       for (let j = 0; j < cells.length; j++) {
         cells[j].innerHTML = cells[j].innerHTML.replace(
           /\|/g,
-          "REPLACETHISWITHAPIPE"
+          REPLACETHISWITHAPIPE
         )
       }
     }
@@ -60,9 +64,6 @@ turndownService.addRule("table", {
     } else return content
   }
 })
-
-const REFSHORTCODESTART = "REFSHORTCODESTART"
-const REFSHORTCODEEND = "REFSHORTCODEEND"
 
 /**
  * Build links with Hugo shortcodes to course sections

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -5,7 +5,7 @@ const markdown = require("markdown-builder")
 const titleCase = require("title-case")
 const TurndownService = require("turndown")
 const turndownPluginGfm = require("turndown-plugin-gfm")
-const { getCourseImageUrl } = require("./helpers")
+const helpers = require("./helpers")
 const gfm = turndownPluginGfm.gfm
 const tables = turndownPluginGfm.tables
 const turndownService = new TurndownService()
@@ -60,7 +60,6 @@ turndownService.addRule("table", {
     } else return content
   }
 })
-const helpers = require("./helpers")
 
 const REFSHORTCODESTART = "REFSHORTCODESTART"
 const REFSHORTCODEEND = "REFSHORTCODEEND"

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -250,7 +250,7 @@ const generateCourseFeatures = courseData => {
     .map(courseFeature => {
       const section = helpers.getCourseSectionFromFeatureUrl(courseFeature)
       const matchingSectionsWithText = courseData["course_pages"].filter(
-        coursePage => coursePage["text"] && coursePage["short_url"] == section
+        coursePage => coursePage["text"] && coursePage["short_url"] === section
       )
       if (section && matchingSectionsWithText.length > 0) {
         return markdown.misc.link(

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -26,7 +26,7 @@ turndownService.addRule("table", {
       .replace(/\r?\n|\r/g, "")
       .replace(/\|\|/g, "|\r\n|")
     // Only do this if header lines are found
-    if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n)/g || []).length > 0) {
+    if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n)/g)) {
       // Get the amount of columns
       content.split("\n").forEach(line => {
         if (line.indexOf("---") !== -1) {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -5,6 +5,7 @@ const markdown = require("markdown-builder")
 const titleCase = require("title-case")
 const TurndownService = require("turndown")
 const turndownPluginGfm = require("turndown-plugin-gfm")
+const { getCourseImageUrl } = require("./helpers")
 const gfm = turndownPluginGfm.gfm
 const tables = turndownPluginGfm.tables
 const turndownService = new TurndownService()

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -18,8 +18,10 @@ turndownService.use(tables)
 turndownService.addRule("table", {
   filter:      ["table"],
   replacement: (content, node, options) => {
-    // Interate the HTML node and replace all pipes inside table
-    // cells with a marker we'll use later
+    /**
+     * Interate the HTML node and replace all pipes inside table
+     * cells with a marker we'll use later
+     */
     for (let i = 0; i < node.rows.length; i++) {
       const cells = node.rows[i].cells
       for (let j = 0; j < cells.length; j++) {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -4,7 +4,7 @@ const yaml = require("js-yaml")
 const markdown = require("markdown-builder")
 const titleCase = require("title-case")
 const TurndownService = require("turndown")
-const turndownPluginGfm = require('turndown-plugin-gfm')
+const turndownPluginGfm = require("turndown-plugin-gfm")
 const gfm = turndownPluginGfm.gfm
 const tables = turndownPluginGfm.tables
 const turndownService = new TurndownService()
@@ -14,9 +14,9 @@ turndownService.use(tables)
 turndownService.addRule("table", {
   filter:      ["table"],
   replacement: content => {
-    content = content.replace('\n', '<br>')
+    content = content.replace("\n", "<br>")
     table = content.substring(content.indexOf("|"), content.lastIndexOf("|"))
-    return table;
+    return table
   }
 })
 const helpers = require("./helpers")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -24,9 +24,9 @@ turndownService.addRule("table", {
     content = content
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
       .replace(/\r?\n|\r/g, "")
-      .replace(/\|\|/g, "|\n|")
+      .replace(/\|\|/g, "|\r\n|")
     // Only do this if header lines are found
-    if (content.indexOf(/(?<=\| \*\*)(.*?)(?=\*\* \|\n])/g) !== -1) {
+    if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n)/g || []).length > 0) {
       // Get the amount of columns
       content.split("\n").forEach(line => {
         if (line.indexOf("---") !== -1) {
@@ -35,11 +35,12 @@ turndownService.addRule("table", {
       })
       // Split headers out on their own so they aren't in one cell
       return content
-        .replace(/\| \*\*/g, "\n**")
+        .replace(/\| \*\*/g, "\r\n**")
         .replace(
-          /\*\* \|\n/g,
-          `**\n\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
+          /\*\* \|\r?\n/g,
+          `**\r\n\r\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
         )
+        .replace(/\|\|/g, "|\r\n|")
     } else return content
   }
 })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -33,7 +33,9 @@ turndownService.addRule("table", {
         .replace(/\| \*\*/g, "\n**")
         .replace(
           /\*\* \|\r?\n|\r/g,
-          `**\n\n${"| ".repeat(totalColumns)}|\n${"| --- ".repeat(totalColumns)}|`
+          `**\n\n${"| ".repeat(totalColumns)}|\n${"| --- ".repeat(
+            totalColumns
+          )}|`
         )
         .replace(/\|\|/g, "|\n|")
     } else return content

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -25,19 +25,23 @@ turndownService.addRule("table", {
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
       .replace(/\r?\n|\r/g, "")
       .replace(/\|\|/g, "|\n|")
-    // Get the amount of columns
-    content.split("\n").forEach(line => {
-      if (line.indexOf("---") !== -1) {
-        columns = line.match(/---/g || []).length
-      }
-    })
-    // Split headers out on their own so they aren't in one cell
-    return content
-      .replace(/\| \*\*/g, "\n**")
-      .replace(
-        /\*\* \|/g,
-        `**\n\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
-      )
+    // Only do this if header lines are found
+    if (content.indexOf(/(?<=\| \*\*)(.*?)(?=\*\* \|\n])/g) !== -1) {
+      // Get the amount of columns
+      content.split("\n").forEach(line => {
+        if (line.indexOf("---") !== -1) {
+          columns = line.match(/---/g || []).length
+        }
+      })
+      // Split headers out on their own so they aren't in one cell
+      return content
+        .replace(/\| \*\*/g, "\n**")
+        .replace(
+          /\*\* \|\n/g,
+          `**\n\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
+        )
+    }
+    else return content
   }
 })
 const helpers = require("./helpers")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -6,8 +6,7 @@ const titleCase = require("title-case")
 const TurndownService = require("turndown")
 const turndownPluginGfm = require("turndown-plugin-gfm")
 const helpers = require("./helpers")
-const gfm = turndownPluginGfm.gfm
-const tables = turndownPluginGfm.tables
+const { gfm, tables } = turndownPluginGfm
 const turndownService = new TurndownService()
 turndownService.use(gfm)
 turndownService.use(tables)

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -18,29 +18,24 @@ turndownService.use(tables)
 turndownService.addRule("table", {
   filter:      ["table"],
   replacement: content => {
-    let columns = 0
     // Get the bounds of the table, remove all line breaks,
     // then reintroduce them between rows
     content = content
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
-      .replace(/\r?\n|\r/g, "{{<br>}}")
-      .replace(/\|{{<br>}}\|/g, "|\r\n|")
+      .replace(/\r?\n|\r/g, "<br>")
+      .replace(/\|<br>\|/g, "|\n|")
     // Only do this if header lines are found
     if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n|\r)/g)) {
       // Get the amount of columns
-      content.split("\n").forEach(line => {
-        if (line.indexOf("---") !== -1) {
-          columns = line.match(/---/g || []).length
-        }
-      })
+      const totalColumns = content.match(/---/g || []).length
       // Split headers out on their own so they aren't in one cell
       return content
-        .replace(/\| \*\*/g, "\r\n**")
+        .replace(/\| \*\*/g, "\n**")
         .replace(
           /\*\* \|\r?\n|\r/g,
-          `**\r\n\r\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
+          `**\n\n${"| ".repeat(totalColumns)}|\n${"| --- ".repeat(totalColumns)}|`
         )
-        .replace(/\|\|/g, "|\r\n|")
+        .replace(/\|\|/g, "|\n|")
     } else return content
   }
 })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -14,12 +14,12 @@ turndownService.use(tables)
 
 /**
  * Sanitize markdown table content
-**/
+ **/
 turndownService.addRule("table", {
   filter:      ["table"],
   replacement: content => {
     let columns = 0
-    // Get the bounds of the table, remove all line breaks, 
+    // Get the bounds of the table, remove all line breaks,
     // then reintroduce them between rows
     content = content
       .substring(content.indexOf("|"), content.lastIndexOf("|"))

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -40,8 +40,7 @@ turndownService.addRule("table", {
           /\*\* \|\n/g,
           `**\n\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
         )
-    }
-    else return content
+    } else return content
   }
 })
 const helpers = require("./helpers")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -15,8 +15,7 @@ turndownService.addRule("table", {
   filter:      ["table"],
   replacement: content => {
     content = content.replace("\n", "<br>")
-    table = content.substring(content.indexOf("|"), content.lastIndexOf("|"))
-    return table
+    return content.substring(content.indexOf("|"), content.lastIndexOf("|"))
   }
 })
 const helpers = require("./helpers")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -12,13 +12,32 @@ const turndownService = new TurndownService()
 turndownService.use(gfm)
 turndownService.use(tables)
 
+/**
+ * Sanitize markdown table content
+**/
 turndownService.addRule("table", {
   filter:      ["table"],
   replacement: content => {
-    return content
+    let columns = 0
+    // Get the bounds of the table, remove all line breaks, 
+    // then reintroduce them between rows
+    content = content
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
       .replace(/\r?\n|\r/g, "")
       .replace(/\|\|/g, "|\n|")
+    // Get the amount of columns
+    content.split("\n").forEach(line => {
+      if (line.indexOf("---") !== -1) {
+        columns = line.match(/---/g || []).length
+      }
+    })
+    // Split headers out on their own so they aren't in one cell
+    return content
+      .replace(/\| \*\*/g, "\n**")
+      .replace(
+        /\*\* \|/g,
+        `**\n\n${"| ".repeat(columns)}|\n${"| --- ".repeat(columns)}|`
+      )
   }
 })
 const helpers = require("./helpers")

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -226,7 +226,7 @@ describe("generateCourseFeatures", () => {
       const matchingSectionsWithText = singleCourseJsonData[
         "course_pages"
       ].filter(
-        coursePage => coursePage["text"] && coursePage["short_url"] == section
+        coursePage => coursePage["text"] && coursePage["short_url"] === section
       )
       if (section && matchingSectionsWithText.length > 0) {
         expect(link).to.be.calledWithExactly(

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -223,7 +223,9 @@ describe("generateCourseFeatures", () => {
   it("calls markdown.misc.link for each item in course_features", () => {
     singleCourseJsonData["course_features"].forEach(courseFeature => {
       const section = helpers.getCourseSectionFromFeatureUrl(courseFeature)
-      const matchingSectionsWithText = singleCourseJsonData["course_pages"].filter(
+      const matchingSectionsWithText = singleCourseJsonData[
+        "course_pages"
+      ].filter(
         coursePage => coursePage["text"] && coursePage["short_url"] == section
       )
       if (section && matchingSectionsWithText.length > 0) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -222,8 +222,16 @@ describe("generateCourseFeatures", () => {
 
   it("calls markdown.misc.link for each item in course_features", () => {
     singleCourseJsonData["course_features"].forEach(courseFeature => {
-      const url = helpers.getCourseSectionFromFeatureUrl(courseFeature)
-      expect(link).to.be.calledWithExactly(courseFeature["ocw_feature"], url)
+      const section = helpers.getCourseSectionFromFeatureUrl(courseFeature)
+      const matchingSectionsWithText = singleCourseJsonData["course_pages"].filter(
+        coursePage => coursePage["text"] && coursePage["short_url"] == section
+      )
+      if (section && matchingSectionsWithText.length > 0) {
+        expect(link).to.be.calledWithExactly(
+          courseFeature["ocw_feature"],
+          `{{% ref "sections/${section}" %}}`
+        )
+      }
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/10

#### What's this PR do?
Adds a turndown rule to process content in raw HTML tables brought in from OCW course sections so they are rendered properly by Hugo.

#### How should this be manually tested?
Run any number of courses through this tool, then take the markdown output and load it into hugo-course-publisher.  The assignments or readings sections usually have tables, and they should now display properly.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/71601691-8fd1df80-2b22-11ea-8539-166e454aafa7.png)

