### PR TITLE
PDF page generation

### DIFF
--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -98,7 +98,6 @@ const writeMarkdownFilesRecursive = (destination, markdownData) => {
         )
         const fileDirPath = path.dirname(filePath)
         if (!directoryExists(fileDirPath)) {
-          console.log(fileDirPath)
           fs.mkdirSync(fileDirPath)
         }
         if (fs.existsSync(filePath)) {

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -99,14 +99,10 @@ const writeMarkdownFilesRecursive = (destination, markdownData) => {
 const writeSectionFiles = (section, destination) => {
   if (section.hasOwnProperty("files")) {
     section["files"].forEach(file => {
-      const filePath = path.join(
-        destination,
-        section["name"].replace("/_index.md", ""),
-        file["name"]
-      )
+      const filePath = path.join(destination, file["name"])
       const fileDirPath = path.dirname(filePath)
       if (!directoryExists(fileDirPath)) {
-        fs.mkdirSync(fileDirPath)
+        fs.mkdirSync(fileDirPath, { recursive: true })
       }
       if (fs.existsSync(filePath)) {
         fs.unlinkSync(filePath)

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -91,7 +91,11 @@ const writeMarkdownFilesRecursive = (destination, markdownData) => {
     fs.writeFileSync(sectionPath, section["data"])
     if (section.hasOwnProperty("files")) {
       section["files"].forEach(file => {
-        const filePath = path.join(destination, section["name"].replace("/_index.md", ""), file["name"])
+        const filePath = path.join(
+          destination,
+          section["name"].replace("/_index.md", ""),
+          file["name"]
+        )
         const fileDirPath = path.dirname(filePath)
         if (!directoryExists(fileDirPath)) {
           console.log(fileDirPath)

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -89,26 +89,30 @@ const writeMarkdownFilesRecursive = (destination, markdownData) => {
       fs.unlinkSync(sectionPath)
     }
     fs.writeFileSync(sectionPath, section["data"])
-    if (section.hasOwnProperty("files")) {
-      section["files"].forEach(file => {
-        const filePath = path.join(
-          destination,
-          section["name"].replace("/_index.md", ""),
-          file["name"]
-        )
-        const fileDirPath = path.dirname(filePath)
-        if (!directoryExists(fileDirPath)) {
-          fs.mkdirSync(fileDirPath)
-        }
-        if (fs.existsSync(filePath)) {
-          fs.unlinkSync(filePath)
-        }
-        fs.writeFileSync(filePath, file["data"])
-      })
-    }
+    writeSectionFiles(section, destination)
     if (section.hasOwnProperty("children")) {
       writeMarkdownFilesRecursive(destination, section["children"])
     }
+  }
+}
+
+const writeSectionFiles = (section, destination) => {
+  if (section.hasOwnProperty("files")) {
+    section["files"].forEach(file => {
+      const filePath = path.join(
+        destination,
+        section["name"].replace("/_index.md", ""),
+        file["name"]
+      )
+      const fileDirPath = path.dirname(filePath)
+      if (!directoryExists(fileDirPath)) {
+        fs.mkdirSync(fileDirPath)
+      }
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath)
+      }
+      fs.writeFileSync(filePath, file["data"])
+    })
   }
 }
 

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -79,18 +79,32 @@ const writeMarkdownFilesRecursive = (destination, markdownData) => {
     For a given course identifier string and array of objects with properties
     name and data, write Hugo markdown files
     */
-  for (const file of markdownData) {
-    const filePath = path.join(destination, file["name"])
-    const dirPath = path.dirname(filePath)
-    if (!directoryExists(dirPath)) {
-      fs.mkdirSync(dirPath, { recursive: true })
+  for (const section of markdownData) {
+    const sectionPath = path.join(destination, section["name"])
+    const sectionDirPath = path.dirname(sectionPath)
+    if (!directoryExists(sectionDirPath)) {
+      fs.mkdirSync(sectionDirPath, { recursive: true })
     }
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath)
+    if (fs.existsSync(sectionPath)) {
+      fs.unlinkSync(sectionPath)
     }
-    fs.writeFileSync(filePath, file["data"])
-    if (file.hasOwnProperty("children")) {
-      writeMarkdownFilesRecursive(destination, file["children"])
+    fs.writeFileSync(sectionPath, section["data"])
+    if (section.hasOwnProperty("files")) {
+      section["files"].forEach(file => {
+        const filePath = path.join(destination, section["name"].replace("/_index.md", ""), file["name"])
+        const fileDirPath = path.dirname(filePath)
+        if (!directoryExists(fileDirPath)) {
+          console.log(fileDirPath)
+          fs.mkdirSync(fileDirPath)
+        }
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath)
+        }
+        fs.writeFileSync(filePath, file["data"])
+      })
+    }
+    if (section.hasOwnProperty("children")) {
+      writeMarkdownFilesRecursive(destination, section["children"])
     }
   }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const _ = require("lodash")
-const url = require("url")
 const path = require("path")
 const departmentsJson = require("./departments.json")
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const _ = require("lodash")
+const url = require("url")
 const path = require("path")
 const departmentsJson = require("./departments.json")
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -330,7 +330,7 @@ const generatePdfMarkdown = (file, courseData) => {
   const pdfFrontMatter = {
     title:         file["title"],
     description:   file["description"],
-    type:          "file",
+    type:          "courses",
     layout:        "pdf",
     file_type:     file["file_type"],
     file_location: file["file_location"],

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -210,7 +210,7 @@ const generateMarkdownRecursive = page => {
   return {
     name:
       isParent || hasFiles
-        ? path.join(pathToChild, "_index.md")
+        ? path.join(pathToChild, "index.md")
         : `${pathToChild}.md`,
     data:     courseSectionMarkdown,
     children: children.map(generateMarkdownRecursive, this),

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -331,6 +331,7 @@ const generatePdfMarkdown = (file, courseData) => {
     title:         file["title"],
     description:   file["description"],
     type:          "file",
+    layout:        "pdf",
     file_type:     file["file_type"],
     file_location: file["file_location"],
     course_id:     courseData["short_url"]

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -245,12 +245,10 @@ const generateMarkdownRecursive = page => {
         : `${pathToChild}.md`,
     data:     courseSectionMarkdown,
     children: children.map(generateMarkdownRecursive, this),
-    files:    pdfFiles.map(file => {
-      return {
-        name: `${path.join(pathToChild, file["id"].replace(".pdf", ""))}.md`,
-        data: generatePdfMarkdown(file, courseData)
-      }
-    })
+    files:    pdfFiles.map(file => ({
+      name: `${path.join(pathToChild, file["id"].replace(".pdf", ""))}.md`,
+      data: generatePdfMarkdown(file, courseData)
+    }))
   }
 }
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -229,7 +229,7 @@ const generateMarkdownRecursive = page => {
     children: children.map(generateMarkdownRecursive, this),
     files:    pdfFiles.map(file => {
       return {
-        name: `${file["uid"]}.md`,
+        name: `${file["id"]}.md`,
         data: generatePdfMarkdown(file, courseData)
       }
     })
@@ -345,6 +345,7 @@ const generatePdfMarkdown = (file, courseData) => {
     description:   file["description"],
     type:          "courses",
     layout:        "pdf",
+    uid:           file["uid"],
     file_type:     file["file_type"],
     file_location: file["file_location"],
     course_id:     courseData["short_url"]

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -181,10 +181,16 @@ const generateMarkdownRecursive = page => {
   const children = courseData["course_pages"].filter(
     coursePage => coursePage["parent_uid"] === page["uid"]
   )
+  const pdfFiles = courseData["course_files"].filter(
+    file =>
+      file["file_type"] === "application/pdf" &&
+      file["parent_uid"] === page["uid"]
+  )
   const parents = courseData["course_pages"].filter(
     coursePage => coursePage["uid"] === page["parent_uid"]
   )
   const isParent = children.length > 0
+  const hasFiles = pdfFiles.length > 0
   const hasParent = parents.length > 0
   const parent = hasParent ? parents[0] : null
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
@@ -202,9 +208,18 @@ const generateMarkdownRecursive = page => {
     courseData
   )}`
   return {
-    name:     isParent ? path.join(pathToChild, "_index.md") : `${pathToChild}.md`,
+    name:
+      isParent || hasFiles
+        ? path.join(pathToChild, "_index.md")
+        : `${pathToChild}.md`,
     data:     courseSectionMarkdown,
-    children: children.map(generateMarkdownRecursive, this)
+    children: children.map(generateMarkdownRecursive, this),
+    files:    pdfFiles.map(file => {
+      return {
+        name: `${helpers.getFilenameFromUrl(file["file_location"])}.md`,
+        data: generatePdfMarkdown(file, courseData)
+      }
+    })
   }
 }
 
@@ -306,6 +321,21 @@ const generateCourseSectionMarkdown = (page, courseData) => {
   } catch (err) {
     return page["text"]
   }
+}
+
+const generatePdfMarkdown = (file, courseData) => {
+  /**
+  Generate the front matter metadata for a PDF file
+  */
+  const pdfFrontMatter = {
+    title:         file["title"],
+    description:   file["description"],
+    type:          "file",
+    file_type:     file["file_type"],
+    file_location: file["file_location"],
+    course_id:     courseData["short_url"]
+  }
+  return `---\n${yaml.safeDump(pdfFrontMatter)}---\n`
 }
 
 module.exports = {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -106,12 +106,15 @@ turndownService.addRule("refshortcode", {
   },
   replacement: (content, node, options) => {
     content = turndownService.escape(content)
-    const ref = turndownService.escape(
-      node
-        .getAttribute("href")
-        .replace(GETPAGESHORTCODESTART, '{{% getpage "')
-        .replace(GETPAGESHORTCODEEND, '" %}}')
-    ).split("\\_").join("_")
+    const ref = turndownService
+      .escape(
+        node
+          .getAttribute("href")
+          .replace(GETPAGESHORTCODESTART, '{{% getpage "')
+          .replace(GETPAGESHORTCODEEND, '" %}}')
+      )
+      .split("\\_")
+      .join("_")
     return `[${content}](${ref})`
   }
 })
@@ -155,7 +158,10 @@ const fixLinks = (page, courseData) => {
         const pdfPath = `${pagePath.replace("/_index.md", "/")}${pdfFile["id"]}`
         htmlStr = htmlStr.replace(
           placeholder,
-          `${GETPAGESHORTCODESTART}${pdfPath.replace(".pdf", "")}${GETPAGESHORTCODEEND}`
+          `${GETPAGESHORTCODESTART}${pdfPath.replace(
+            ".pdf",
+            ""
+          )}${GETPAGESHORTCODEEND}`
         )
       })
     })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -247,7 +247,7 @@ const generateMarkdownRecursive = page => {
     children: children.map(generateMarkdownRecursive, this),
     files:    pdfFiles.map(file => {
       return {
-        name: `${file["id"].replace(".pdf", "")}.md`,
+        name: `${path.join(pathToChild, file["id"].replace(".pdf", ""))}.md`,
         data: generatePdfMarkdown(file, courseData)
       }
     })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -45,7 +45,9 @@ describe("generateMarkdownFromJson", () => {
           section["name"] === `${filename}.md` ||
           section["name"] === `${filename}/_index.md`
       )[0]
-      const hasChildren = sectionMarkdownData["children"].length > 0
+      const hasChildren =
+        sectionMarkdownData["children"].length > 0 ||
+        sectionMarkdownData["files"].length > 0
       filename = hasChildren ? `${filename}/_index.md` : `${filename}.md`
       assert.include(markdownFileNames, filename)
       if (hasChildren) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -59,8 +59,18 @@ describe("generateMarkdownFromJson", () => {
             return markdownData["name"]
           }
         )
+        const fileMarkdownFileNames = sectionMarkdownData["files"].map(
+          markdownData => {
+            return markdownData["name"]
+          }
+        )
         const expectedChildren = singleCourseJsonData["course_pages"].filter(
           page => page["parent_uid"] === sectionUid
+        )
+        const expectedFiles = singleCourseJsonData["course_files"].filter(
+          file =>
+            file["parent_uid"] === sectionUid &&
+            file["file_type"] === "application/pdf"
         )
         expectedChildren.forEach(expectedChild => {
           const childFilename = `${helpers.pathToChildRecursive(
@@ -69,6 +79,19 @@ describe("generateMarkdownFromJson", () => {
             singleCourseJsonData
           )}.md`
           assert.include(childMarkdownFileNames, childFilename)
+        })
+        expectedFiles.forEach(expectedFile => {
+          const fileFilename = `${path.join(
+            helpers.pathToChildRecursive(
+              "sections/",
+              singleCourseJsonData["course_pages"].filter(
+                coursePage => coursePage["short_url"] === expectedSection
+              )[0],
+              singleCourseJsonData
+            ),
+            expectedFile["id"].replace(".pdf", "")
+          )}.md`
+          assert.include(fileMarkdownFileNames, fileFilename)
         })
       }
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/jK4E1jk9/34-desktop-mobile-pdf-viewer

#### What's this PR do?
This PR adds support for iterating the `course_files` array and rendering PDF files that it finds as markdown pages.  It changes the behavior a bit in that pages that have PDF's attached to them will become sections (folders with an `_index.md` file) and the PDF will be deposited as children of that section, but not added to the nav.

#### How should this be manually tested?
Test should pass, and you should be able to generate markdown from the ocw-next sample courses with hugo-course-publisher.  Note that since this PR contains a new shortcode, you'll need to use the corresponding branch, named `cg/pdf-viewer`.