### PR TITLE
static prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If the `-c` option has been specified, processing will be filtered by the course
 | `-c, --courses`      | Only if download flag is true  | `/path/to/courses.json` | If enabled, courses processed will be filtered based on the format above |
 | `--download`      | No  | `true or false` | Download `master.json` files from a configured S3 bucket and a list of courses passed in with `-c` |
 | `--strips3`       | No  | `true or false` | Strip the s3 base URL from all OCW resources |
+| `--staticPrefix`       | No  | `/path/to/static/assets` | When `--strips3` is set to true, replace the s3 base URL with this string |
 
 ## Environment Variables
 | Variable | Description  |

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -40,6 +40,12 @@ const options = yargs
       "A flag that tells ocw-to-hugo to strip the s3 base url from OCW resources",
     type:         "boolean",
     demandOption: false
+  })
+  .option("staticPrefix", {
+    describe:
+      "When strips3 is set to true, the value passed into this argument will replace the s3 prefix on static assets",
+    type:         "string",
+    demandOption: false
   }).argv
 
 const run = async () => {
@@ -54,8 +60,9 @@ const run = async () => {
   }
   writeBoilerplate(options.output).then(() => {
     scanCourses(options.input, options.output, {
-      courses: options.courses,
-      strips3: options.strips3
+      courses:      options.courses,
+      strips3:      options.strips3,
+      staticPrefix: options.staticPrefix
     })
   })
 }

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -47,6 +47,7 @@ const scanCourses = (inputPath, outputPath, options = {}) => {
   try {
     const jsonPath = options.courses
     helpers.runOptions.strips3 = options.strips3
+    helpers.runOptions.staticPrefix = options.staticPrefix
     const courseList = jsonPath
       ? JSON.parse(fs.readFileSync(jsonPath))["courses"]
       : fs.readdirSync(inputPath).filter(course => !course.startsWith("."))

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -367,7 +367,8 @@ const htmlSafeText = text =>
 
 const stripS3 = text => {
   if (runOptions.strips3) {
-    return text.replace(AWS_REGEX, "")
+    const staticPrefix = runOptions.staticPrefix ? runOptions.staticPrefix : ""
+    return text.replace(AWS_REGEX, staticPrefix)
   } else return text
 }
 

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -199,4 +199,13 @@ describe("stripS3", () => {
       "https://open-learning-course-data.s3.amazonaws.com/test.jpg"
     )
   })
+
+  it("replaces the s3 prefix with a static prefix if set", () => {
+    helpers.runOptions.staticPrefix = "/courses"
+    const input = "https://open-learning-course-data.s3.amazonaws.com/test.jpg"
+    assert.equal(
+      helpers.stripS3(input),
+      "/courses/test.jpg"
+    )
+  })
 })

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -203,9 +203,6 @@ describe("stripS3", () => {
   it("replaces the s3 prefix with a static prefix if set", () => {
     helpers.runOptions.staticPrefix = "/courses"
     const input = "https://open-learning-course-data.s3.amazonaws.com/test.jpg"
-    assert.equal(
-      helpers.stripS3(input),
-      "/courses/test.jpg"
-    )
+    assert.equal(helpers.stripS3(input), "/courses/test.jpg")
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/196

#### What's this PR do?
This PR adds an optional argument, `--staticPrefix` that, when used in conjunction with `--strips3`, will be used as the replacement for the s3 base url instead of a blank string.

#### How should this be manually tested?
Convert any number of courses with `--strips3` and a `--staticPrefix` of your choice and verify that the links to static content from s3 are prefixed with what you entered.
