### PR TITLE
handle pre-escaped backticks

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -371,7 +371,7 @@ const stripS3 = text => {
   } else return text
 }
 
-const unescapeBackticks = text => text.replace(/\\`/g, "`")
+const unescapeBackticks = text => text.replace(/\\`/g, "&grave;")
 
 module.exports = {
   distinct,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -371,6 +371,8 @@ const stripS3 = text => {
   } else return text
 }
 
+const unescapeBackticks = text => text.replace(/\\`/g, "`")
+
 module.exports = {
   distinct,
   directoryExists,
@@ -389,6 +391,7 @@ module.exports = {
   resolveYouTubeEmbed,
   htmlSafeText,
   stripS3,
+  unescapeBackticks,
   courseUidList,
   runOptions
 }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -118,7 +118,7 @@ turndownService.addRule("codeblockfix", {
 /**
  * turn kbd, tt and samp elements into inline code blocks
  */
-turndownService.addRule("kbdfix", {
+turndownService.addRule("inlinecodeblockfix", {
   filter: node =>
     node.nodeName === "KBD" ||
     node.nodeName === "TT" ||

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -135,14 +135,13 @@ turndownService.addRule("inlinecodeblockfix", {
       content.match(backTickSingleQuoteWrap).forEach(match => {
         content = content.replace(`\\\`${match}'`, match)
       })
-      return `\`${content}\``
     } catch (err) {
       loggers.fileLogger.log({
         level:   "error",
         message: err
       })
     }
-    return content
+    return `\`${content}\``
   }
 })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -129,6 +129,8 @@ turndownService.addRule("kbdfix", {
      * between a backtick and a single quote
      */
     try {
+      // eslint seems to think the escaped backtick in the regex is useless, but it's not
+      // eslint-disable-next-line no-useless-escape
       const backTickSingleQuoteWrap = new RegExp(/(?<=\`)(.*?)(?=')/g)
       content.match(backTickSingleQuoteWrap).forEach(match => {
         content = content.replace(`\\\`${match}'`, match)

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -471,4 +471,10 @@ describe("turndown service", () => {
     const markdown = markdownGenerators.turndownService.turndown(inputHTML)
     assert.equal(markdown, `{{< anchor "test" >}}`)
   })
+
+  it("should turn inline code blocks into text surrounded by backticks", () => {
+    const inputHTML = `<kbd>\`test'</kbd><tt>\`test'</tt><samp>\`test'</samp>`
+    const markdown = markdownGenerators.turndownService.turndown(inputHTML)
+    assert.equal(markdown, "`test``test``test`")
+  })
 })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -419,12 +419,14 @@ describe("generateCourseSectionMarkdown", () => {
     )
   })
 
-  it ("should strip pre-escaped backticks from markdown", () => {
+  it("should strip pre-escaped backticks from markdown", () => {
     assert(
-      !markdownGenerators.generateCourseSectionMarkdown(
-        coursePagesWithText[0],
-        singleCourseJsonData
-      ).includes("\\`")
+      !markdownGenerators
+        .generateCourseSectionMarkdown(
+          coursePagesWithText[0],
+          singleCourseJsonData
+        )
+        .includes("\\`")
     )
   })
 })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -418,6 +418,15 @@ describe("generateCourseSectionMarkdown", () => {
       )
     )
   })
+
+  it ("should strip pre-escaped backticks from markdown", () => {
+    assert(
+      !markdownGenerators.generateCourseSectionMarkdown(
+        coursePagesWithText[0],
+        singleCourseJsonData
+      ).includes("\\`")
+    )
+  })
 })
 
 describe("generateCourseFeaturesMarkdown", () => {
@@ -473,7 +482,7 @@ describe("turndown service", () => {
   })
 
   it("should turn inline code blocks into text surrounded by backticks", () => {
-    const inputHTML = `<kbd>\`test'</kbd><tt>\`test'</tt><samp>\`test'</samp>`
+    const inputHTML = `<kbd>test</kbd><tt>test</tt><samp>test</samp>`
     const markdown = markdownGenerators.turndownService.turndown(inputHTML)
     assert.equal(markdown, "`test``test``test`")
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/62

#### What's this PR do?
Adds a turndown rule to handle inline code blocks and a helper function to handle pre-escaped backticks

#### How should this be manually tested?
Convert courses with pre-escaped backticks (i.e. `1-124j-foundations-of-software-engineering-fall-2000`) and make sure `hugo-course-publisher` builds properly with it in the content directory.
