### PR TITLE
Use only UID's for menu identifiers

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -235,8 +235,8 @@ const generateMarkdownRecursive = page => {
   const parent = hasParent ? parents[0] : null
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
-    `${page["uid"]}_${page["short_url"]}`,
-    hasParent ? `${parent["uid"]}_${parent["short_url"]}` : null,
+    `${page["uid"]}`,
+    hasParent ? `${parent["uid"]}` : null,
     (this["menuIndex"] + 1) * 10,
     courseData["short_url"]
   )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/104

#### What's this PR do?
This removes the unnecessary underscore separated short_url from the menu identifier.  It's not necessary and the unpredictable nature of the characters in the `short_url` property breaks the menu in some cases.

#### How should this be manually tested?
Run the conversion.  It should complete successfully and all tests should pass.  Menu identifiers should all now just be UID's.