### PR TITLE
fix escaping of square brackets in link text

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -117,7 +117,7 @@ turndownService.addRule("codeblockfix", {
 /**
  * Build links with Hugo shortcodes to course sections
  **/
-turndownService.addRule("refshortcode", {
+turndownService.addRule("getpageshortcode", {
   filter: (node, options) => {
     if (node.nodeName === "A" && node.getAttribute("href")) {
       if (node.getAttribute("href").includes(GETPAGESHORTCODESTART)) {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -130,7 +130,10 @@ turndownService.addRule("refshortcode", {
     const children = Array.prototype.slice.call(node.childNodes)
     if (!children.filter(child => child.nodeName === "IMG").length > 0) {
       // if this link doesn't contain an image, escape the content
-      content = turndownService.escape(content)
+      // except first make sure there are no pre-escaped square brackets
+      content = turndownService.escape(
+        content.replace(/\\\[/g, "[").replace(/\\\]/g, "]")
+      )
     }
     const ref = turndownService
       .escape(

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -10,6 +10,8 @@ const titleCase = require("title-case")
 const tmp = require("tmp")
 tmp.setGracefulCleanup()
 
+const { GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
+
 const testDataPath = "test_data/courses"
 const singleCourseId =
   "2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009"
@@ -406,5 +408,16 @@ describe("turndown service", () => {
       problematicHTML
     )
     assert.equal(markdown, "```\nstuff\nin\nthe\nblock\n```")
+  })
+
+  it("should properly escape square brackets inside link text", () => {
+    const problematicHTML = `<a href="${GETPAGESHORTCODESTART}courses/${singleCourseId}/syllabus${GETPAGESHORTCODEEND}">[R&amp;T]</a>`
+    const markdown = markdownGenerators.turndownService.turndown(
+      problematicHTML
+    )
+    assert.equal(
+      markdown,
+      `[\\[R&T\\]]({{% getpage "courses/2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009/syllabus" %}})`
+    )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/166

#### What's this PR do?
The text of some links in OCW content have pre-escaped square brackets in them.  Since text needs to be escaped before going in the square brackets of a markdown link, feeding these pre-escaped square brackets into that results in `\\\[` which is interpreted as LaTeX by MathJax.  This PR un-escapes square brackets before escaping the entire text content of links.

#### How should this be manually tested?
Run a conversion and look at the markdown for the page in the attached issue or any other page that has link text on OCW with square brackets in it and ensure that the resulting markdown has inner square brackets properly escaped and they aren't `\\\[`.