### PR TITLE
build the course number out of the proper data

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -57,7 +57,9 @@ const getDepartments = courseData => {
 }
 
 const getCourseNumbers = courseData => {
-  let courseNumbers = [`${courseData["department_number"]}.${courseData["master_course_number"]}`]
+  let courseNumbers = [
+    `${courseData["department_number"]}.${courseData["master_course_number"]}`
+  ]
   if (courseData["extra_course_number"]) {
     courseNumbers = courseNumbers.concat(
       courseData["extra_course_number"].map(

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -35,7 +35,7 @@ const findDepartmentByNumber = departmentNumber => {
 }
 
 const getDepartments = courseData => {
-  const primaryDepartmentNumber = courseData["sort_as"].split(".")[0]
+  const primaryDepartmentNumber = courseData["department_number"]
   const department = findDepartmentByNumber(primaryDepartmentNumber)
   if (department) {
     let departments = [department["title"]]
@@ -57,7 +57,7 @@ const getDepartments = courseData => {
 }
 
 const getCourseNumbers = courseData => {
-  let courseNumbers = [courseData["sort_as"]]
+  let courseNumbers = [`${courseData["department_number"]}.${courseData["master_course_number"]}`]
   if (courseData["extra_course_number"]) {
     courseNumbers = courseNumbers.concat(
       courseData["extra_course_number"].map(

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -41,7 +41,7 @@ describe("getDepartments", () => {
 
 describe("getCourseNumbers", () => {
   it("returns the expected course numbers for a given course json input", () => {
-    assert.equal(helpers.getCourseNumbers(singleCourseJsonData)[0], "2.00 A")
+    assert.equal(helpers.getCourseNumbers(singleCourseJsonData)[0], "2.00AJ")
     assert.equal(helpers.getCourseNumbers(singleCourseJsonData)[1], "16.00AJ")
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/129

#### What's this PR do?
Uses `${department_number}.${master_course_number}` to build the course number instead of using `sort_as`.

#### How should this be manually tested?
View the deploy preview in the corresponding `hugo-course-publisher` PR here: https://github.com/mitodl/hugo-course-publisher/pull/137 and ensure that the course numbers match what's expected.
