### PR TITLE
Course home menu entry was at the wrong config level

### DIFF
--- a/src/lib/markdown_generators.js
+++ b/src/lib/markdown_generators.js
@@ -99,11 +99,11 @@ const generateCourseHomeFrontMatter = courseData => {
       topics:        courseData["course_collections"].map(makeTopic),
       course_number: courseNumber,
       term:          `${courseData["from_semester"]} ${courseData["from_year"]}`,
-      level:         courseData["course_level"],
-      menu:          {
-        main: {
-          weight: -10
-        }
+      level:         courseData["course_level"]
+    },
+    menu: {
+      main: {
+        weight: -10
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/14

#### What's this PR do?
Front matter generation for the course home page had the menu item entry inside of the course_info node, when it should have been at the root.

#### How should this be manually tested?
Convert a course, then generate a static site using hugo-course-generator.  The "Course Home" menu item should appear.
