### PR TITLE
anchor shortcode content

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -158,8 +158,8 @@ turndownService.addRule("anchorshortcode", {
   replacement: (content, node, options) => {
     const name = node.getAttribute("name")
     const href = node.getAttribute("href")
-    return `{{< anchor "${name}" ${
-      href ? `"${href}"` : ""
+    return `{{< anchor "${name}"${
+      href ? ` "${href}"` : ""
     } >}}${content}{{< /anchor >}}`
   }
 })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -156,7 +156,7 @@ turndownService.addRule("anchorshortcode", {
     return false
   },
   replacement: (content, node, options) => {
-    return `{{< anchor "${node.getAttribute("name")}" >}}`
+    return `{{< anchor "${node.getAttribute("name")}" "${content}" >}}`
   }
 })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -156,7 +156,7 @@ turndownService.addRule("anchorshortcode", {
     return false
   },
   replacement: (content, node, options) => {
-    return `{{< anchor "${node.getAttribute("name")}" >}}${content}{{< anchor />}}`
+    return `{{< anchor "${node.getAttribute("name")}" >}}${content}{{< /anchor >}}`
   }
 })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -156,9 +156,11 @@ turndownService.addRule("anchorshortcode", {
     return false
   },
   replacement: (content, node, options) => {
-    return `{{< anchor "${node.getAttribute(
-      "name"
-    )}" >}}${content}{{< /anchor >}}`
+    const name = node.getAttribute("name")
+    const href = node.getAttribute("href")
+    return `{{< anchor "${name}" ${
+      href ? `"${href}"` : ""
+    } >}}${content}{{< /anchor >}}`
   }
 })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -156,7 +156,9 @@ turndownService.addRule("anchorshortcode", {
     return false
   },
   replacement: (content, node, options) => {
-    return `{{< anchor "${node.getAttribute("name")}" >}}${content}{{< /anchor >}}`
+    return `{{< anchor "${node.getAttribute(
+      "name"
+    )}" >}}${content}{{< /anchor >}}`
   }
 })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -156,7 +156,7 @@ turndownService.addRule("anchorshortcode", {
     return false
   },
   replacement: (content, node, options) => {
-    return `{{< anchor "${node.getAttribute("name")}" "${content}" >}}`
+    return `{{< anchor "${node.getAttribute("name")}" >}}${content}{{< anchor />}}`
   }
 })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -480,7 +480,7 @@ describe("turndown service", () => {
   it("should generate an anchor shortcode for an a tag with a name attribute", () => {
     const inputHTML = `<a name="test">test</a>`
     const markdown = markdownGenerators.turndownService.turndown(inputHTML)
-    assert.equal(markdown, `{{< anchor "test" >}}test{{< anchor />}}`)
+    assert.equal(markdown, `{{< anchor "test" >}}test{{< /anchor >}}`)
   })
 
   it("should turn inline code blocks into text surrounded by backticks", () => {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -483,6 +483,15 @@ describe("turndown service", () => {
     assert.equal(markdown, `{{< anchor "test" >}}test{{< /anchor >}}`)
   })
 
+  it("should generate an anchor shortcode for an a tag with a name and href attribute", () => {
+    const inputHTML = `<a name="test" href="https://ocw.mit.edu">test</a>`
+    const markdown = markdownGenerators.turndownService.turndown(inputHTML)
+    assert.equal(
+      markdown,
+      `{{< anchor "test" "https://ocw.mit.edu" >}}test{{< /anchor >}}`
+    )
+  })
+
   it("should turn inline code blocks into text surrounded by backticks", () => {
     const inputHTML = `<kbd>test</kbd><tt>test</tt><samp>test</samp>`
     const markdown = markdownGenerators.turndownService.turndown(inputHTML)

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -478,9 +478,9 @@ describe("turndown service", () => {
   })
 
   it("should generate an anchor shortcode for an a tag with a name attribute", () => {
-    const inputHTML = `<a name="test"></a>`
+    const inputHTML = `<a name="test">test</a>`
     const markdown = markdownGenerators.turndownService.turndown(inputHTML)
-    assert.equal(markdown, `{{< anchor "test" >}}`)
+    assert.equal(markdown, `{{< anchor "test" >}}test{{< anchor />}}`)
   })
 
   it("should turn inline code blocks into text surrounded by backticks", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/75

#### What's this PR do?
This PR adds `content` as the inner HTML of the generated `anchor` shortcode, which is then pulled in as `.Inner` in the shortcode itself.

#### How should this be manually tested?
Generate some markdown, ensure that `anchor` shortcodes have content in them where they're supposed to.  The turndown rule catches all `a` tags with a `name` property so you should check source HTML that follows this pattern. `1-124j-foundations-of-software-engineering-fall-2000` is a good place to start.
