### PR TITLE
Add videogallery and is_media_gallery keys

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -237,6 +237,8 @@ const generateMarkdownRecursive = page => {
     page["title"],
     `${page["uid"]}`,
     hasParent ? `${parent["uid"]}` : null,
+    hasMedia,
+    page["is_media_gallery"],
     (this["menuIndex"] + 1) * 10,
     courseData["short_url"]
   )
@@ -307,6 +309,8 @@ const generateCourseSectionFrontMatter = (
   title,
   pageId,
   parentId,
+  hasMedia,
+  isMediaGallery,
   menuIndex,
   courseId
 ) => {
@@ -325,6 +329,13 @@ const generateCourseSectionFrontMatter = (
   }
   if (parentId) {
     courseSectionFrontMatter["menu"][courseId]["parent"] = parentId
+  }
+  if (hasMedia) {
+    courseSectionFrontMatter["type"] = "courses"
+    courseSectionFrontMatter["layout"] = "videogallery"
+  }
+  if (isMediaGallery) {
+    courseSectionFrontMatter["is_media_gallery"] = true
   }
   return `---\n${yaml.safeDump(courseSectionFrontMatter)}---\n`
 }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -260,6 +260,8 @@ describe("generateCourseSectionFrontMatter", () => {
           "Syllabus",
           "syllabus",
           null,
+          false,
+          false,
           10,
           singleCourseJsonData["short_url"]
         )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/UmSYgFJs/36-video-list-page-mobile-desktop

#### What's this PR do?
Sections containing any media now have the `layout` key in `_index.md` set to `videogallery`.  If a source page has `is_media_gallery` set, this value is also now passed along.

#### How should this be manually tested?
Run the markdown conversion, verify that the new keys show up where they should.