### PR TITLE
mirror hugo-course-publisher contentDir

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,12 @@
     "dotenv": "^8.2.0",
     "js-yaml": "^3.13.1",
     "markdown-builder": "^0.9.0",
+    "simple-git": "^2.20.1",
     "title-case": "^3.0.2",
+    "tmp": "^0.2.1",
     "turndown": "^6.0.0",
     "turndown-plugin-gfm": "^1.0.2",
+    "walk": "^2.3.14",
     "winston": "^3.2.1",
     "yargs": "^15.0.2"
   },
@@ -54,7 +57,6 @@
     "prettier-eslint-cli": "^5.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^8.0.4",
-    "sinon-chai": "^3.4.0",
-    "tmp": "^0.1.0"
+    "sinon-chai": "^3.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,12 +29,10 @@
     "dotenv": "^8.2.0",
     "js-yaml": "^3.13.1",
     "markdown-builder": "^0.9.0",
-    "simple-git": "^2.20.1",
     "title-case": "^3.0.2",
     "tmp": "^0.2.1",
     "turndown": "^6.0.0",
     "turndown-plugin-gfm": "^1.0.2",
-    "walk": "^2.3.14",
     "winston": "^3.2.1",
     "yargs": "^15.0.2"
   },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -3,7 +3,7 @@
 
 const yargs = require("yargs")
 const { downloadCourses } = require("../aws_sync")
-const { scanCourses } = require("../file_operations")
+const { downloadBoilerplate, scanCourses } = require("../file_operations")
 
 const { MISSING_JSON_ERROR_MESSAGE } = require("../constants")
 const loggers = require("../loggers")

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -3,7 +3,7 @@
 
 const yargs = require("yargs")
 const { downloadCourses } = require("../aws_sync")
-const { downloadBoilerplate, scanCourses } = require("../file_operations")
+const { fetchBoilerplate, scanCourses } = require("../file_operations")
 
 const { MISSING_JSON_ERROR_MESSAGE } = require("../constants")
 const loggers = require("../loggers")
@@ -52,9 +52,8 @@ const run = async () => {
     })
     throw new Error(MISSING_JSON_ERROR_MESSAGE)
   }
-  scanCourses(options.input, options.output, {
-    courses: options.courses,
-    strips3: options.strips3
+  fetchBoilerplate(options.output).then(() => {
+    scanCourses(options.input, options.output, options.courses)
   })
 }
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -3,7 +3,7 @@
 
 const yargs = require("yargs")
 const { downloadCourses } = require("../aws_sync")
-const { fetchBoilerplate, scanCourses } = require("../file_operations")
+const { writeBoilerplate, scanCourses } = require("../file_operations")
 
 const { MISSING_JSON_ERROR_MESSAGE } = require("../constants")
 const loggers = require("../loggers")
@@ -52,8 +52,11 @@ const run = async () => {
     })
     throw new Error(MISSING_JSON_ERROR_MESSAGE)
   }
-  fetchBoilerplate(options.output).then(() => {
-    scanCourses(options.input, options.output, options.courses)
+  writeBoilerplate(options.output).then(() => {
+    scanCourses(options.input, options.output, {
+      courses: options.courses,
+      strips3: options.strips3
+    })
   })
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,18 +11,29 @@ module.exports = {
   AWS_REGEX: new RegExp(
     /https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/g
   ),
-  BOILERPLATE_MARKDOWN: [{
-      path: "",
-      name: "_index.md",
-      content: `---\ntitle: Hugo Course Publisher\n---\n`
-    }, {
-      path: "search",
-      name: "_index.md",
-      content: `---\ntitle: Search\ntype: search\n---\n`
-    }, {
-      path: "courses",
-      name: "_index.md",
-      content: `---\ntitle: Courses\ntype: courseindex\n---\n`
+  BOILERPLATE_MARKDOWN: [
+    {
+      path:    "",
+      name:    "_index.md",
+      content: {
+        title: "Hugo Course Publisher"
+      }
+    },
+    {
+      path:    "search",
+      name:    "_index.md",
+      content: {
+        title: "Search",
+        type:  "search"
+      }
+    },
+    {
+      path:    "courses",
+      name:    "_index.md",
+      content: {
+        title: "Courses",
+        type:  "courseindex"
+      }
     }
   ]
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,5 +11,18 @@ module.exports = {
   AWS_REGEX: new RegExp(
     /https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/g
   ),
-  HUGO_COURSE_PUBLISHER_GIT: "git@github.com:mitodl/hugo-course-publisher.git"
+  BOILERPLATE_MARKDOWN: [{
+      path: "",
+      name: "_index.md",
+      content: `---\ntitle: Hugo Course Publisher\n---\n`
+    }, {
+      path: "search",
+      name: "_index.md",
+      content: `---\ntitle: Search\ntype: search\n---\n`
+    }, {
+      path: "courses",
+      name: "_index.md",
+      content: `---\ntitle: Courses\ntype: courseindex\n---\n`
+    }
+  ]
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,5 +10,6 @@ module.exports = {
     "No courses found!  For more information, see README.md",
   AWS_REGEX: new RegExp(
     /https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/g
-  )
+  ),
+  HUGO_COURSE_PUBLISHER_GIT: "git@github.com:mitodl/hugo-course-publisher.git"
 }

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -3,6 +3,7 @@
 const fs = require("fs")
 const util = require("util")
 const path = require("path")
+const yaml = require("js-yaml")
 const cliProgress = require("cli-progress")
 
 const {
@@ -25,8 +26,9 @@ const writeBoilerplate = async outputPath => {
   BOILERPLATE_MARKDOWN.forEach(file => {
     if (!directoryExists(file.path)) {
       const filePath = path.join(outputPath, file.path)
+      const content = `---\n${yaml.safeDump(file.content)}---\n`
       fs.mkdirSync(filePath, { recursive: true })
-      fs.writeFileSync(path.join(filePath, file.name), file.content)
+      fs.writeFileSync(path.join(filePath, file.name), content)
     }
   })
 }

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -3,9 +3,9 @@
 const fs = require("fs")
 const util = require("util")
 const path = require("path")
+const rimraf = require("rimraf")
 const tmp = require("tmp")
 const cliProgress = require("cli-progress")
-const simpleGit = require("simple-git")
 const walk = require("walk")
 
 const {
@@ -23,7 +23,6 @@ const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },
   cliProgress.Presets.shades_classic
 )
-const git = simpleGit()
 const readdir = util.promisify(fs.readdir)
 
 const scanCourses = (inputPath, outputPath, options = {}) => {

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -88,8 +88,6 @@ const fetchBoilerplate = (outputPath, done) => {
               path.join(root, fileStats.name),
               path.join(outputRoot, fileStats.name)
             )
-          } else {
-            nodeNamesArray = []
           }
           next()
         },

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -44,7 +44,7 @@ const scanCourses = (inputPath, outputPath, options = {}) => {
       ? courseList.length
       : courseList.filter(file => directoryExists(path.join(inputPath, file)))
         .length
-    const coursesPath = path.join(outputPath, "site", "content", "courses")
+    const coursesPath = path.join(outputPath, "courses")
     if (numCourses > 0) {
       // populate the course uid mapping
       courseList.forEach(async course => {

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -8,7 +8,8 @@ const git = require("simple-git")
 
 const {
   NO_COURSES_FOUND_MESSAGE,
-  MISSING_COURSE_ERROR_MESSAGE
+  MISSING_COURSE_ERROR_MESSAGE,
+  BOILERPLATE_MARKDOWN
 } = require("./constants")
 const helpers = require("./helpers")
 const fileOperations = require("./file_operations")
@@ -28,35 +29,14 @@ const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
   singleCourseJsonData
 )
 
-describe("fetchBoilerplate", () => {
-  let consoleLog, git, rimRafSync
-  const sandbox = sinon.createSandbox()
-  const tmpDir = tmp.dirSync({ prefix: "output" }).name
-  const coursesPath = path.join(tmpDir, "courses")
-
-  beforeEach(async () => {
-    consoleLog = sandbox.stub(console, "log")
-    git = sandbox.stub(helpers, "getGit").returns({
-      clone: (repo, dir) => {
-        if (!helpers.directoryExists(coursesPath)) {
-          fs.mkdirSync(coursesPath)
-        }
-      }
+describe("writeBoilerplate", () => {
+  it("writes the files as expected", async () => {
+    const outputPath = tmp.dirSync({ prefix: "output" }).name
+    await fileOperations.writeBoilerplate(outputPath)
+    BOILERPLATE_MARKDOWN.forEach(file => {
+      const tmpFileContents = fs.readFileSync(path.join(outputPath, file.path, file.name))
+      assert.equal(tmpFileContents, file.content)
     })
-    rimRafSync = sandbox.stub(rimraf, "sync")
-    await fileOperations.fetchBoilerplate(tmpDir)
-  })
-
-  afterEach(() => {
-    sandbox.restore()
-  })
-
-  it("runs the function successfully and we see the mocked folder in the output folder", async () => {
-    expect(fs.readdirSync(tmpDir)[0]).to.equal("courses")
-  })
-
-  it("cleans up the git tmp folder when done", async () => {
-    expect(rimRafSync).to.be.calledOnce
   })
 })
 

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -4,7 +4,7 @@ const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
 const tmp = require("tmp")
 const rimraf = require("rimraf")
-const git = require("simple-git")
+const yaml = require("js-yaml")
 
 const {
   NO_COURSES_FOUND_MESSAGE,
@@ -34,8 +34,11 @@ describe("writeBoilerplate", () => {
     const outputPath = tmp.dirSync({ prefix: "output" }).name
     await fileOperations.writeBoilerplate(outputPath)
     BOILERPLATE_MARKDOWN.forEach(file => {
-      const tmpFileContents = fs.readFileSync(path.join(outputPath, file.path, file.name))
-      assert.equal(tmpFileContents, file.content)
+      const expectedContent = `---\n${yaml.safeDump(file.content)}---\n`
+      const tmpFileContents = fs.readFileSync(
+        path.join(outputPath, file.path, file.name)
+      )
+      assert.equal(tmpFileContents, expectedContent)
     })
   })
 })

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -85,7 +85,7 @@ describe("scanCourses", () => {
     expect(readdirSync).to.be.calledOnce
   })
 
-  it("scans the three test courses and reports to console", () => {
+  it("scans the four test courses and reports to console", () => {
     fileOperations.scanCourses(inputPath, outputPath)
     expect(consoleLog).calledWithExactly(logMessage)
   })

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -32,14 +32,14 @@ describe("fetchBoilerplate", () => {
   let consoleLog, git, rimRafSync
   const sandbox = sinon.createSandbox()
   const tmpDir = tmp.dirSync({ prefix: "output" }).name
-  const sitePath = path.join(tmpDir, "site")
+  const coursesPath = path.join(tmpDir, "courses")
 
   beforeEach(async () => {
     consoleLog = sandbox.stub(console, "log")
     git = sandbox.stub(helpers, "getGit").returns({
       clone: (repo, dir) => {
-        if (!helpers.directoryExists(sitePath)) {
-          fs.mkdirSync(sitePath)
+        if (!helpers.directoryExists(coursesPath)) {
+          fs.mkdirSync(coursesPath)
         }
       }
     })
@@ -52,7 +52,7 @@ describe("fetchBoilerplate", () => {
   })
 
   it("runs the function successfully and we see the mocked folder in the output folder", async () => {
-    expect(fs.readdirSync(tmpDir)[0]).to.equal("site")
+    expect(fs.readdirSync(tmpDir)[0]).to.equal("courses")
   })
 
   it("cleans up the git tmp folder when done", async () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,7 +3,11 @@ const fs = require("fs")
 const path = require("path")
 
 const departmentsJson = require("./departments.json")
-const { AWS_REGEX, GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
+const {
+  AWS_REGEX,
+  GETPAGESHORTCODESTART,
+  GETPAGESHORTCODEEND
+} = require("./constants")
 const loggers = require("./loggers")
 
 const courseUidList = {}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,18 +1,13 @@
 const _ = require("lodash")
 const fs = require("fs")
 const path = require("path")
-const simpleGit = require("simple-git")
 
 const departmentsJson = require("./departments.json")
-const { GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
+const { AWS_REGEX, GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
 const loggers = require("./loggers")
 
 const courseUidList = {}
-const git = simpleGit()
-
-const getGit = () => {
-  return git
-}
+const runOptions = {}
 
 const distinct = (value, index, self) => {
   return self.indexOf(value) === index
@@ -373,7 +368,6 @@ const stripS3 = text => {
 }
 
 module.exports = {
-  getGit,
   distinct,
   directoryExists,
   createOrOverwriteFile,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,17 +1,18 @@
 const _ = require("lodash")
 const fs = require("fs")
 const path = require("path")
-const departmentsJson = require("./departments.json")
+const simpleGit = require("simple-git")
 
-const {
-  GETPAGESHORTCODESTART,
-  GETPAGESHORTCODEEND,
-  AWS_REGEX
-} = require("./constants")
+const departmentsJson = require("./departments.json")
+const { GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
 const loggers = require("./loggers")
 
 const courseUidList = {}
-const runOptions = {}
+const git = simpleGit()
+
+const getGit = () => {
+  return git
+}
 
 const distinct = (value, index, self) => {
   return self.indexOf(value) === index
@@ -372,6 +373,7 @@ const stripS3 = text => {
 }
 
 module.exports = {
+  getGit,
   distinct,
   directoryExists,
   createOrOverwriteFile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,18 +102,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@kwsites/file-exists@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
-  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
-  dependencies:
-    debug "^4.1.1"
-
-"@kwsites/promise-deferred@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
-  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
-
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -797,7 +785,7 @@ debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -1328,11 +1316,6 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
-
-foreachasync@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
-  integrity sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -2793,15 +2776,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-simple-git@^2.20.1:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.20.1.tgz#bab3f4d083ed6e1655a7c62ab8e8920eecae86f6"
-  integrity sha512-aa9s2ZLjXlHCVGbDXQLInMLvLkxKEclqMU9X5HMXi3tLWLxbWObz1UgtyZha6ocHarQtFp0OjQW9KHVR1g6wbA==
-  dependencies:
-    "@kwsites/file-exists" "^1.1.1"
-    "@kwsites/promise-deferred" "^1.1.1"
-    debug "^4.1.1"
-
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -3283,13 +3257,6 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
-
-walk@^2.3.14:
-  version "2.3.14"
-  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
-  integrity sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==
-  dependencies:
-    foreachasync "^3.0.0"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,18 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -785,7 +797,7 @@ debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1, debug@^4.1.0:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -1316,6 +1328,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+foreachasync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
+  integrity sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -2668,14 +2685,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -2782,6 +2792,15 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-git@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.20.1.tgz#bab3f4d083ed6e1655a7c62ab8e8920eecae86f6"
+  integrity sha512-aa9s2ZLjXlHCVGbDXQLInMLvLkxKEclqMU9X5HMXi3tLWLxbWObz1UgtyZha6ocHarQtFp0OjQW9KHVR1g6wbA==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.1.1"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -3100,12 +3119,12 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
   dependencies:
-    rimraf "^2.6.3"
+    rimraf "^3.0.0"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -3264,6 +3283,13 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
+
+walk@^2.3.14:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
+  integrity sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==
+  dependencies:
+    foreachasync "^3.0.0"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
This is part of the work for https://github.com/mitodl/hugo-course-publisher/issues/184
Closes https://github.com/mitodl/hugo-course-publisher/issues/191
Closes https://github.com/mitodl/ocw-to-hugo/issues/67

#### What's this PR do?
This adds code to fetch the `hugo-course-publisher` content boilerplate and inject it into the output directory along with courses.  This is so we can use the direct output of `ocw-to-hugo` as the `contentDir` argument in hugo when building `hugo-course-publisher`.

#### How should this be manually tested?
Run a markdown conversion and then build the site using `hugo-course-publisher` with the following commands:

```sh
npm run build:webpack
hugo -d dist -s site -v --contentDir (ocw-to-hugo output folder here)
```
