### PR TITLE
resolve course uid's

### DIFF
--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -91,8 +91,7 @@ const getMasterJsonFileName = async coursePath => {
     const contents = await readdir(coursePath)
     const fileName = contents.find(
       file =>
-        RegExp("^[0-9a-f]{32}_master.json").test(file) ||
-        file === "master.json"
+        RegExp("^[0-9a-f]{32}_master.json").test(file) || file === "master.json"
     )
     if (fileName) {
       return path.join(coursePath, fileName)

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -60,9 +60,7 @@ const getCourseUid = async (inputPath, course) => {
   const coursePath = path.join(inputPath, course)
   const masterJsonFile = await getMasterJsonFileName(coursePath)
   if (masterJsonFile) {
-    const courseData = JSON.parse(
-      fs.readFileSync(masterJsonFile)
-    )
+    const courseData = JSON.parse(fs.readFileSync(masterJsonFile))
     return courseData["uid"]
   }
 }
@@ -75,9 +73,7 @@ const scanCourse = async (inputPath, outputPath, course) => {
   const coursePath = path.join(inputPath, course)
   const masterJsonFile = await getMasterJsonFileName(coursePath)
   if (masterJsonFile) {
-    const courseData = JSON.parse(
-      fs.readFileSync(masterJsonFile)
-    )
+    const courseData = JSON.parse(fs.readFileSync(masterJsonFile))
     const markdownData = markdownGenerators.generateMarkdownFromJson(courseData)
     writeMarkdownFilesRecursive(
       path.join(outputPath, courseData["short_url"]),
@@ -86,7 +82,7 @@ const scanCourse = async (inputPath, outputPath, course) => {
   }
 }
 
-const getMasterJsonFileName = async (coursePath) => {
+const getMasterJsonFileName = async coursePath => {
   /*
     This function scans a course directory for a master json file and returns it
   */
@@ -94,11 +90,15 @@ const getMasterJsonFileName = async (coursePath) => {
     if (helpers.directoryExists(coursePath)) {
       // If the item is indeed a directory, read all files in it
       const contents = await readdir(coursePath)
-      return path.join(coursePath, contents.find(
-        file => (RegExp("^[0-9a-f]{32}_master.json").test(file) || file === "master.json")
-      ))
-    }
-    else {
+      return path.join(
+        coursePath,
+        contents.find(
+          file =>
+            RegExp("^[0-9a-f]{32}_master.json").test(file) ||
+            file === "master.json"
+        )
+      )
+    } else {
       console.log(coursePath)
       const courseError = `${coursePath} - ${MISSING_COURSE_ERROR_MESSAGE}`
       loggers.fileLogger.log({

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -99,7 +99,6 @@ const getMasterJsonFileName = async coursePath => {
         )
       )
     } else {
-      console.log(coursePath)
       const courseError = `${coursePath} - ${MISSING_COURSE_ERROR_MESSAGE}`
       loggers.fileLogger.log({
         level:   "error",

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -5,7 +5,7 @@ const { assert, expect } = require("chai").use(require("sinon-chai"))
 const tmp = require("tmp")
 const rimraf = require("rimraf")
 
-const { NO_COURSES_FOUND_MESSAGE } = require("./constants")
+const { NO_COURSES_FOUND_MESSAGE, MISSING_COURSE_ERROR_MESSAGE } = require("./constants")
 const helpers = require("./helpers")
 const fileOperations = require("./file_operations")
 const markdownGenerators = require("./markdown_generators")
@@ -130,7 +130,27 @@ describe("scanCourse", () => {
   it("throws an error when you call it with a course that doesn't exist", async () => {
     await expect(
       fileOperations.scanCourse(testDataPath, outputPath, "test_missing")
-    ).to.eventually.be.rejectedWith("no such file or directory")
+    ).to.eventually.be.rejectedWith(`${path.join(testDataPath, "test_missing")} - ${MISSING_COURSE_ERROR_MESSAGE}`)
+  })
+})
+
+describe("getMasterJsonFileName", () => {
+  it("gives the expected filename for a sample course", async () => {
+    const masterJsonFileName = await fileOperations.getMasterJsonFileName(path.join(testDataPath, singleCourseId))
+    assert.equal(masterJsonFileName, singleCourseMasterJsonPath)
+  })
+
+  it("throws an error when you call it with nonexistent directory", async () => {
+    await expect(
+      fileOperations.getMasterJsonFileName(path.join(testDataPath, "test_missing"))
+      ).to.eventually.be.rejectedWith(`${path.join(testDataPath, "test_missing")} - ${MISSING_COURSE_ERROR_MESSAGE}`)
+  })
+
+  it("throws an error when you call it with a directory with no master json file", async () => {
+    const emptyDirectory = path.join("test_data", "empty")
+    await expect(
+      fileOperations.getMasterJsonFileName(emptyDirectory)
+    ).to.eventually.be.rejectedWith(`${emptyDirectory} - ${MISSING_COURSE_ERROR_MESSAGE}`)
   })
 })
 

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -5,7 +5,10 @@ const { assert, expect } = require("chai").use(require("sinon-chai"))
 const tmp = require("tmp")
 const rimraf = require("rimraf")
 
-const { NO_COURSES_FOUND_MESSAGE, MISSING_COURSE_ERROR_MESSAGE } = require("./constants")
+const {
+  NO_COURSES_FOUND_MESSAGE,
+  MISSING_COURSE_ERROR_MESSAGE
+} = require("./constants")
 const helpers = require("./helpers")
 const fileOperations = require("./file_operations")
 const markdownGenerators = require("./markdown_generators")
@@ -130,27 +133,43 @@ describe("scanCourse", () => {
   it("throws an error when you call it with a course that doesn't exist", async () => {
     await expect(
       fileOperations.scanCourse(testDataPath, outputPath, "test_missing")
-    ).to.eventually.be.rejectedWith(`${path.join(testDataPath, "test_missing")} - ${MISSING_COURSE_ERROR_MESSAGE}`)
+    ).to.eventually.be.rejectedWith(
+      `${path.join(
+        testDataPath,
+        "test_missing"
+      )} - ${MISSING_COURSE_ERROR_MESSAGE}`
+    )
   })
 })
 
 describe("getMasterJsonFileName", () => {
   it("gives the expected filename for a sample course", async () => {
-    const masterJsonFileName = await fileOperations.getMasterJsonFileName(path.join(testDataPath, singleCourseId))
+    const masterJsonFileName = await fileOperations.getMasterJsonFileName(
+      path.join(testDataPath, singleCourseId)
+    )
     assert.equal(masterJsonFileName, singleCourseMasterJsonPath)
   })
 
   it("throws an error when you call it with nonexistent directory", async () => {
     await expect(
-      fileOperations.getMasterJsonFileName(path.join(testDataPath, "test_missing"))
-      ).to.eventually.be.rejectedWith(`${path.join(testDataPath, "test_missing")} - ${MISSING_COURSE_ERROR_MESSAGE}`)
+      fileOperations.getMasterJsonFileName(
+        path.join(testDataPath, "test_missing")
+      )
+    ).to.eventually.be.rejectedWith(
+      `${path.join(
+        testDataPath,
+        "test_missing"
+      )} - ${MISSING_COURSE_ERROR_MESSAGE}`
+    )
   })
 
   it("throws an error when you call it with a directory with no master json file", async () => {
     const emptyDirectory = path.join("test_data", "empty")
     await expect(
       fileOperations.getMasterJsonFileName(emptyDirectory)
-    ).to.eventually.be.rejectedWith(`${emptyDirectory} - ${MISSING_COURSE_ERROR_MESSAGE}`)
+    ).to.eventually.be.rejectedWith(
+      `${emptyDirectory} - ${MISSING_COURSE_ERROR_MESSAGE}`
+    )
   })
 })
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,6 +6,8 @@ const departmentsJson = require("./departments.json")
 const { GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
 const loggers = require("./loggers")
 
+const courseUidList = {}
+
 const distinct = (value, index, self) => {
   return self.indexOf(value) === index
 }
@@ -192,6 +194,12 @@ const resolveUids = (htmlStr, page, courseData) => {
         const linkedFile = courseData["course_files"].find(
           file => file["uid"] === uid
         )
+        // filter courseUidList values on the UID in the URL
+        const linkedCourse = Object.entries(courseUidList).find(([key, value]) => {
+          if (value === uid) {
+            return key
+          }
+        })
         if (linkedPage) {
           // a course_page has been found for this UID
           const linkPagePath = `${pathToChildRecursive(
@@ -222,6 +230,10 @@ const resolveUids = (htmlStr, page, courseData) => {
             // link directly to the static content
             htmlStr = htmlStr.replace(url, linkedFile["file_location"])
           }
+        }
+        if (linkedCourse) {
+          const linkedCourseId = linkedCourse[0]
+          htmlStr = htmlStr.replace(url, `/courses/${linkedCourseId}`)
         }
       }
     )
@@ -362,5 +374,6 @@ module.exports = {
   resolveUids,
   resolveRelativeLinks,
   resolveYouTubeEmbed,
-  htmlSafeText
+  htmlSafeText,
+  courseUidList
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -195,11 +195,13 @@ const resolveUids = (htmlStr, page, courseData) => {
           file => file["uid"] === uid
         )
         // filter courseUidList values on the UID in the URL
-        const linkedCourse = Object.entries(courseUidList).find(([key, value]) => {
-          if (value === uid) {
-            return key
+        const linkedCourse = Object.entries(courseUidList).find(
+          ([key, value]) => {
+            if (value === uid) {
+              return key
+            }
           }
-        })
+        )
         if (linkedPage) {
           // a course_page has been found for this UID
           const linkPagePath = `${pathToChildRecursive(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/136

#### What's this PR do?
This PR does a couple things:
 - refactors `master.json` file discovery / opening into its own function
 - before generating markdown, a list of course uid's is generated and stored
 - `resolveUids` now scans this list of course uid's to see if a link is supposed to be to another course and rewrites it if found

#### How should this be manually tested?
Convert a course such as 8.03SC that has links to other courses (on the syllabus page in this case) and ensure that the `resolveuid` links are re-written.