### PR TITLE
Consolidated topics structure

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const _ = require("lodash")
 const path = require("path")
 const departmentsJson = require("./departments.json")
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -88,6 +88,7 @@ const getCourseSectionFromFeatureUrl = courseFeature => {
   } else return featureUrl
 }
 
+/* eslint-disable camelcase */
 const getConsolidatedTopics = courseCollections => {
   let topics = {}
   courseCollections.forEach(courseCollection => {
@@ -105,6 +106,7 @@ const getConsolidatedTopics = courseCollections => {
   })
   return topics
 }
+/* eslint-disable camelcase */
 
 const getYoutubeEmbedHtml = media => {
   const youTubeMedia = media["embedded_media"].filter(embeddedMedia => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -91,29 +91,27 @@ const getConsolidatedTopics = courseCollections => {
   const topics = {}
   courseCollections.forEach(courseCollection => {
     if (!topics.hasOwnProperty(courseCollection["ocw_feature"])) {
-      if (!topics.hasOwnProperty(courseCollection["ocw_feature"])) {
-        topics[courseCollection["ocw_feature"]] = {}
+      topics[courseCollection["ocw_feature"]] = {}
+    }
+    if (courseCollection["ocw_subfeature"]) {
+      if (
+        !topics[courseCollection["ocw_feature"]].hasOwnProperty(
+          courseCollection["ocw_subfeature"]
+        )
+      ) {
+        topics[courseCollection["ocw_feature"]][
+          courseCollection["ocw_subfeature"]
+        ] = []
       }
-      if (courseCollection["ocw_subfeature"]) {
+      if (courseCollection["ocw_speciality"]) {
         if (
-          !topics[courseCollection["ocw_feature"]].hasOwnProperty(
+          !topics[courseCollection["ocw_feature"]][
             courseCollection["ocw_subfeature"]
-          )
+          ].includes(courseCollection["ocw_speciality"])
         ) {
           topics[courseCollection["ocw_feature"]][
             courseCollection["ocw_subfeature"]
-          ] = []
-        }
-        if (courseCollection["ocw_speciality"]) {
-          if (
-            !topics[courseCollection["ocw_feature"]][
-              courseCollection["ocw_subfeature"]
-            ].includes(courseCollection["ocw_speciality"])
-          ) {
-            topics[courseCollection["ocw_feature"]][
-              courseCollection["ocw_subfeature"]
-            ].push(courseCollection["ocw_speciality"])
-          }
+          ].push(courseCollection["ocw_speciality"])
         }
       }
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -102,7 +102,12 @@ const getConsolidatedTopics = courseCollections => {
         Boolean
       )
     }
-    topics = _.merge(topics, collectionTopic)
+    
+    topics = _.mergeWith(topics, collectionTopic, (objValue, srcValue) => {
+      if (_.isArray(objValue)) {
+        return objValue.concat(srcValue)
+      }
+    })
   })
   return topics
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -88,33 +88,19 @@ const getCourseSectionFromFeatureUrl = courseFeature => {
 }
 
 const getConsolidatedTopics = courseCollections => {
-  const topics = {}
+  let topics = {}
   courseCollections.forEach(courseCollection => {
-    if (!topics.hasOwnProperty(courseCollection["ocw_feature"])) {
-      topics[courseCollection["ocw_feature"]] = {}
+    const { ocw_feature, ocw_subfeature, ocw_speciality } = courseCollection
+
+    const collectionTopic = {
+      [ ocw_feature ]: {}
     }
-    if (courseCollection["ocw_subfeature"]) {
-      if (
-        !topics[courseCollection["ocw_feature"]].hasOwnProperty(
-          courseCollection["ocw_subfeature"]
-        )
-      ) {
-        topics[courseCollection["ocw_feature"]][
-          courseCollection["ocw_subfeature"]
-        ] = []
-      }
-      if (courseCollection["ocw_speciality"]) {
-        if (
-          !topics[courseCollection["ocw_feature"]][
-            courseCollection["ocw_subfeature"]
-          ].includes(courseCollection["ocw_speciality"])
-        ) {
-          topics[courseCollection["ocw_feature"]][
-            courseCollection["ocw_subfeature"]
-          ].push(courseCollection["ocw_speciality"])
-        }
-      }
+    if (ocw_subfeature) {
+      collectionTopic[ocw_feature][ocw_subfeature] = [ocw_speciality].filter(
+        Boolean
+      )
     }
+    topics = _.merge(topics, collectionTopic)
   })
   return topics
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -95,7 +95,7 @@ const getConsolidatedTopics = courseCollections => {
     const { ocw_feature, ocw_subfeature, ocw_speciality } = courseCollection
 
     const collectionTopic = {
-      [ ocw_feature ]: {}
+      [ocw_feature]: {}
     }
     if (ocw_subfeature) {
       collectionTopic[ocw_feature][ocw_subfeature] = [ocw_speciality].filter(

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -102,7 +102,7 @@ const getConsolidatedTopics = courseCollections => {
         Boolean
       )
     }
-    
+
     topics = _.mergeWith(topics, collectionTopic, (objValue, srcValue) => {
       if (_.isArray(objValue)) {
         return objValue.concat(srcValue)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -87,21 +87,36 @@ const getCourseSectionFromFeatureUrl = courseFeature => {
   } else return featureUrl
 }
 
-const getCourseCollectionObject = courseCollection => {
-  const feature = courseCollection["ocw_feature"]
-  const subfeature = courseCollection["ocw_subfeature"]
-  const speciality = courseCollection["ocw_speciality"]
-  const collection = {}
-  if (feature) {
-    collection["topic"] = feature
-  }
-  if (subfeature) {
-    collection["subtopic"] = subfeature
-  }
-  if (speciality) {
-    collection["speciality"] = speciality
-  }
-  return collection
+const getConsolidatedTopics = courseCollections => {
+  const topics = {}
+  courseCollections.forEach(courseCollection => {
+    if (!topics.hasOwnProperty(courseCollection["ocw_feature"])) {
+      topics[courseCollection["ocw_feature"]] = {}
+      if (courseCollection["ocw_subfeature"]) {
+        if (
+          !topics[courseCollection["ocw_feature"]].hasOwnProperty(
+            courseCollection["ocw_subfeature"]
+          )
+        ) {
+          topics[courseCollection["ocw_feature"]][
+            courseCollection["ocw_subfeature"]
+          ] = []
+        }
+        if (courseCollection["ocw_speciality"]) {
+          if (
+            !topics[courseCollection["ocw_feature"]][
+              courseCollection["ocw_subfeature"]
+            ].includes(courseCollection["ocw_speciality"])
+          ) {
+            topics[courseCollection["ocw_feature"]][
+              courseCollection["ocw_subfeature"]
+            ].push(courseCollection["ocw_speciality"])
+          }
+        }
+      }
+    }
+  })
+  return topics
 }
 
 const getCourseCollectionText = (courseCollection, separator) => {
@@ -145,7 +160,7 @@ module.exports = {
   getCourseNumbers,
   getCourseFeatureObject,
   getCourseSectionFromFeatureUrl,
-  getCourseCollectionObject,
+  getConsolidatedTopics,
   getCourseCollectionText,
   getYoutubeEmbedHtml,
   pathToChildRecursive

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -91,7 +91,9 @@ const getConsolidatedTopics = courseCollections => {
   const topics = {}
   courseCollections.forEach(courseCollection => {
     if (!topics.hasOwnProperty(courseCollection["ocw_feature"])) {
-      topics[courseCollection["ocw_feature"]] = {}
+      if (!topics.hasOwnProperty(courseCollection["ocw_feature"])) {
+        topics[courseCollection["ocw_feature"]] = {}
+      }
       if (courseCollection["ocw_subfeature"]) {
         if (
           !topics[courseCollection["ocw_feature"]].hasOwnProperty(
@@ -117,13 +119,6 @@ const getConsolidatedTopics = courseCollections => {
     }
   })
   return topics
-}
-
-const getCourseCollectionText = (courseCollection, separator) => {
-  const collection = getCourseCollectionObject(courseCollection)
-  return Object.keys(collection)
-    .map(property => collection[property])
-    .join(` ${separator} `)
 }
 
 const getYoutubeEmbedHtml = media => {
@@ -161,7 +156,6 @@ module.exports = {
   getCourseFeatureObject,
   getCourseSectionFromFeatureUrl,
   getConsolidatedTopics,
-  getCourseCollectionText,
   getYoutubeEmbedHtml,
   pathToChildRecursive
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -82,29 +82,6 @@ describe("getCourseSectionFromFeatureUrl", () => {
   })
 })
 
-describe("getCourseCollectionObject", () => {
-  it("returns a course collection object with the expected keys", () => {
-    const collection = helpers.getCourseCollectionObject(
-      singleCourseJsonData["course_collections"][0]
-    )
-    assert.equal(collection["topic"], "Engineering")
-    assert.equal(collection["subtopic"], "Systems Engineering")
-    assert.equal(collection["speciality"], "Systems Design")
-  })
-})
-
-describe("getCourseCollectionText", () => {
-  it("returns the expected course collection text from a course collection object and a separator", () => {
-    assert.equal(
-      helpers.getCourseCollectionText(
-        singleCourseJsonData["course_collections"][0],
-        ">"
-      ),
-      "Engineering > Systems Engineering > Systems Design"
-    )
-  })
-})
-
 describe("getYoutubeEmbedHtml", () => {
   it("returned html strings contain the youtube media url for each embedded media", () => {
     let html = ""

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -230,9 +230,7 @@ const generateCourseHomeFrontMatter = courseData => {
       course_features: courseData["course_features"].map(courseFeature =>
         helpers.getCourseFeatureObject(courseFeature)
       ),
-      topics: courseData["course_collections"].map(courseCollection =>
-        helpers.getCourseCollectionObject(courseCollection)
-      ),
+      topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
       course_numbers: helpers.getCourseNumbers(courseData),
       term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,
       level:          courseData["course_level"]

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -297,27 +297,6 @@ const generateCourseFeatures = courseData => {
   return `${courseFeaturesHeader}\n${markdown.lists.ul(courseFeatures)}`
 }
 
-const generateCourseCollections = courseData => {
-  /**
-    Generate markdown for the "Course Collections" section of the home page
-    */
-  const courseCollectionsHeader = markdown.headers.hX(5, "Course Collections")
-  const courseCollectionsSubHeader = `\nSee related courses in the following collections:\n\n${markdown.emphasis.i(
-    "Find Courses by Topic"
-  )}\n\n`
-  const courseCollections = courseData["course_collections"].map(
-    courseCollection => {
-      return markdown.misc.link(
-        helpers.getCourseCollectionText(courseCollection, ">"),
-        "#"
-      )
-    }
-  )
-  return `${courseCollectionsHeader}${courseCollectionsSubHeader}${markdown.lists.ul(
-    courseCollections
-  )}`
-}
-
 const generateCourseSectionMarkdown = (page, courseData) => {
   /**
     Generate markdown a given course section page
@@ -334,6 +313,5 @@ module.exports = {
   generateCourseHomeFrontMatter,
   generateCourseSectionFrontMatter,
   generateCourseFeatures,
-  generateCourseCollections,
   generateCourseSectionMarkdown
 }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -297,39 +297,6 @@ describe("generateCourseFeatures", () => {
   })
 })
 
-describe("generateCourseCollections", () => {
-  let courseCollections, hX, link, ul
-  const sandbox = sinon.createSandbox()
-
-  beforeEach(() => {
-    hX = sandbox.spy(markdown.headers, "hX")
-    link = sandbox.spy(markdown.misc, "link")
-    ul = sandbox.spy(markdown.lists, "ul")
-    courseCollections = markdownGenerators.generateCourseCollections(
-      singleCourseJsonData
-    )
-  })
-
-  afterEach(() => {
-    sandbox.restore()
-  })
-
-  it("calls markdown.headers.hx to create the Course Collections header", () => {
-    expect(hX).to.be.calledWithExactly(5, "Course Collections")
-  })
-
-  it("calls markdown.misc.link for each item in course_collections", () => {
-    singleCourseJsonData["course_collections"].forEach(courseCollection => {
-      const collection = helpers.getCourseCollectionText(courseCollection, ">")
-      expect(link).to.be.calledWithExactly(collection, "#")
-    })
-  })
-
-  it("calls markdown.lists.ul to create the Course Features list", () => {
-    expect(ul).to.be.calledOnce
-  })
-})
-
 describe("generateCourseSectionMarkdown", () => {
   it("can be called without generating an error and returns something", () => {
     const coursePagesWithText = singleCourseJsonData["course_pages"].filter(

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -77,17 +77,14 @@ describe("generateCourseHomeFrontMatter", () => {
   let courseHomeFrontMatter,
     getCourseImageUrl,
     getCourseNumbers,
-    getCourseCollectionObject,
+    getConsolidatedTopics,
     safeDump
   const sandbox = sinon.createSandbox()
 
   beforeEach(() => {
     getCourseImageUrl = sandbox.spy(helpers, "getCourseImageUrl")
     getCourseNumbers = sandbox.spy(helpers, "getCourseNumbers")
-    getCourseCollectionObject = sandbox.spy(
-      helpers,
-      "getCourseCollectionObject"
-    )
+    getConsolidatedTopics = sandbox.spy(helpers, "getConsolidatedTopics")
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeFrontMatter = yaml.safeLoad(
       markdownGenerators
@@ -148,23 +145,34 @@ describe("generateCourseHomeFrontMatter", () => {
     )
   })
 
-  it("calls getCourseCollectionObject with each of the elements in course_collections", () => {
-    singleCourseJsonData["course_collections"].forEach(courseCollection => {
-      expect(getCourseCollectionObject).to.be.calledWith(courseCollection)
-    })
+  it("calls getConsolidatedTopics with course_collections", () => {
+    expect(getConsolidatedTopics).to.be.calledWith(
+      singleCourseJsonData["course_collections"]
+    )
   })
 
   it("sets the topics property on the course info object to data parsed from course_collections in the course json data", () => {
-    const expectedValues = singleCourseJsonData[
-      "course_collections"
-    ].map(courseCollection =>
-      helpers.getCourseCollectionObject(courseCollection)
+    const expectedValues = helpers.getConsolidatedTopics(
+      singleCourseJsonData["course_collections"]
     )
     const foundValues = courseHomeFrontMatter["course_info"]["topics"]
-    expectedValues.forEach((expectedValue, index) => {
-      Object.keys(foundValues[index]).forEach(property => {
-        assert.equal(expectedValue[property], foundValues[index][property])
-      })
+    Object.keys(expectedValues).forEach(expectedTopicKey => {
+      assert.isTrue(foundValues.hasOwnProperty(expectedTopicKey))
+      Object.keys(expectedValues[expectedTopicKey]).forEach(
+        expectedSubTopicKey => {
+          assert.isTrue(
+            foundValues[expectedTopicKey].hasOwnProperty(expectedSubTopicKey)
+          )
+          expectedValues[expectedTopicKey][expectedSubTopicKey].forEach(
+            (expectedSpeciality, index) => {
+              assert.equal(
+                expectedSpeciality,
+                foundValues[expectedTopicKey][expectedSubTopicKey][index]
+              )
+            }
+          )
+        }
+      )
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/kFngfkoX/28-course-by-topic-widget

#### What's this PR do?
Firstly, this PR removes all functions & tests related to the `course_collections` string manipulation and markdown generation that is not needed anymore.  The topics contained in this object are now consolidated into a hierarchical structure and put into the course home page front matter under the key `topics`.

#### How should this be manually tested?
All tests should pass.  When you generate markdown for the sample sites now, you should see a new `topics` object in the course home front matter that is a hierarchical representation of the topic -> subtopic -> speciality relationship.