### PR TITLE
Course collections speciality

### DIFF
--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -35,7 +35,6 @@ const scanCourses = (source, destination) => {
   // Iterate all subdirectories under source
   directoriesScanned = 0
   const contents = fs.readdirSync(source)
-  // console.log("readdir called")
   const totalDirectories = contents.filter(file =>
     directoryExists(path.join(source, file))
   ).length

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,18 +42,28 @@ const getCourseSectionFromFeatureUrl = courseFeature => {
   return urlParts[urlParts.length - 1].split("#")[0]
 }
 
-const getCourseCollectionText = (courseCollection, separator) => {
+const getCourseCollectionObject = courseCollection => {
   const feature = courseCollection["ocw_feature"]
   const subfeature = courseCollection["ocw_subfeature"]
   const speciality = courseCollection["ocw_speciality"]
-  let collection = feature
+  const collection = {}
+  if (feature) {
+    collection["feature"] = feature
+  }
   if (subfeature) {
-    collection = `${collection} ${separator} ${subfeature}`
+    collection["subfeature"] = subfeature
   }
   if (speciality) {
-    collection = `${collection} ${separator} ${speciality}`
+    collection["speciality"] = speciality
   }
   return collection
+}
+
+const getCourseCollectionText = (courseCollection, separator) => {
+  const collection = getCourseCollectionObject(courseCollection)
+  return Object.keys(collection)
+    .map(property => collection[property])
+    .join(` ${separator} `)
 }
 
 const getYoutubeEmbedHtml = media => {
@@ -87,6 +97,7 @@ module.exports = {
   getCourseImageUrl,
   getCourseNumber,
   getCourseSectionFromFeatureUrl,
+  getCourseCollectionObject,
   getCourseCollectionText,
   getYoutubeEmbedHtml,
   pathToChildRecursive

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -48,10 +48,10 @@ const getCourseCollectionObject = courseCollection => {
   const speciality = courseCollection["ocw_speciality"]
   const collection = {}
   if (feature) {
-    collection["feature"] = feature
+    collection["topic"] = feature
   }
   if (subfeature) {
-    collection["subfeature"] = subfeature
+    collection["subtopic"] = subfeature
   }
   if (speciality) {
     collection["speciality"] = speciality

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,29 +42,18 @@ const getCourseSectionFromFeatureUrl = courseFeature => {
   return urlParts[urlParts.length - 1].split("#")[0]
 }
 
-const getCourseCollectionText = courseCollection => {
+const getCourseCollectionText = (courseCollection, separator) => {
   const feature = courseCollection["ocw_feature"]
   const subfeature = courseCollection["ocw_subfeature"]
-  const specialty = courseCollection["ocw_specialty"]
+  const speciality = courseCollection["ocw_speciality"]
   let collection = feature
   if (subfeature) {
-    collection = `${collection} > ${subfeature}`
+    collection = `${collection} ${separator} ${subfeature}`
   }
-  if (specialty) {
-    collection = `${collection} > ${specialty}`
+  if (speciality) {
+    collection = `${collection} ${separator} ${speciality}`
   }
   return collection
-}
-
-const makeTopic = feature => {
-  let topic = ""
-  if (feature["ocw_feature"]) {
-    topic = feature["ocw_feature"]
-  }
-  if (feature["ocw_subfeature"]) {
-    topic = `${topic} - ${feature["ocw_subfeature"]}`
-  }
-  return topic
 }
 
 const getYoutubeEmbedHtml = media => {
@@ -99,7 +88,6 @@ module.exports = {
   getCourseNumber,
   getCourseSectionFromFeatureUrl,
   getCourseCollectionText,
-  makeTopic,
   getYoutubeEmbedHtml,
   pathToChildRecursive
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -44,7 +44,8 @@ describe("getCourseCollectionText", () => {
   it("returns the expected course collection from a course collection object", () => {
     assert.equal(
       helpers.getCourseCollectionText(
-        singleCourseJsonData["course_collections"][0], ">"
+        singleCourseJsonData["course_collections"][0],
+        ">"
       ),
       "Engineering > Systems Engineering > Systems Design"
     )

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -45,8 +45,8 @@ describe("getCourseCollectionObject", () => {
     const collection = helpers.getCourseCollectionObject(
       singleCourseJsonData["course_collections"][0]
     )
-    assert.equal(collection["feature"], "Engineering")
-    assert.equal(collection["subfeature"], "Systems Engineering")
+    assert.equal(collection["topic"], "Engineering")
+    assert.equal(collection["subtopic"], "Systems Engineering")
     assert.equal(collection["speciality"], "Systems Design")
   })
 })

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -44,18 +44,9 @@ describe("getCourseCollectionText", () => {
   it("returns the expected course collection from a course collection object", () => {
     assert.equal(
       helpers.getCourseCollectionText(
-        singleCourseJsonData["course_collections"][0]
+        singleCourseJsonData["course_collections"][0], ">"
       ),
-      "Engineering > Systems Engineering"
-    )
-  })
-})
-
-describe("makeTopic", () => {
-  it("returns the expected topic from a course collection object", () => {
-    assert.equal(
-      helpers.makeTopic(singleCourseJsonData["course_collections"][0]),
-      "Engineering - Systems Engineering"
+      "Engineering > Systems Engineering > Systems Design"
     )
   })
 })

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -40,8 +40,17 @@ describe("getCourseSectionFromFeatureUrl", () => {
   })
 })
 
+describe("getCourseCollectionObject", () => {
+  it("returns a course collection object with the expected keys", () => {
+    const collection = helpers.getCourseCollectionObject(singleCourseJsonData["course_collections"][0])
+    assert.equal(collection["feature"], "Engineering")
+    assert.equal(collection["subfeature"], "Systems Engineering")
+    assert.equal(collection["speciality"], "Systems Design")
+  })
+})
+
 describe("getCourseCollectionText", () => {
-  it("returns the expected course collection from a course collection object", () => {
+  it("returns the expected course collection text from a course collection object and a separator", () => {
     assert.equal(
       helpers.getCourseCollectionText(
         singleCourseJsonData["course_collections"][0],

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -42,7 +42,9 @@ describe("getCourseSectionFromFeatureUrl", () => {
 
 describe("getCourseCollectionObject", () => {
   it("returns a course collection object with the expected keys", () => {
-    const collection = helpers.getCourseCollectionObject(singleCourseJsonData["course_collections"][0])
+    const collection = helpers.getCourseCollectionObject(
+      singleCourseJsonData["course_collections"][0]
+    )
     assert.equal(collection["feature"], "Engineering")
     assert.equal(collection["subfeature"], "Systems Engineering")
     assert.equal(collection["speciality"], "Systems Design")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -230,7 +230,9 @@ const generateCourseHomeFrontMatter = courseData => {
       department: titleCase.titleCase(
         courseData["url"].split("/")[2].replace(/-/g, " ")
       ),
-      topics:        courseData["course_collections"].map(courseCollection => helpers.getCourseCollectionText(courseCollection, ">")),
+      topics: courseData["course_collections"].map(courseCollection =>
+        helpers.getCourseCollectionText(courseCollection, ">")
+      ),
       course_number: helpers.getCourseNumber(courseData),
       term:          `${courseData["from_semester"]} ${courseData["from_year"]}`,
       level:         courseData["course_level"]

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -231,7 +231,7 @@ const generateCourseHomeFrontMatter = courseData => {
         courseData["url"].split("/")[2].replace(/-/g, " ")
       ),
       topics: courseData["course_collections"].map(courseCollection =>
-        helpers.getCourseCollectionText(courseCollection, ">")
+        helpers.getCourseCollectionObject(courseCollection)
       ),
       course_number: helpers.getCourseNumber(courseData),
       term:          `${courseData["from_semester"]} ${courseData["from_year"]}`,

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -230,7 +230,7 @@ const generateCourseHomeFrontMatter = courseData => {
       department: titleCase.titleCase(
         courseData["url"].split("/")[2].replace(/-/g, " ")
       ),
-      topics:        courseData["course_collections"].map(helpers.makeTopic),
+      topics:        courseData["course_collections"].map(courseCollection => helpers.getCourseCollectionText(courseCollection, ">")),
       course_number: helpers.getCourseNumber(courseData),
       term:          `${courseData["from_semester"]} ${courseData["from_year"]}`,
       level:         courseData["course_level"]
@@ -308,7 +308,7 @@ const generateCourseCollections = courseData => {
   const courseCollections = courseData["course_collections"].map(
     courseCollection => {
       return markdown.misc.link(
-        helpers.getCourseCollectionText(courseCollection),
+        helpers.getCourseCollectionText(courseCollection, ">"),
         "#"
       )
     }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -77,14 +77,14 @@ describe("generateCourseHomeFrontMatter", () => {
   let courseHomeFrontMatter,
     getCourseImageUrl,
     getCourseNumber,
-    getCourseCollectionText,
+    getCourseCollectionObject,
     safeDump
   const sandbox = sinon.createSandbox()
 
   beforeEach(() => {
     getCourseImageUrl = sandbox.spy(helpers, "getCourseImageUrl")
     getCourseNumber = sandbox.spy(helpers, "getCourseNumber")
-    getCourseCollectionText = sandbox.spy(helpers, "getCourseCollectionText")
+    getCourseCollectionObject = sandbox.spy(helpers, "getCourseCollectionObject")
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeFrontMatter = yaml.safeLoad(
       markdownGenerators
@@ -142,9 +142,9 @@ describe("generateCourseHomeFrontMatter", () => {
     assert.equal(expectedValue, foundValue)
   })
 
-  it("calls getCourseCollectionText with each of the elements in course_collections", () => {
+  it("calls getCourseCollectionObject with each of the elements in course_collections", () => {
     singleCourseJsonData["course_collections"].forEach(courseCollection => {
-      expect(getCourseCollectionText).to.be.calledWith(courseCollection, ">")
+      expect(getCourseCollectionObject).to.be.calledWith(courseCollection)
     })
   })
 
@@ -152,11 +152,13 @@ describe("generateCourseHomeFrontMatter", () => {
     const expectedValues = singleCourseJsonData[
       "course_collections"
     ].map(courseCollection =>
-      helpers.getCourseCollectionText(courseCollection, ">")
+      helpers.getCourseCollectionObject(courseCollection)
     )
     const foundValues = courseHomeFrontMatter["course_info"]["topics"]
     expectedValues.forEach((expectedValue, index) => {
-      assert.equal(expectedValue, foundValues[index])
+      Object.keys(foundValues[index]).forEach(property => {
+        assert.equal(expectedValue[property], foundValues[index][property])
+      })
     })
   })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -84,7 +84,10 @@ describe("generateCourseHomeFrontMatter", () => {
   beforeEach(() => {
     getCourseImageUrl = sandbox.spy(helpers, "getCourseImageUrl")
     getCourseNumber = sandbox.spy(helpers, "getCourseNumber")
-    getCourseCollectionObject = sandbox.spy(helpers, "getCourseCollectionObject")
+    getCourseCollectionObject = sandbox.spy(
+      helpers,
+      "getCourseCollectionObject"
+    )
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeFrontMatter = yaml.safeLoad(
       markdownGenerators

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -77,14 +77,14 @@ describe("generateCourseHomeFrontMatter", () => {
   let courseHomeFrontMatter,
     getCourseImageUrl,
     getCourseNumber,
-    makeTopic,
+    getCourseCollectionText,
     safeDump
   const sandbox = sinon.createSandbox()
 
   beforeEach(() => {
     getCourseImageUrl = sandbox.spy(helpers, "getCourseImageUrl")
     getCourseNumber = sandbox.spy(helpers, "getCourseNumber")
-    makeTopic = sandbox.spy(helpers, "makeTopic")
+    getCourseCollectionText = sandbox.spy(helpers, "getCourseCollectionText")
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeFrontMatter = yaml.safeLoad(
       markdownGenerators
@@ -142,17 +142,19 @@ describe("generateCourseHomeFrontMatter", () => {
     assert.equal(expectedValue, foundValue)
   })
 
-  it("calls makeTopic with each of the elements in course_collections", () => {
+  it("calls getCourseCollectionText with each of the elements in course_collections", () => {
     singleCourseJsonData["course_collections"].forEach(courseCollection => {
-      expect(makeTopic).to.be.calledWith(courseCollection)
+      expect(getCourseCollectionText).to.be.calledWith(courseCollection, ">")
     })
   })
 
   it("sets the topics property on the course info object to data parsed from course_collections in the course json data", () => {
     const expectedValues = singleCourseJsonData["course_collections"].map(
-      helpers.makeTopic
+      courseCollection => helpers.getCourseCollectionText(courseCollection, ">")
     )
     const foundValues = courseHomeFrontMatter["course_info"]["topics"]
+    console.log(expectedValues)
+    console.log(foundValues)
     expectedValues.forEach((expectedValue, index) => {
       assert.equal(expectedValue, foundValues[index])
     })
@@ -302,7 +304,7 @@ describe("generateCourseCollections", () => {
 
   it("calls markdown.misc.link for each item in course_collections", () => {
     singleCourseJsonData["course_collections"].forEach(courseCollection => {
-      const collection = helpers.getCourseCollectionText(courseCollection)
+      const collection = helpers.getCourseCollectionText(courseCollection, ">")
       expect(link).to.be.calledWithExactly(collection, "#")
     })
   })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -149,8 +149,10 @@ describe("generateCourseHomeFrontMatter", () => {
   })
 
   it("sets the topics property on the course info object to data parsed from course_collections in the course json data", () => {
-    const expectedValues = singleCourseJsonData["course_collections"].map(
-      courseCollection => helpers.getCourseCollectionText(courseCollection, ">")
+    const expectedValues = singleCourseJsonData[
+      "course_collections"
+    ].map(courseCollection =>
+      helpers.getCourseCollectionText(courseCollection, ">")
     )
     const foundValues = courseHomeFrontMatter["course_info"]["topics"]
     console.log(expectedValues)

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -155,8 +155,6 @@ describe("generateCourseHomeFrontMatter", () => {
       helpers.getCourseCollectionText(courseCollection, ">")
     )
     const foundValues = courseHomeFrontMatter["course_info"]["topics"]
-    console.log(expectedValues)
-    console.log(foundValues)
     expectedValues.forEach((expectedValue, index) => {
       assert.equal(expectedValue, foundValues[index])
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/RQRqs9FQ/35-topic-subtopic-specialty

#### What's this PR do?
Removes the `makeTopic` function and refactors `getCourseCollectionsText` to serve as a singular function for getting a text representation of an object from the `course_collections` array in `master.json`.  "Specialty was also changed to "speciality" to match what's in the `master.json` file and the speciality is now being rendered as the last part of the string that is returned.

#### How should this be manually tested?
All tests should pass, and you should be able to run the program against the sample courses and see topics being rendered with their speciality.
