### PR TITLE
list_in_left_nav fix

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -215,17 +215,13 @@ const generateMarkdownRecursive = page => {
   const hasMedia = coursePageEmbeddedMedia.length > 0
   const hasParent = parents.length > 0
   const parent = hasParent ? parents[0] : null
-  const isGrandChild = hasParent
-    ? courseData["course_pages"].filter(
-      coursePage => coursePage["uid"] === parent["parent_uid"]
-    ).length > 0
-    : false
+  const inRootNav = page["parent_uid"] === courseData["uid"]
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
     page["short_page_title"],
     `${page["uid"]}`,
     hasParent ? parent["uid"] : null,
-    isGrandChild,
+    inRootNav,
     hasMedia,
     page["is_media_gallery"],
     (this["menuIndex"] + 1) * 10,
@@ -365,7 +361,7 @@ const generateCourseSectionFrontMatter = (
   shortTitle,
   pageId,
   parentId,
-  isGrandChild,
+  inRootNav,
   hasMedia,
   isMediaGallery,
   menuIndex,
@@ -382,7 +378,7 @@ const generateCourseSectionFrontMatter = (
     layout:    "course_section"
   }
 
-  if (!isGrandChild || listInLeftNav) {
+  if (inRootNav || listInLeftNav) {
     courseSectionFrontMatter["menu"] = {
       [courseId]: {
         identifier: pageId,

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -316,6 +316,51 @@ describe("generateCourseSectionFrontMatter", () => {
   it("calls yaml.safeDump once", () => {
     expect(safeDump).to.be.calledOnce
   })
+
+  it("doesn't create a menu entry if list_in_left_nav is false and it's not a root section", () => {
+    courseSectionFrontMatter = yaml.safeLoad(
+      markdownGenerators
+        .generateCourseSectionFrontMatter(
+          "Syllabus",
+          "Syllabus",
+          "syllabus",
+          null,
+          false,
+          false,
+          false,
+          10,
+          false,
+          singleCourseJsonData["short_url"]
+        )
+        .replace(/---\n/g, "")
+    )
+    expect(courseSectionFrontMatter["menu"]).to.be.undefined
+  })
+
+  it("creates a menu entry if list_in_left_nav is true and it's not a root section", () => {
+    courseSectionFrontMatter = yaml.safeLoad(
+      markdownGenerators
+        .generateCourseSectionFrontMatter(
+          "Syllabus",
+          "Syllabus",
+          "syllabus",
+          null,
+          false,
+          false,
+          false,
+          10,
+          true,
+          singleCourseJsonData["short_url"]
+        )
+        .replace(/---\n/g, "")
+    )
+    assert.equal(
+      10,
+      courseSectionFrontMatter["menu"][singleCourseJsonData["short_url"]][
+        "weight"
+      ]
+    )
+  })
 })
 
 describe("generateCourseFeatures", () => {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -285,7 +285,7 @@ describe("generateCourseSectionFrontMatter", () => {
           "Syllabus",
           "syllabus",
           null,
-          false,
+          true,
           false,
           false,
           10,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/181

#### What's this PR do?
Only creates menu items for root level pages and children that have `list_in_left_nav` set to true.

#### How should this be manually tested?
Run a conversion and confirm that only root level pages and pages with `list_in_left_nav` set to true have menu items in their front matter.