### PR TITLE
Multiple departments and course numbers

### DIFF
--- a/src/departments.json
+++ b/src/departments.json
@@ -1,0 +1,149 @@
+[{
+    "title": "Chemistry",
+    "id": "chemistry",
+    "depNo": "5"
+}, {
+    "title": "Biological Engineering",
+    "id": "biological-engineering",
+    "depNo": "20"
+}, {
+    "title": "Aeronautics and Astronautics",
+    "id": "aeronautics-and-astronautics",
+    "depNo": "16"
+}, {
+    "title": "Global Studies and Languages",
+    "id": "global-studies-and-languages",
+    "depNo": "21G"
+}, {
+    "title": "Mathematics",
+    "id": "mathematics",
+    "depNo": "18"
+}, {
+    "title": "Health Sciences and Technology",
+    "id": "health-sciences-and-technology",
+    "depNo": "HST"
+}, {
+    "title": "Edgerton Center",
+    "id": "edgerton-center",
+    "depNo": "EC"
+}, {
+    "title": "Women's and Gender Studies",
+    "id": "womens-and-gender-studies",
+    "depNo": "WGS"
+}, {
+    "title": "Urban Studies and Planning",
+    "id": "urban-studies-and-planning",
+    "depNo": "11"
+}, {
+    "title": "Sloan School of Management",
+    "id": "sloan-school-of-management",
+    "depNo": "15"
+}, {
+    "title": "Anthropology",
+    "id": "anthropology",
+    "depNo": "21A"
+}, {
+    "title": "Engineering Systems Division",
+    "id": "engineering-systems-division",
+    "depNo": "ESD"
+}, {
+    "title": "Chemical Engineering",
+    "id": "chemical-engineering",
+    "depNo": "10"
+}, {
+    "title": "Earth, Atmospheric, and Planetary Sciences",
+    "id": "earth-atmospheric-and-planetary-sciences",
+    "depNo": "12"
+}, {
+    "title": "Music and Theater Arts",
+    "id": "music-and-theater-arts",
+    "depNo": "21M"
+}, {
+    "title": "Athletics, Physical Education and Recreation",
+    "id": "athletics-physical-education-and-recreation",
+    "depNo": "PE"
+}, {
+    "title": "Architecture",
+    "id": "architecture",
+    "depNo": "4"
+}, {
+    "title": "Experimental Study Group",
+    "id": "experimental-study-group",
+    "depNo": "ES"
+}, {
+    "title": "Literature",
+    "id": "literature",
+    "depNo": "21L"
+}, {
+    "title": "Mechanical Engineering",
+    "id": "mechanical-engineering",
+    "depNo": "2"
+}, {
+    "title": "Electrical Engineering and Computer Science",
+    "id": "electrical-engineering-and-computer-science",
+    "depNo": "6"
+}, {
+    "title": "Materials Science and Engineering",
+    "id": "materials-science-and-engineering",
+    "depNo": "3"
+}, {
+    "title": "History",
+    "id": "history",
+    "depNo": "21H"
+}, {
+    "title": "Linguistics and Philosophy",
+    "id": "linguistics-and-philosophy",
+    "depNo": "24"
+}, {
+    "title": "Institute for Data, Systems, and Society",
+    "id": "institute-for-data-systems-and-society",
+    "depNo": "IDS"
+}, {
+    "title": "Biology",
+    "id": "biology",
+    "depNo": "7"
+}, {
+    "title": "Civil and Environmental Engineering",
+    "id": "civil-and-environmental-engineering",
+    "depNo": "1"
+}, {
+    "title": "Comparative Media Studies/Writing",
+    "id": "comparative-media-studies-writing",
+    "depNo": "CMS-W"
+}, {
+    "title": "Nuclear Science and Engineering",
+    "id": "nuclear-engineering",
+    "depNo": "22"
+}, {
+    "title": "Economics",
+    "id": "economics",
+    "depNo": "14"
+}, {
+    "title": "Concourse",
+    "id": "concourse",
+    "depNo": "CC"
+}, {
+    "title": "Brain and Cognitive Sciences",
+    "id": "brain-and-cognitive-sciences",
+    "depNo": "9"
+}, {
+    "title": "Science, Technology, and Society",
+    "id": "science-technology-and-society",
+    "depNo": "STS"
+}, {
+    "title": "Political Science",
+    "id": "political-science",
+    "depNo": "17"
+}, {
+    "title": "Media Arts and Sciences",
+    "id": "media-arts-and-sciences",
+    "depNo": "MAS"
+}, {
+    "title": "Physics",
+    "id": "physics",
+    "depNo": "8"
+}, {
+    "title": "Supplemental Resources",
+    "id": "supplemental-resources",
+    "depNo": "RES"
+}]

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,12 @@
 const path = require("path")
 const departmentsJson = require("./departments.json")
 
+const findDepartmentByNumber = departmentNumber => {
+  return departmentsJson.find(department => {
+    return department["depNo"] === departmentNumber.toString()
+  })
+}
+
 const getCourseImageUrl = courseData => {
   /*
     Constructs the course image filename using parts of the course short_url
@@ -28,9 +34,7 @@ const getCourseImageUrl = courseData => {
 
 const getDepartments = courseData => {
   const primaryDepartmentNumber = courseData["sort_as"].split(".")[0]
-  const department = departmentsJson.find(departmentObject => {
-    return departmentObject["depNo"] === primaryDepartmentNumber
-  })
+  const department = findDepartmentByNumber(primaryDepartmentNumber)
   if (department) {
     let departments = [department["title"]]
     if (courseData["extra_course_number"]) {
@@ -39,9 +43,7 @@ const getDepartments = courseData => {
           const extraDepartmentNumber = extraCourseNumber[
             "linked_course_number_col"
           ].split(".")[0]
-          const department = departmentsJson.find(departmentObject => {
-            return departmentObject["depNo"] === extraDepartmentNumber
-          })
+          const department = findDepartmentByNumber(extraDepartmentNumber)
           if (department) {
             return department["title"]
           } else return null
@@ -124,6 +126,7 @@ const pathToChildRecursive = (basePath, child, courseData) => {
 
 module.exports = {
   getCourseImageUrl,
+  findDepartmentByNumber,
   getDepartments,
   getCourseNumbers,
   getCourseSectionFromFeatureUrl,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const path = require("path")
+const departmentsJson = require("./departments.json")
 
 const getCourseImageUrl = courseData => {
   /*
@@ -25,14 +26,44 @@ const getCourseImageUrl = courseData => {
     : "images/course_image.jpg"
 }
 
-const getCourseNumber = courseData => {
-  let courseNumber = courseData["sort_as"]
-  if (courseData["extra_course_number"]) {
-    if (courseData["extra_course_number"]["sort_as_col"]) {
-      courseNumber = `${courseNumber} / ${courseData["extra_course_number"]["sort_as_col"]}`
+const getDepartments = courseData => {
+  const primaryDepartmentNumber = courseData["sort_as"].split(".")[0]
+  const department = departmentsJson.find(departmentObject => {
+    return departmentObject["depNo"] === primaryDepartmentNumber
+  })
+  if (department) {
+    let departments = [department["title"]]
+    if (courseData["extra_course_number"]) {
+      departments = departments.concat(
+        courseData["extra_course_number"].map(
+          extraCourseNumber =>  {
+            const extraDepartmentNumber = extraCourseNumber["linked_course_number_col"].split(".")[0]
+            const department = departmentsJson.find(departmentObject => {
+              return (departmentObject["depNo"] === extraDepartmentNumber)
+            })
+            if (department) {
+              return department["title"]
+            }
+            else return null
+          }
+        )
+      )
     }
+    return [...new Set(departments)].filter(Boolean)
   }
-  return courseNumber
+  else return []
+}
+
+const getCourseNumbers = courseData => {
+  let courseNumbers = [courseData["sort_as"]]
+  if (courseData["extra_course_number"]) {
+    courseNumbers = courseNumbers.concat(
+      courseData["extra_course_number"].map(
+        extraCourseNumber => extraCourseNumber["linked_course_number_col"]
+      )
+    )
+  }
+  return courseNumbers
 }
 
 const getCourseSectionFromFeatureUrl = courseFeature => {
@@ -95,7 +126,8 @@ const pathToChildRecursive = (basePath, child, courseData) => {
 
 module.exports = {
   getCourseImageUrl,
-  getCourseNumber,
+  getDepartments,
+  getCourseNumbers,
   getCourseSectionFromFeatureUrl,
   getCourseCollectionObject,
   getCourseCollectionText,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -35,23 +35,21 @@ const getDepartments = courseData => {
     let departments = [department["title"]]
     if (courseData["extra_course_number"]) {
       departments = departments.concat(
-        courseData["extra_course_number"].map(
-          extraCourseNumber =>  {
-            const extraDepartmentNumber = extraCourseNumber["linked_course_number_col"].split(".")[0]
-            const department = departmentsJson.find(departmentObject => {
-              return (departmentObject["depNo"] === extraDepartmentNumber)
-            })
-            if (department) {
-              return department["title"]
-            }
-            else return null
-          }
-        )
+        courseData["extra_course_number"].map(extraCourseNumber => {
+          const extraDepartmentNumber = extraCourseNumber[
+            "linked_course_number_col"
+          ].split(".")[0]
+          const department = departmentsJson.find(departmentObject => {
+            return departmentObject["depNo"] === extraDepartmentNumber
+          })
+          if (department) {
+            return department["title"]
+          } else return null
+        })
       )
     }
     return [...new Set(departments)].filter(Boolean)
-  }
-  else return []
+  } else return []
 }
 
 const getCourseNumbers = courseData => {

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -23,6 +23,16 @@ describe("getCourseImageUrl", () => {
   })
 })
 
+describe("findDepartmentByNumber", () => {
+  it("returns the expected department for a given department number integer", () => {
+    assert.equal(helpers.findDepartmentByNumber(18)["title"], "Mathematics")
+  })
+
+  it("returns the expected department for a given department number string", () => {
+    assert.equal(helpers.findDepartmentByNumber("18")["title"], "Mathematics")
+  })
+})
+
 describe("getDepartments", () => {
   it("returns the expected departments for a given course json input", () => {
     assert.equal(

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -25,8 +25,14 @@ describe("getCourseImageUrl", () => {
 
 describe("getDepartments", () => {
   it("returns the expected departments for a given course json input", () => {
-    assert.equal(helpers.getDepartments(singleCourseJsonData)[0], "Mechanical Engineering")
-    assert.equal(helpers.getDepartments(singleCourseJsonData)[1], "Aeronautics and Astronautics")
+    assert.equal(
+      helpers.getDepartments(singleCourseJsonData)[0],
+      "Mechanical Engineering"
+    )
+    assert.equal(
+      helpers.getDepartments(singleCourseJsonData)[1],
+      "Aeronautics and Astronautics"
+    )
   })
 })
 

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -23,9 +23,17 @@ describe("getCourseImageUrl", () => {
   })
 })
 
-describe("getCourseNumber", () => {
-  it("returns the expected course number for a given course json input", () => {
-    assert.equal(helpers.getCourseNumber(singleCourseJsonData), "2.00 A")
+describe("getDepartments", () => {
+  it("returns the expected departments for a given course json input", () => {
+    assert.equal(helpers.getDepartments(singleCourseJsonData)[0], "Mechanical Engineering")
+    assert.equal(helpers.getDepartments(singleCourseJsonData)[1], "Aeronautics and Astronautics")
+  })
+})
+
+describe("getCourseNumbers", () => {
+  it("returns the expected course numbers for a given course json input", () => {
+    assert.equal(helpers.getCourseNumbers(singleCourseJsonData)[0], "2.00 A")
+    assert.equal(helpers.getCourseNumbers(singleCourseJsonData)[1], "16.00AJ")
   })
 })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -227,15 +227,13 @@ const generateCourseHomeFrontMatter = courseData => {
         instructor =>
           `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
       ),
-      department: titleCase.titleCase(
-        courseData["url"].split("/")[2].replace(/-/g, " ")
-      ),
-      topics: courseData["course_collections"].map(courseCollection =>
+      departments: helpers.getDepartments(courseData),
+      topics:      courseData["course_collections"].map(courseCollection =>
         helpers.getCourseCollectionObject(courseCollection)
       ),
-      course_number: helpers.getCourseNumber(courseData),
-      term:          `${courseData["from_semester"]} ${courseData["from_year"]}`,
-      level:         courseData["course_level"]
+      course_numbers: helpers.getCourseNumbers(courseData),
+      term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,
+      level:          courseData["course_level"]
     },
     menu: {
       [courseData["short_url"]]: {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -76,14 +76,14 @@ describe("generateMarkdownFromJson", () => {
 describe("generateCourseHomeFrontMatter", () => {
   let courseHomeFrontMatter,
     getCourseImageUrl,
-    getCourseNumber,
+    getCourseNumbers,
     getCourseCollectionObject,
     safeDump
   const sandbox = sinon.createSandbox()
 
   beforeEach(() => {
     getCourseImageUrl = sandbox.spy(helpers, "getCourseImageUrl")
-    getCourseNumber = sandbox.spy(helpers, "getCourseNumber")
+    getCourseNumbers = sandbox.spy(helpers, "getCourseNumbers")
     getCourseCollectionObject = sandbox.spy(
       helpers,
       "getCourseCollectionObject"
@@ -138,11 +138,8 @@ describe("generateCourseHomeFrontMatter", () => {
   })
 
   it("sets the department property on the course_info node to the deparentment found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
-    const expectedValue = titleCase.titleCase(
-      singleCourseJsonData["url"].split("/")[2].replace(/-/g, " ")
-    )
-    const foundValue = courseHomeFrontMatter["course_info"]["department"]
-    assert.equal(expectedValue, foundValue)
+    assert.equal("Mechanical Engineering", courseHomeFrontMatter["course_info"]["departments"][0])
+    assert.equal("Aeronautics and Astronautics", courseHomeFrontMatter["course_info"]["departments"][1])
   })
 
   it("calls getCourseCollectionObject with each of the elements in course_collections", () => {
@@ -165,13 +162,13 @@ describe("generateCourseHomeFrontMatter", () => {
     })
   })
 
-  it("calls getCourseNumber with the course json data", () => {
-    expect(getCourseNumber).to.be.calledWithExactly(singleCourseJsonData)
+  it("calls getCourseNumbers with the course json data", () => {
+    expect(getCourseNumbers).to.be.calledWithExactly(singleCourseJsonData)
   })
 
   it("sets the course_number property on the course info object to data parsed from sort_as and extra_course_number properties in the course json data", () => {
-    const expectedValue = helpers.getCourseNumber(singleCourseJsonData)
-    const foundValue = courseHomeFrontMatter["course_info"]["course_number"]
+    const expectedValue = helpers.getCourseNumbers(singleCourseJsonData)[0]
+    const foundValue = courseHomeFrontMatter["course_info"]["course_numbers"][0]
     assert.equal(expectedValue, foundValue)
   })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -138,8 +138,14 @@ describe("generateCourseHomeFrontMatter", () => {
   })
 
   it("sets the department property on the course_info node to the deparentment found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
-    assert.equal("Mechanical Engineering", courseHomeFrontMatter["course_info"]["departments"][0])
-    assert.equal("Aeronautics and Astronautics", courseHomeFrontMatter["course_info"]["departments"][1])
+    assert.equal(
+      "Mechanical Engineering",
+      courseHomeFrontMatter["course_info"]["departments"][0]
+    )
+    assert.equal(
+      "Aeronautics and Astronautics",
+      courseHomeFrontMatter["course_info"]["departments"][1]
+    )
   })
 
   it("calls getCourseCollectionObject with each of the elements in course_collections", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/kVtunwvL/33-course-info-multiple-departments-multiple-course-numbers

#### What's this PR do?
Adds support for multiple departments / course numbers.

#### How should this be manually tested?
Run the program against the sample courses, verify that the front matter properties are now "departments" and "course_numbers" and that courses that should have multiples have them.
