### PR TITLE
fix course images

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,29 +10,6 @@ const findDepartmentByNumber = departmentNumber => {
   })
 }
 
-const getCourseImageUrl = courseData => {
-  /*
-    Constructs the course image filename using parts of the course short_url
-    */
-  const courseNameParts = courseData["short_url"].split("-")
-  const imageName = `${courseNameParts[0]}-${
-    courseNameParts[1]
-  }${courseNameParts[courseNameParts.length - 2].charAt(0)}${courseNameParts[
-    courseNameParts.length - 1
-  ].slice(2)}.jpg`
-  const courseImageMedia = courseData["course_files"].find(media => {
-    if (media["parent_uid"] === courseData["uid"]) {
-      const fileLocationParts = media["file_location"].split("/")
-      const jsonFile = fileLocationParts[fileLocationParts.length - 1]
-      const imageFile = `${media["uid"]}_${imageName}`
-      return jsonFile === imageFile
-    }
-  })
-  return courseImageMedia
-    ? courseImageMedia["file_location"]
-    : "images/course_image.jpg"
-}
-
 const getDepartments = courseData => {
   const primaryDepartmentNumber = courseData["sort_as"].split(".")[0]
   const department = findDepartmentByNumber(primaryDepartmentNumber)
@@ -141,7 +118,6 @@ const pathToChildRecursive = (basePath, child, courseData) => {
 }
 
 module.exports = {
-  getCourseImageUrl,
   findDepartmentByNumber,
   getDepartments,
   getCourseNumbers,

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -14,15 +14,6 @@ const singleCourseMasterJsonPath = path.join(
 const singleCourseRawData = fs.readFileSync(singleCourseMasterJsonPath)
 const singleCourseJsonData = JSON.parse(singleCourseRawData)
 
-describe("getCourseImageUrl", () => {
-  it("returns the expected course image file name for a given course json input", () => {
-    assert.equal(
-      helpers.getCourseImageUrl(singleCourseJsonData),
-      "https://open-learning-course-data.s3.amazonaws.com/2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009/b6a31a6a85998d664ea826a766d9032b_2-00ajs09.jpg"
-    )
-  })
-})
-
 describe("findDepartmentByNumber", () => {
   it("returns the expected department for a given department number integer", () => {
     assert.equal(helpers.findDepartmentByNumber(18)["title"], "Mathematics")

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -217,7 +217,7 @@ const generateCourseHomeFrontMatter = courseData => {
     title:                       "Course Home",
     course_id:                   courseData["short_url"],
     course_title:                courseData["title"],
-    course_image_url:            helpers.getCourseImageUrl(courseData),
+    course_image_url:            courseData["image_src"],
     course_image_alternate_text: courseData["image_alternate_text"],
     course_image_caption_text:   courseData["image_caption_text"],
     course_description:          courseData["description"],

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -74,15 +74,10 @@ describe("generateMarkdownFromJson", () => {
 })
 
 describe("generateCourseHomeFrontMatter", () => {
-  let courseHomeFrontMatter,
-    getCourseImageUrl,
-    getCourseNumbers,
-    getConsolidatedTopics,
-    safeDump
+  let courseHomeFrontMatter, getCourseNumbers, getConsolidatedTopics, safeDump
   const sandbox = sinon.createSandbox()
 
   beforeEach(() => {
-    getCourseImageUrl = sandbox.spy(helpers, "getCourseImageUrl")
     getCourseNumbers = sandbox.spy(helpers, "getCourseNumbers")
     getConsolidatedTopics = sandbox.spy(helpers, "getConsolidatedTopics")
     safeDump = sandbox.spy(yaml, "safeDump")
@@ -109,12 +104,8 @@ describe("generateCourseHomeFrontMatter", () => {
     assert.equal(expectedValue, foundValue)
   })
 
-  it("calls getCourseImageUrl with the course json data", () => {
-    expect(getCourseImageUrl).to.be.calledWithExactly(singleCourseJsonData)
-  })
-
-  it("sets the course_image_url property to the value returned from helpers.getCourseImageUrl", () => {
-    const expectedValue = helpers.getCourseImageUrl(singleCourseJsonData)
+  it("sets the course_image_url property to the image_src of the course json data", () => {
+    const expectedValue = singleCourseJsonData["image_src"]
     const foundValue = courseHomeFrontMatter["course_image_url"]
     assert.equal(expectedValue, foundValue)
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-to-hugo/issues/28

#### What's this PR do?
This PR fixes how the course image is populated in the markdown

#### How should this be manually tested?
Download the sample courses from https://www.dropbox.com/sh/u6jm32n5jwqrjrk/AADxQD82UcsvqcVNfOSLterZa?dl=0

Run the script to convert ocw data to markdown

Verify that unique course images are set
