### PR TITLE
other_information_text

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -252,21 +252,20 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
       // ensure that this is not resolveuid or an external link
       if (!url.includes("resolveuid") && url[0] === "/") {
         // split the url into its parts
-        const parts = url.split("/")
+        const parts = url.split("/").filter(part => part !== "")
         /**
          * disassembles the OCW URL based on the following patten:
          *
          * EXAMPLE: /courses/mathematics/18-01-single-variable-calculus-fall-2006/exams/prfinalsol.pdf
          *
-         * 0: blank string
-         * 1: "courses"
-         * 2: department ("mathematics")
-         * 3: course ID ("18-01-single-variable-calculus-fall-2006")
-         * 4 - ?: section and subsections with the page / file at the end
+         * 0: "courses"
+         * 1: department ("mathematics")
+         * 2: course ID ("18-01-single-variable-calculus-fall-2006")
+         * 3 - ?: section and subsections with the page / file at the end
          */
-        const courseId = parts[3]
+        const courseId = parts[2]
         if (courseId) {
-          const layers = parts.length - 4
+          const layers = parts.length - 3
           let sections = []
           let page = null
           if (layers === 0) {
@@ -274,7 +273,7 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
             page = "index.htm"
           } else if (layers === 1) {
             // root section link
-            page = parts[4]
+            page = parts[3]
           } else {
             // this is a link to something in a subsection, slice out the layers and page
             sections = parts.slice(parts.length - layers, parts.length - 1)
@@ -308,7 +307,9 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
           } else {
             // match page from url to the short_url property on a course page
             courseData["course_pages"].forEach(coursePage => {
-              if (coursePage["short_url"] === page) {
+              if (
+                coursePage["short_url"].toLowerCase() === page.toLowerCase()
+              ) {
                 const pageName = page.replace(/(index)?\.html?/g, "")
                 const newUrl = `${GETPAGESHORTCODESTART}${path.join(
                   newUrlBase,
@@ -327,7 +328,7 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
   } catch (err) {
     loggers.fileLogger.error(err.message)
   }
-  return htmlStr
+  return htmlStr.replace(/http:\/\/ocw.mit.edu/g, "")
 }
 
 const resolveYouTubeEmbed = (htmlStr, courseData) => {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -106,7 +106,11 @@ turndownService.addRule("refshortcode", {
     return false
   },
   replacement: (content, node, options) => {
-    content = turndownService.escape(content)
+    const children = Array.prototype.slice.call(node.childNodes)
+    if (!children.filter(child => child.nodeName === "IMG").length > 0) {
+      // if this link doesn't contain an image, escape the content
+      content = turndownService.escape(content)
+    }
     const ref = turndownService
       .escape(
         node

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -120,8 +120,17 @@ turndownService.addRule("refshortcode", {
   }
 })
 
-const fixLinks = (page, courseData) => {
-  let htmlStr = page["text"]
+/**
+ * Render h4 tags as an h5 instead
+ */
+turndownService.addRule("h4", {
+  filter:      ["h4"],
+  replacement: (content, node, options) => {
+    return `##### ${content}`
+  }
+})
+
+const fixLinks = (htmlStr, page, courseData) => {
   if (htmlStr) {
     htmlStr = helpers.resolveUids(htmlStr, page, courseData)
     htmlStr = helpers.resolveRelativeLinks(htmlStr, courseData)
@@ -144,7 +153,7 @@ const generateMarkdownFromJson = courseData => {
   return [
     {
       name: "_index.md",
-      data: generateCourseHomeFrontMatter(courseData)
+      data: generateCourseHomeMarkdown(courseData)
     },
     ...rootSections.map(generateMarkdownRecursive, this)
   ]
@@ -242,10 +251,27 @@ const generateMarkdownRecursive = page => {
   }
 }
 
-const generateCourseHomeFrontMatter = courseData => {
+const generateCourseHomeMarkdown = courseData => {
   /**
     Generate the front matter metadata for the course home page given course_data JSON
     */
+  const courseHomePage = courseData["course_pages"].find(
+    coursePage => coursePage["type"] === "CourseHomeSection"
+  )
+  const courseDescription = courseData["description"]
+    ? turndownService.turndown(
+      fixLinks(courseData["description"], courseHomePage, courseData)
+    )
+    : ""
+  const otherInformationText = courseData["other_information_text"]
+    ? turndownService.turndown(
+      fixLinks(
+        courseData["other_information_text"],
+        courseHomePage,
+        courseData
+      )
+    )
+    : ""
 
   const frontMatter = {
     title:                      "Course Home",
@@ -261,8 +287,7 @@ const generateCourseHomeFrontMatter = courseData => {
     course_image_caption_text: courseData["image_caption_text"]
       ? courseData["image_caption_text"]
       : "",
-    course_description: courseData["description"],
-    course_info:        {
+    course_info: {
       instructors: courseData["instructors"].map(
         instructor =>
           `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
@@ -284,7 +309,9 @@ const generateCourseHomeFrontMatter = courseData => {
     }
   }
   try {
-    return `---\n${yaml.safeDump(frontMatter)}---\n`
+    return `---\n${yaml.safeDump(
+      frontMatter
+    )}---\n${courseDescription}\n${otherInformationText}`
   } catch (err) {
     loggers.fileLogger.log({
       level:   "error",
@@ -361,7 +388,7 @@ const generateCourseSectionMarkdown = (page, courseData) => {
     */
   try {
     return `${turndownService.turndown(
-      fixLinks(page, courseData)
+      fixLinks(page["text"], page, courseData)
     )}${generateCourseFeaturesMarkdown(page, courseData)}`
   } catch (err) {
     loggers.fileLogger.log({
@@ -434,7 +461,7 @@ const generateCourseFeaturesMarkdown = (page, courseData) => {
 
 module.exports = {
   generateMarkdownFromJson,
-  generateCourseHomeFrontMatter,
+  generateCourseHomeMarkdown,
   generateCourseSectionFrontMatter,
   generateCourseFeatures,
   generateCourseSectionMarkdown,

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -139,18 +139,21 @@ describe("generateMarkdownFromJson", () => {
 })
 
 describe("generateCourseHomeMarkdown", () => {
-  let courseHomeFrontMatter, getCourseNumbers, getConsolidatedTopics, safeDump
+  let courseHomeMarkdown,
+    courseHomeFrontMatter,
+    getCourseNumbers,
+    getConsolidatedTopics,
+    safeDump
   const sandbox = sinon.createSandbox()
 
   beforeEach(() => {
     getCourseNumbers = sandbox.spy(helpers, "getCourseNumbers")
     getConsolidatedTopics = sandbox.spy(helpers, "getConsolidatedTopics")
     safeDump = sandbox.spy(yaml, "safeDump")
-    courseHomeFrontMatter = yaml.safeLoad(
-      markdownGenerators
-        .generateCourseHomeMarkdown(singleCourseJsonData)
-        .replace(/---\n/g, "")
+    courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
+      singleCourseJsonData
     )
+    courseHomeFrontMatter = yaml.safeLoad(courseHomeMarkdown.split("---\n")[1])
   })
 
   afterEach(() => {
@@ -178,12 +181,6 @@ describe("generateCourseHomeMarkdown", () => {
   it("sets the course_thumbnail_image_url property to the thumbnail_image_src of the course json data", () => {
     const expectedValue = singleCourseJsonData["thumbnail_image_src"]
     const foundValue = courseHomeFrontMatter["course_thumbnail_image_url"]
-    assert.equal(expectedValue, foundValue)
-  })
-
-  it("sets the course_description property to the description property of the course json data", () => {
-    const expectedValue = singleCourseJsonData["description"]
-    const foundValue = courseHomeFrontMatter["course_description"]
     assert.equal(expectedValue, foundValue)
   })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -138,7 +138,7 @@ describe("generateMarkdownFromJson", () => {
   })
 })
 
-describe("generateCourseHomeFrontMatter", () => {
+describe("generateCourseHomeMarkdown", () => {
   let courseHomeFrontMatter, getCourseNumbers, getConsolidatedTopics, safeDump
   const sandbox = sinon.createSandbox()
 
@@ -148,7 +148,7 @@ describe("generateCourseHomeFrontMatter", () => {
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeFrontMatter = yaml.safeLoad(
       markdownGenerators
-        .generateCourseHomeFrontMatter(singleCourseJsonData)
+        .generateCourseHomeMarkdown(singleCourseJsonData)
         .replace(/---\n/g, "")
     )
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/135

#### What's this PR do?
This PR pulls the new `other_information_text` field from `master.json`.  The `course_description` field was removed from couse home front matter and instead, the `description` and `other_information_text` fields are run through `fixLinks` and `turndown`, then concatenated together and inserted as the body of the course home page as markdown.  This way, shortcode links still work and we don't have to put HTML directly into the markdown files.

#### How should this be manually tested?
Make sure you have master json based on [this](https://github.com/mitodl/ocw-data-parser/tree/cg/other-information-text) branch of ocw-data-parser, and make sure you have `14-01sc-principles-of-microeconomics-fall-2011` in your `courses.json`.  Run ocw-to-hugo on this master json and put the markdown into `hugo-course-publisher` and run the site, then go to the following URL:

http://localhost:3000/courses/14-01sc-principles-of-microeconomics-fall-2011/

You should see the previously missing "Course Format" section appear.  There will be a missing image, but you should be able to click the link to be brought to the Syllabus.  We should address the remaining missing static stock OCW images in another PR, as it's not limited to just this example.