### PR TITLE
Add image caption / alt text

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -214,12 +214,14 @@ const generateCourseHomeFrontMatter = courseData => {
     */
 
   const frontMatter = {
-    title:              "Course Home",
-    course_id:          courseData["short_url"],
-    course_title:       courseData["title"],
-    course_image_url:   helpers.getCourseImageUrl(courseData),
-    course_description: courseData["description"],
-    course_info:        {
+    title:                       "Course Home",
+    course_id:                   courseData["short_url"],
+    course_title:                courseData["title"],
+    course_image_url:            helpers.getCourseImageUrl(courseData),
+    course_image_alternate_text: courseData["image_alternate_text"],
+    course_image_caption_text:   courseData["image_caption_text"],
+    course_description:          courseData["description"],
+    course_info:                 {
       instructors: courseData["instructors"].map(
         instructor =>
           `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/HQzBhlkR/49-fix-course-image-on-the-desktop

#### What's this PR do?
This adds the `course_image_caption_text` and `course_image_alternate_text` keys to the course home page front matter from master json.

#### How should this be manually tested?
Test should pass.  Run the conversion against the sample courses and verify that caption and alternate text fields exist in the home page front matter and that the content seems right.
