### PR TITLE
fix anchor links

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -114,6 +114,18 @@ turndownService.addRule("codeblockfix", {
   }
 })
 
+turndownService.addRule("anchorshortcode", {
+  filter: (node, options) => {
+    if (node.nodeName === "A" && node.getAttribute("name")) {
+      return true
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    return `{{< anchor "${node.getAttribute("name")}" >}}`
+  }
+})
+
 /**
  * Build links with Hugo shortcodes to course sections
  **/

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -114,6 +114,9 @@ turndownService.addRule("codeblockfix", {
   }
 })
 
+/**
+ * Build anchor link shortcodes
+ **/
 turndownService.addRule("anchorshortcode", {
   filter: (node, options) => {
     if (node.nodeName === "A" && node.getAttribute("name")) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -465,4 +465,10 @@ describe("turndown service", () => {
       `[\\[R&T\\]]({{% getpage "courses/2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009/syllabus" %}})`
     )
   })
+
+  it("should generate an anchor shortcode for an a tag with a name attribute", () => {
+    const inputHTML = `<a name="test"></a>`
+    const markdown = markdownGenerators.turndownService.turndown(inputHTML)
+    assert.equal(markdown, `{{< anchor "test" >}}`)
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/167

#### What's this PR do?
Adds a turndown rule to create anchor shortcodes for `a` elements with a `name` attribute.

#### How should this be manually tested?
Convert the sample courses and make sure `<a name="example"><a>` elements in HTML are converted to a shortcode that looks like `{{< anchor "example" >}}`.