### PR TITLE
strip s3 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ If the `-c` option has been specified, processing will be filtered by the course
 
 ## Arguments
 
-| Argument | Required? | Valid values  |
-| :------- | :-------- | :------------ |
-| `-c, -courses`      | Only if download flag is true  | `/path/to/courses.json` |
-| `-d, -download`      | No  | `(true | false)` |
-| `-i, -input`      | Yes | `/path/to/open-learning-course-data` |
-| `-o, -output`      | Yes | `/path/to/hugo-markdown-output` |
+| Argument | Required? | Valid values  | Description |
+| :------- | :-------- | :------------ | :------------ |
+| `-i, --input`      | Yes | `/path/to/open-learning-course-data` | Input folder of OCW course folders containing `master.json` files and optionally static content |
+| `-o, --output`      | Yes | `/path/to/hugo-markdown-output` | Output path to place `hugo-course-publisher` content folder in |
+| `-c, --courses`      | Only if download flag is true  | `/path/to/courses.json` | If enabled, courses processed will be filtered based on the format above |
+| `--download`      | No  | `true or false` | Download `master.json` files from a configured S3 bucket and a list of courses passed in with `-c` |
+| `--strips3`       | No  | `true or false` | Strip the s3 base URL from all OCW resources |
 
 ## Environment Variables
 | Variable | Description  |

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -36,7 +36,8 @@ const options = yargs
     demandOption: false
   })
   .option("strips3", {
-    describe:     "A flag that tells ocw-to-hugo to strip the s3 base url from OCW resources",
+    describe:
+      "A flag that tells ocw-to-hugo to strip the s3 base url from OCW resources",
     type:         "boolean",
     demandOption: false
   }).argv

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -11,19 +11,6 @@ const loggers = require("../loggers")
 // Gather arguments
 const options = yargs
   .usage("Usage: -s <path> -d <path>")
-  .option("c", {
-    alias:        "courses",
-    describe:     "A JSON file describing courses to process",
-    type:         "string",
-    demandOption: false
-  })
-  .option("d", {
-    alias:    "download",
-    describe:
-      "A flag that if set to true to will download courses passed in from AWS",
-    type:         "boolean",
-    demandOption: false
-  })
   .option("i", {
     alias:        "input",
     describe:     "Input directory of courses",
@@ -35,6 +22,23 @@ const options = yargs
     describe:     "Output directory for Hugo markdown",
     type:         "string",
     demandOption: true
+  })
+  .option("c", {
+    alias:        "courses",
+    describe:     "A JSON file describing courses to process",
+    type:         "string",
+    demandOption: false
+  })
+  .option("download", {
+    describe:
+      "A flag that if set to true to will download courses passed in from AWS",
+    type:         "boolean",
+    demandOption: false
+  })
+  .option("strips3", {
+    describe:     "A flag that tells ocw-to-hugo to strip the s3 base url from OCW resources",
+    type:         "boolean",
+    demandOption: false
   }).argv
 
 const run = async () => {
@@ -47,7 +51,10 @@ const run = async () => {
     })
     throw new Error(MISSING_JSON_ERROR_MESSAGE)
   }
-  scanCourses(options.input, options.output, options.courses)
+  scanCourses(options.input, options.output, {
+    courses: options.courses,
+    strips3: options.strips3
+  })
 }
 
 run()

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,5 +7,8 @@ module.exports = {
   MISSING_COURSE_ERROR_MESSAGE:
     "Specified course was not found.  You need to either place the course there or use the -d option to download it from AWS.  For more information, see README.md",
   NO_COURSES_FOUND_MESSAGE:
-    "No courses found!  For more information, see README.md"
+    "No courses found!  For more information, see README.md",
+  AWS_REGEX: new RegExp(
+    /https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/g
+  )
 }

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -20,7 +20,7 @@ const progressBar = new cliProgress.SingleBar(
 )
 const readdir = util.promisify(fs.readdir)
 
-const scanCourses = (inputPath, outputPath, jsonPath = null) => {
+const scanCourses = (inputPath, outputPath, options = {}) => {
   /*
     This function scans the input directory for course folders
   */
@@ -31,10 +31,12 @@ const scanCourses = (inputPath, outputPath, jsonPath = null) => {
   if (!directoryExists(outputPath)) {
     throw new Error("Invalid output directory")
   }
-  const courseList = jsonPath
-    ? JSON.parse(fs.readFileSync(jsonPath))["courses"]
+  const coursesJson = options.courses
+  helpers.runOptions.strips3 = options.strips3
+  const courseList = coursesJson
+    ? JSON.parse(fs.readFileSync(coursesJson))["courses"]
     : fs.readdirSync(inputPath).filter(course => !course.startsWith("."))
-  const numCourses = jsonPath
+  const numCourses = coursesJson
     ? courseList.length
     : courseList.filter(file => directoryExists(path.join(inputPath, file)))
       .length

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -73,7 +73,7 @@ describe("scanCourses", () => {
     fileOperations.scanCourses(
       inputPath,
       outputPath,
-      "test_data/courses_blank.json"
+      { courses: "test_data/courses_blank.json" }
     )
     expect(consoleLog).calledWithExactly(NO_COURSES_FOUND_MESSAGE)
   })

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -13,7 +13,6 @@ const helpers = require("./helpers")
 const fileOperations = require("./file_operations")
 const markdownGenerators = require("./markdown_generators")
 
-tmp.setGracefulCleanup()
 const testDataPath = "test_data/courses"
 const singleCourseId =
   "2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009"
@@ -70,11 +69,9 @@ describe("scanCourses", () => {
   })
 
   it("displays an error when you call it with an empty courses.json", () => {
-    fileOperations.scanCourses(
-      inputPath,
-      outputPath,
-      { courses: "test_data/courses_blank.json" }
-    )
+    fileOperations.scanCourses(inputPath, outputPath, {
+      courses: "test_data/courses_blank.json"
+    })
     expect(consoleLog).calledWithExactly(NO_COURSES_FOUND_MESSAGE)
   })
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -235,9 +235,7 @@ const resolveUids = (htmlStr, page, courseData) => {
             )
           } else {
             // link directly to the static content
-            htmlStr = stripS3(
-              htmlStr.replace(url, linkedFile["file_location"])
-            )
+            htmlStr = stripS3(htmlStr.replace(url, linkedFile["file_location"]))
           }
         }
         if (linkedCourse) {
@@ -370,8 +368,7 @@ const htmlSafeText = text =>
 const stripS3 = text => {
   if (runOptions.strips3) {
     return text.replace(AWS_REGEX, "")
-  }
-  else return text
+  } else return text
 }
 
 module.exports = {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -360,6 +360,12 @@ const resolveYouTubeEmbed = (htmlStr, courseData) => {
 const htmlSafeText = text =>
   text.replace(/("|')/g, "").replace(/(\r\n|\r|\n)/g, " ")
 
+const awsRegEx = new RegExp(/https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/)
+
+const stripAws = text => {  
+  return text.replace(awsRegEx, "")
+}
+
 module.exports = {
   distinct,
   directoryExists,
@@ -377,5 +383,7 @@ module.exports = {
   resolveRelativeLinks,
   resolveYouTubeEmbed,
   htmlSafeText,
+  stripAws,
+  awsRegEx,
   courseUidList
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,6 +11,7 @@ const {
 const loggers = require("./loggers")
 
 const courseUidList = {}
+const runOptions = {}
 
 const distinct = (value, index, self) => {
   return self.indexOf(value) === index
@@ -234,7 +235,7 @@ const resolveUids = (htmlStr, page, courseData) => {
             )
           } else {
             // link directly to the static content
-            htmlStr = stripAws(
+            htmlStr = stripS3(
               htmlStr.replace(url, linkedFile["file_location"])
             )
           }
@@ -321,7 +322,7 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
                 htmlStr = htmlStr.replace(url, newUrl)
               } else if (media["file_location"].includes(page)) {
                 // write link directly to file
-                htmlStr = stripAws(htmlStr.replace(url, media["file_location"]))
+                htmlStr = stripS3(htmlStr.replace(url, media["file_location"]))
               }
             })
           } else {
@@ -366,8 +367,11 @@ const resolveYouTubeEmbed = (htmlStr, courseData) => {
 const htmlSafeText = text =>
   text.replace(/("|')/g, "").replace(/(\r\n|\r|\n)/g, " ")
 
-const stripAws = text => {
-  return text.replace(AWS_REGEX, "")
+const stripS3 = text => {
+  if (runOptions.strips3) {
+    return text.replace(AWS_REGEX, "")
+  }
+  else return text
 }
 
 module.exports = {
@@ -387,6 +391,7 @@ module.exports = {
   resolveRelativeLinks,
   resolveYouTubeEmbed,
   htmlSafeText,
-  stripAws,
-  courseUidList
+  stripS3,
+  courseUidList,
+  runOptions
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,7 +3,11 @@ const fs = require("fs")
 const path = require("path")
 const departmentsJson = require("./departments.json")
 
-const { GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
+const {
+  GETPAGESHORTCODESTART,
+  GETPAGESHORTCODEEND,
+  AWS_REGEX
+} = require("./constants")
 const loggers = require("./loggers")
 
 const courseUidList = {}
@@ -230,7 +234,9 @@ const resolveUids = (htmlStr, page, courseData) => {
             )
           } else {
             // link directly to the static content
-            htmlStr = htmlStr.replace(url, linkedFile["file_location"])
+            htmlStr = stripAws(
+              htmlStr.replace(url, linkedFile["file_location"])
+            )
           }
         }
         if (linkedCourse) {
@@ -315,7 +321,7 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
                 htmlStr = htmlStr.replace(url, newUrl)
               } else if (media["file_location"].includes(page)) {
                 // write link directly to file
-                htmlStr = htmlStr.replace(url, media["file_location"])
+                htmlStr = stripAws(htmlStr.replace(url, media["file_location"]))
               }
             })
           } else {
@@ -360,10 +366,8 @@ const resolveYouTubeEmbed = (htmlStr, courseData) => {
 const htmlSafeText = text =>
   text.replace(/("|')/g, "").replace(/(\r\n|\r|\n)/g, " ")
 
-const awsRegEx = new RegExp(/https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/)
-
-const stripAws = text => {  
-  return text.replace(awsRegEx, "")
+const stripAws = text => {
+  return text.replace(AWS_REGEX, "")
 }
 
 module.exports = {
@@ -384,6 +388,5 @@ module.exports = {
   resolveYouTubeEmbed,
   htmlSafeText,
   stripAws,
-  awsRegEx,
   courseUidList
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -163,3 +163,40 @@ describe("resolveRelativeLinks", () => {
     assert.isTrue(result.indexOf(GETPAGESHORTCODESTART) !== -1)
   })
 })
+
+describe("stripS3", () => {
+  beforeEach(() => {
+    helpers.runOptions.strips3 = true
+  })
+
+  afterEach(() => {
+    helpers.runOptions.strips3 = undefined
+  })
+
+  it("strips OCW base S3 URL from a URL string", () => {
+    const input = "https://open-learning-course-data.s3.amazonaws.com/test.jpg"
+    assert.equal(helpers.stripS3(input), "/test.jpg")
+  })
+
+  it("strips regardless of protocol", () => {
+    const input = "http://open-learning-course-data.s3.amazonaws.com/test.jpg"
+    assert.equal(helpers.stripS3(input), "/test.jpg")
+  })
+
+  it("does not strip from a non OCW url", () => {
+    const input = "https://something-else.amazonaws.com/test.jpg"
+    assert.equal(
+      helpers.stripS3(input),
+      "https://something-else.amazonaws.com/test.jpg"
+    )
+  })
+
+  it("does not strip if the option is turned off", () => {
+    helpers.runOptions.strips3 = undefined
+    const input = "https://open-learning-course-data.s3.amazonaws.com/test.jpg"
+    assert.equal(
+      helpers.stripS3(input),
+      "https://open-learning-course-data.s3.amazonaws.com/test.jpg"
+    )
+  })
+})

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -13,7 +13,6 @@ const {
 } = require("./constants")
 const helpers = require("./helpers")
 const loggers = require("./loggers")
-const constants = require("./constants")
 
 const turndownService = new TurndownService({
   codeBlockStyle: "fenced"

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -133,7 +133,7 @@ turndownService.addRule("anchorshortcode", {
 /**
  * Strip open-learning-course-data*.s3.amazonaws.com urls back to being absolute urls
  */
-turndownService.addRule("stripaws", {
+turndownService.addRule("stripS3", {
   filter: (node, options) => {
     if (node.nodeName === "A" && node.getAttribute("href")) {
       if (node.getAttribute("href").match(AWS_REGEX)) {
@@ -148,7 +148,7 @@ turndownService.addRule("stripaws", {
   },
   replacement: (content, node, options) => {
     const attr = node.nodeName === "A" ? "href" : "src"
-    return `[${content}](${helpers.stripAws(node.getAttribute(attr))})`
+    return `[${content}](${helpers.stripS3(node.getAttribute(attr))})`
   }
 })
 
@@ -382,10 +382,10 @@ const generateCourseHomeMarkdown = courseData => {
     }
   }
   // strip out any direct s3 pathing in course image urls
-  frontMatter["course_image_url"] = helpers.stripAws(
+  frontMatter["course_image_url"] = helpers.stripS3(
     frontMatter["course_image_url"]
   )
-  frontMatter["course_thumbnail_image_url"] = helpers.stripAws(
+  frontMatter["course_thumbnail_image_url"] = helpers.stripS3(
     frontMatter["course_thumbnail_image_url"]
   )
   try {
@@ -499,7 +499,7 @@ const generatePdfMarkdown = (file, courseData) => {
     layout:        "pdf",
     uid:           file["uid"],
     file_type:     file["file_type"],
-    file_location: helpers.stripAws(file["file_location"]),
+    file_location: helpers.stripS3(file["file_location"]),
     course_id:     courseData["short_url"]
   }
   return `---\n${yaml.safeDump(pdfFrontMatter)}---\n`
@@ -539,7 +539,7 @@ const generateCourseFeaturesMarkdown = (page, courseData) => {
         )
         courseFeaturesMarkdown = `${courseFeaturesMarkdown}\n{{< image-gallery id="${
           page["uid"]
-        }_nanogallery2" baseUrl="${helpers.stripAws(
+        }_nanogallery2" baseUrl="${helpers.stripS3(
           baseUrl
         )}" >}}\n${imageShortcodes.join("\n")}\n{{</ image-gallery >}}`
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/70

#### What's this PR do?
This PR adds the ability to optionally strip OCW S3 base URL's from the output, turning these links into absolute links relative to the site root.

#### How should this be manually tested?
Convert any number of courses with the `--strips3` option and verify that open-learning-course-data based s3 links have their base URL stripped.  Without this option, the links should remain as they are.
