### PR TITLE
image gallery support

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -419,7 +419,7 @@ const generateCourseFeaturesMarkdown = (page, courseData) => {
         )
         courseFeaturesMarkdown = `${courseFeaturesMarkdown}\n{{< image-gallery id="${
           page["uid"]
-        }_nanogallery2" data-nanogallery2='{ "itemsBaseURL": ${baseUrl} }' >}}\n${imageShortcodes.join(
+        }_nanogallery2" baseUrl="${baseUrl}" >}}\n${imageShortcodes.join(
           "\n"
         )}\n{{</ image-gallery >}}`
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/134

#### What's this PR do?
This PR adds support for processing pages marked as `is_image_gallery: true`, rendering the appropriate shortcodes at the end of the markdown.

#### How should this be manually tested?
Convert a course that contains an image gallery and verify that the shortcodes are rendered in the format below:

```
{{< image-gallery id="de36fe69cf33ddf238bc3896d0ce9eff_nanogallery2" baseUrl="https://open-learning-course-data-ci.s3.amazonaws.com/12-001-introduction-to-geology-fall-2013/" >}}
{{< image-gallery-item href="915b6ae8ee3ce0531360df600464d389_IMG_20141011_092912.jpg" data-ngdesc="Prof. Perron points out a feature on a rock hand sample. Courtesy of Taylor Perron. Used with permission." text="Prof. Perron points out a feature on a rock hand sample. " >}}
{{< image-gallery-item href="0b2f13988f6f25b5cdf7c614a9399467_IMG_20141011_092937.jpg" data-ngdesc="The students of 12.001 investigate an outcrop. Courtesy of Taylor Perron. Used with permission." text="The students of 12.001 investigate an outcrop. " >}}
{{< image-gallery-item href="2c20fb5ffb5ae7c7bcf1cd4e0b7bcb02_IMG_20141011_093641.jpg" data-ngdesc="The students of 12.001 investigate a breccia along a major fault. Courtesy of Taylor Perron. Used with permission." text="The students of 12.001 investigate a breccia along a major fault. " >}}
{{< image-gallery-item href="5ecd7681670f0c9083dabe297896c859_IMG_20141011_095027.jpg" data-ngdesc="The instructor points out breccia along a fault. Courtesy of Taylor Perron. Used with permission." text="The instructor points out breccia along a fault. " >}}
{{< image-gallery-item href="7ff7b871e55c4582437c144bea654691_IMG_20141011_101459.jpg" data-ngdesc="Prof. Jagoutz explains the local geology. Courtesy of Taylor Perron. Used with permission." text="Prof. Jagoutz explains the local geology. " >}}
{{< image-gallery-item href="21e89114553335187548b04a81090a5f_IMG_20141011_112705.jpg" data-ngdesc="The teaching assistants demonstrate how to measure strike and dip. Courtesy of Taylor Perron. Used with permission." text="The teaching assistants demonstrate how to measure strike and dip." >}}
{{< image-gallery-item href="58680d86305357112a8290985507bb20_IMG_20141011_131206.jpg" data-ngdesc="The class walks through the Canajoharie gorge. Courtesy of Taylor Perron. Used with permission." text="The class walks through the Canajoharie gorge. " >}}
{{< image-gallery-item href="7f1b9b69d23390d193856b8744680592_IMG_20141011_140309.jpg" data-ngdesc="The class measures the strike and dip of beds near the Canajoharie gorge. Courtesy of Taylor Perron. Used with permission." text="The class measures the strike and dip of beds near the Canajoharie gorge. " >}}
{{< image-gallery-item href="b288ab62a7f3977c4251ed2043968f88_IMG_20141011_160112.jpg" data-ngdesc="Steeply dipping beds. Courtesy of Taylor Perron. Used with permission." text="Steeply dipping beds." >}}
{{< image-gallery-item href="c45d49719c244f95c653522c55bb8896_IMG_20141012_113515.jpg" data-ngdesc="Students walk to an outcrop. Courtesy of Taylor Perron. Used with permission." text="Students walk to an outcrop. " >}}
{{< image-gallery-item href="b7c133da444ee8e71cf60bea081b6e60_IMG_20141012_114203.jpg" data-ngdesc="Prof. Jagoutz leads a discussion near a stream. Courtesy of Taylor Perron. Used with permission." text="Prof. Jagoutz leads a discussion near a stream. " >}}
{{</ image-gallery >}}
```

Note that as of this writing, [this](https://github.com/mitodl/ocw-data-parser/pull/33) PR will need to be merged and deployed, and master json will need to be refreshed before running this. 
 Either that, or you will need to manually insert `is_image_gallery: true` into an appropriate page in order to test.  An example of a course with an image gallery page would be the "Field Trip" page in this course:

`ocw-to-hugo/private/courses/12-001-introduction-to-geology-fall-2013/d9aad1541f1a9d3c0f7b0dcf9531a9a1_master.json`