### PR TITLE
ignore course download section

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -152,7 +152,8 @@ const generateMarkdownFromJson = courseData => {
   const rootSections = courseData["course_pages"].filter(
     page =>
       page["parent_uid"] === courseData["uid"] &&
-      page["type"] !== "CourseHomeSection"
+      page["type"] !== "CourseHomeSection" &&
+      page["type"] !== "DownloadSection"
   )
   return [
     {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -55,7 +55,8 @@ describe("generateMarkdownFromJson", () => {
       .filter(
         page =>
           page["parent_uid"] === singleCourseJsonData["uid"] &&
-          page["type"] !== "CourseHomeSection"
+          page["type"] !== "CourseHomeSection" &&
+          page["type"] !== "DownloadSection"
       )
       .map(page => page["short_url"])
     const markdownFileNames = singleCourseMarkdownData.map(markdownData => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/bVQwTyeU/170-download-course-material-should-be-a-button-in-course-info

#### What's this PR do?
This PR prevents `ocw-to-hugo` from processing pages with a type of `DownloadSection`

#### How should this be manually tested?
Run the conversion and confirm that the output does not contain markdown for the "Download Course Materials" sections