### PR TITLE
type and layout for "course"

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -178,7 +178,7 @@ const generateMarkdownRecursive = page => {
     courseData["course_embedded_media"]
   )
     .map(embeddedMedia => {
-      embeddedMedia["type"] = "courses"
+      embeddedMedia["type"] = "course"
       embeddedMedia["layout"] = "video"
       return embeddedMedia
     })
@@ -288,8 +288,8 @@ const generateCourseHomeMarkdown = courseData => {
 
   const frontMatter = {
     title:                      "Course Home",
-    type:                       "course_home",
-    layout:                     "section",
+    type:                       "course",
+    layout:                     "course_home",
     course_id:                  courseData["short_url"],
     course_title:               courseData["title"],
     course_image_url:           courseData["image_src"] ? courseData["image_src"] : "",
@@ -353,15 +353,15 @@ const generateCourseSectionFrontMatter = (
     */
   const courseSectionFrontMatter = {
     title:     title,
-    course_id: courseId
+    course_id: courseId,
+    type:      "course",
+    layout:    "course_section"
   }
 
   if (!isGrandChild || listInLeftNav) {
     courseSectionFrontMatter["menu"] = {
       [courseId]: {
         identifier: pageId,
-        type:       "section",
-        layout:     "section",
         name:       shortTitle,
         weight:     menuIndex
       }
@@ -372,7 +372,6 @@ const generateCourseSectionFrontMatter = (
   }
 
   if (hasMedia) {
-    courseSectionFrontMatter["type"] = "courses"
     courseSectionFrontMatter["layout"] = "videogallery"
   }
   if (isMediaGallery) {
@@ -431,7 +430,7 @@ const generatePdfMarkdown = (file, courseData) => {
   const pdfFrontMatter = {
     title:         file["title"],
     description:   file["description"],
-    type:          "courses",
+    type:          "course",
     layout:        "pdf",
     uid:           file["uid"],
     file_type:     file["file_type"],


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/170

#### What's this PR do?
This PR sets `type` on all content to "course" and specifies the layout for course home page vs sections.

#### How should this be manually tested?
Convert some courses and verify that the `type` front matter property is set to "course" for all pages and the `layout` property is set based on the content.  Course home pages should be "course_home" and sections should be "course_section."  PDF's, videos, etc. should be set to their respective templates.