### PR TITLE
fix code block issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src",
     "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi 'src/**/*.js'",
     "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi 'src/**/*.js'",
-    "test": "./scripts/js_test.sh"
+    "test": "./scripts/js_test.sh",
+    "test:watch": "WATCH=1 ./scripts/js_test.sh"
   },
   "repository": {
     "type": "git",

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -13,7 +13,9 @@ const {
 const helpers = require("./helpers")
 const loggers = require("./loggers")
 
-const turndownService = new TurndownService()
+const turndownService = new TurndownService({
+  codeBlockStyle: "fenced"
+})
 turndownService.use(gfm)
 turndownService.use(tables)
 
@@ -90,6 +92,25 @@ turndownService.addRule("table", {
           .replace(/\|\|/g, "|\n|")
       )
     } else return content
+  }
+})
+
+/**
+ * fix some strangely formatted code blocks in OCW
+ * see https://github.com/mitodl/hugo-course-publisher/issues/154
+ * for discussion
+ */
+turndownService.addRule("codeblockfix", {
+  filter: node =>
+    node.nodeName === "PRE" &&
+    node.firstChild &&
+    node.firstChild.nodeName === "SPAN",
+  replacement: (content, node, options) => {
+    if (content.match(/\r?\n/)) {
+      return `\n\n\`\`\`\n${content.replace(/`/g, "")}\n\`\`\`\n\n`
+    } else {
+      return content
+    }
   }
 })
 
@@ -489,5 +510,6 @@ module.exports = {
   generateCourseSectionFrontMatter,
   generateCourseFeatures,
   generateCourseSectionMarkdown,
-  generateCourseFeaturesMarkdown
+  generateCourseFeaturesMarkdown,
+  turndownService
 }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -397,3 +397,14 @@ describe("generateCourseFeaturesMarkdown", () => {
     })
   })
 })
+
+describe("turndown service", () => {
+  it("should not get tripped up on problematic code blocks", () => {
+    const problematicHTML =
+      "<pre><span><code>stuff\nin\nthe\nblock</span></pre>"
+    const markdown = markdownGenerators.turndownService.turndown(
+      problematicHTML
+    )
+    assert.equal(markdown, "```\nstuff\nin\nthe\nblock\n```")
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

fixes #57 

#### What's this PR do?

this fixes an issue where code blocks that should have been fenced with triple-backticks were being treated as inline blocks and fenced with single backticks. See here for details: https://github.com/mitodl/hugo-course-publisher/issues/154

#### How should this be manually tested?

you can try transforming the matlab course ("18-s997-introduction-to-matlab-programming-fall-2011"). several of the sections include code blocks showing matlab commands, and they are messed up. this should fix that issue, and you should see multi-line code blocks with triple backticks and proper spacing.