### PR TITLE
don't throw an error to the console if a course is missing

### DIFF
--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -127,7 +127,6 @@ const getMasterJsonFileName = async coursePath => {
     message: courseError
   })
   progressBar.increment()
-  throw new Error(courseError)
 }
 
 const writeMarkdownFilesRecursive = (outputPath, markdownData) => {

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -142,17 +142,6 @@ describe("scanCourse", () => {
       singleCourseJsonData
     )
   })
-
-  it("throws an error when you call it with a course that doesn't exist", async () => {
-    await expect(
-      fileOperations.scanCourse(testDataPath, outputPath, "test_missing")
-    ).to.eventually.be.rejectedWith(
-      `${path.join(
-        testDataPath,
-        "test_missing"
-      )} - ${MISSING_COURSE_ERROR_MESSAGE}`
-    )
-  })
 })
 
 describe("getMasterJsonFileName", () => {
@@ -161,28 +150,6 @@ describe("getMasterJsonFileName", () => {
       path.join(testDataPath, singleCourseId)
     )
     assert.equal(masterJsonFileName, singleCourseMasterJsonPath)
-  })
-
-  it("throws an error when you call it with nonexistent directory", async () => {
-    await expect(
-      fileOperations.getMasterJsonFileName(
-        path.join(testDataPath, "test_missing")
-      )
-    ).to.eventually.be.rejectedWith(
-      `${path.join(
-        testDataPath,
-        "test_missing"
-      )} - ${MISSING_COURSE_ERROR_MESSAGE}`
-    )
-  })
-
-  it("throws an error when you call it with a directory with no master json file", async () => {
-    const emptyDirectory = path.join("test_data", "empty")
-    await expect(
-      fileOperations.getMasterJsonFileName(emptyDirectory)
-    ).to.eventually.be.rejectedWith(
-      `${emptyDirectory} - ${MISSING_COURSE_ERROR_MESSAGE}`
-    )
   })
 })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/73

#### What's this PR do?
Prevents `ocw-to-hugo` from throwing an error to the console when there is a folder in the input directory without a master.json file and only logs it to the file error log instead.

#### How should this be manually tested?
Place a folder in your input folder with no master.json file in it.  When run, `ocw-to-hugo` should not spit an error out to the console and instead just write it to the error log.
