### PR TITLE
no left nav for grandchildren

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -351,7 +351,7 @@ const generateCourseSectionFrontMatter = (
     course_id: courseId
   }
 
-  if (!isGrandChild || (isGrandChild && listInLeftNav)) {
+  if (!isGrandChild || listInLeftNav) {
     courseSectionFrontMatter["menu"] = {
       [courseId]: {
         identifier: pageId,

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -190,9 +190,11 @@ const generateMarkdownRecursive = page => {
   const hasMedia = coursePageEmbeddedMedia.length > 0
   const hasParent = parents.length > 0
   const parent = hasParent ? parents[0] : null
-  const isGrandChild = hasParent ? courseData["course_pages"].filter(
-    coursePage => coursePage["uid"] === parent["parent_uid"]
-  ).length > 0 : false
+  const isGrandChild = hasParent
+    ? courseData["course_pages"].filter(
+      coursePage => coursePage["uid"] === parent["parent_uid"]
+    ).length > 0
+    : false
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
     `${page["uid"]}`,
@@ -348,7 +350,7 @@ const generateCourseSectionFrontMatter = (
     title:     title,
     course_id: courseId
   }
-  
+
   if (!isGrandChild || (isGrandChild && listInLeftNav)) {
     courseSectionFrontMatter["menu"] = {
       [courseId]: {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -24,7 +24,7 @@ turndownService.addRule("table", {
   filter:      ["table"],
   replacement: (content, node, options) => {
     /**
-     * Interate the HTML node and replace all pipes inside table
+     * Iterate the HTML node and replace all pipes inside table
      * cells with a marker we'll use later
      */
     for (let i = 0; i < node.rows.length; i++) {
@@ -190,13 +190,18 @@ const generateMarkdownRecursive = page => {
   const hasMedia = coursePageEmbeddedMedia.length > 0
   const hasParent = parents.length > 0
   const parent = hasParent ? parents[0] : null
+  const isGrandChild = hasParent ? courseData["course_pages"].filter(
+    coursePage => coursePage["uid"] === parent["parent_uid"]
+  ).length > 0 : false
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
     `${page["uid"]}`,
-    hasParent ? `${parent["uid"]}` : null,
+    hasParent ? parent["uid"] : null,
+    isGrandChild,
     hasMedia,
     page["is_media_gallery"],
     (this["menuIndex"] + 1) * 10,
+    page["list_in_left_nav"],
     courseData["short_url"]
   )
   this["menuIndex"]++
@@ -329,9 +334,11 @@ const generateCourseSectionFrontMatter = (
   title,
   pageId,
   parentId,
+  isGrandChild,
   hasMedia,
   isMediaGallery,
   menuIndex,
+  listInLeftNav,
   courseId
 ) => {
   /**
@@ -339,17 +346,21 @@ const generateCourseSectionFrontMatter = (
     */
   const courseSectionFrontMatter = {
     title:     title,
-    course_id: courseId,
-    menu:      {
+    course_id: courseId
+  }
+  
+  if (!isGrandChild || (isGrandChild && listInLeftNav)) {
+    courseSectionFrontMatter["menu"] = {
       [courseId]: {
         identifier: pageId,
         weight:     menuIndex
       }
     }
+    if (parentId) {
+      courseSectionFrontMatter["menu"][courseId]["parent"] = parentId
+    }
   }
-  if (parentId) {
-    courseSectionFrontMatter["menu"][courseId]["parent"] = parentId
-  }
+
   if (hasMedia) {
     courseSectionFrontMatter["type"] = "courses"
     courseSectionFrontMatter["layout"] = "videogallery"

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -283,7 +283,9 @@ describe("generateCourseSectionFrontMatter", () => {
           null,
           false,
           false,
+          false,
           10,
+          false,
           singleCourseJsonData["short_url"]
         )
         .replace(/---\n/g, "")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/IHLhRE3H/159-dont-include-third-level-pages-in-the-left-nav-unless-listinleftnav-is-set-to-true

#### What's this PR do?
This PR adds the `isGrandChild` and `listInLeftNav` argument to `generateCourseSectionFrontMatter`.  Any pages 3rd tier or higher will now not be added to the left nav unless `lisntInLeftNav` is true.

#### How should this be manually tested?
Find a course in that has 3rd tier nav items, for example:

https://ocw-next.netlify.app/courses/res-15-003-shaping-the-future-of-work-15-662x-spring-2016/sections/introduction-challenges-and-opportunities/

Download and parse said course using `ocw-data-parser` on [this)(https://github.com/mitodl/ocw-data-parser/tree/cg/list-in-left-nav) branch.  Use the master json produced from this with this branch of `ocw-to-hugo`, then verify the output has the appropriate nav items removed.

#### Any background context you want to provide?
Other relevant PR's:
https://github.com/mitodl/ocw-data-parser/pull/41
https://github.com/mitodl/hugo-course-publisher/pull/149