### PR TITLE
Refactor for async/await and error handling

### DIFF
--- a/src/aws_sync.js
+++ b/src/aws_sync.js
@@ -14,7 +14,7 @@ const progressBar = new cliProgress.SingleBar(
 )
 
 const downloadCourses = async (coursesJson, coursesDir) => {
-  if (!await fileExists(coursesJson)) {
+  if (!(await fileExists(coursesJson))) {
     throw new Error("Invalid courses JSON")
   }
   if (!coursesDir) {

--- a/src/aws_sync.js
+++ b/src/aws_sync.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
 
-const fs = require("fs")
+const { readFile, stat } = require("./fsPromises")
 const path = require("path")
 const AWS = require("aws-sdk")
 require("dotenv").config()
 const cliProgress = require("cli-progress")
 
-const { createOrOverwriteFile } = require("./helpers")
+const { createOrOverwriteFile, fileExists } = require("./helpers")
 
 const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },
@@ -14,7 +14,7 @@ const progressBar = new cliProgress.SingleBar(
 )
 
 const downloadCourses = async (coursesJson, coursesDir) => {
-  if (!fs.existsSync(coursesJson)) {
+  if (!await fileExists(coursesJson)) {
     throw new Error("Invalid courses JSON")
   }
   if (!coursesDir) {
@@ -43,7 +43,7 @@ const downloadCourses = async (coursesJson, coursesDir) => {
   }
 
   const s3 = new AWS.S3()
-  const courses = JSON.parse(fs.readFileSync(coursesJson))["courses"]
+  const courses = JSON.parse(await readFile(coursesJson))["courses"]
   const totalCourses = courses.length
   console.log(`Downloading ${totalCourses} courses from AWS...`)
   progressBar.start(totalCourses, 0)
@@ -69,8 +69,8 @@ const downloadCourseRecursive = async (s3, bucketParams, destination) => {
         Bucket: bucketParams.Bucket,
         Key:    content.Key
       }
-      if (fs.existsSync(filePath)) {
-        const mtime = fs.statSync(filePath).mtime
+      if (await fileExists(filePath)) {
+        const mtime = (await stat(filePath)).mtime
         if (content.LastModified > mtime) {
           return await s3.getObject(getObjectParams).promise()
         }
@@ -82,14 +82,14 @@ const downloadCourseRecursive = async (s3, bucketParams, destination) => {
   )
   modifiedFiles = modifiedFiles.filter(file => file)
 
-  const writeS3Object = file => {
+  const writeS3Object = async file => {
     const key = listData.Contents.find(content => content.ETag === file.ETag)
       .Key
-    createOrOverwriteFile(path.join(destination, key), file.Body)
+    await createOrOverwriteFile(path.join(destination, key), file.Body)
   }
 
-  modifiedFiles.forEach(writeS3Object)
-  newFiles.forEach(writeS3Object)
+  await Promise.all(modifiedFiles.map(writeS3Object))
+  await Promise.all(newFiles.map(writeS3Object))
 
   if (listData.IsTruncated) {
     bucketParams.ContinuationToken = listData.NextContinuationToken

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -65,10 +65,7 @@ const run = async () => {
 run()
   .catch(err => {
     console.error("Error:", err)
-    loggers.fileLogger.log({
-      level:   "error",
-      message: err.message
-    })
+    loggers.fileLogger.error(err)
     process.exit(1)
   })
   .then(() => {

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -52,18 +52,13 @@ const run = async () => {
   if (options.courses && options.download) {
     await downloadCourses(options.courses, options.input)
   } else if (options.download && !options.courses) {
-    loggers.fileLogger.log({
-      level:   "error",
-      message: MISSING_JSON_ERROR_MESSAGE
-    })
     throw new Error(MISSING_JSON_ERROR_MESSAGE)
   }
-  writeBoilerplate(options.output).then(() => {
-    scanCourses(options.input, options.output, {
-      courses:      options.courses,
-      strips3:      options.strips3,
-      staticPrefix: options.staticPrefix
-    })
+  await writeBoilerplate(options.output)
+  await scanCourses(options.input, options.output, {
+    courses:      options.courses,
+    strips3:      options.strips3,
+    staticPrefix: options.staticPrefix
   })
 }
 
@@ -71,7 +66,7 @@ run().catch(err => {
   console.error("Error:", err)
   loggers.fileLogger.log({
     level:   "error",
-    message: err
+    message: err.message
   })
   process.exit(1)
 })

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -63,10 +63,15 @@ const run = async () => {
 }
 
 run().catch(err => {
-  console.error("Error:", err)
+  console.error("Error:", err, Object.keys(err))
   loggers.fileLogger.log({
     level:   "error",
     message: err.message
   })
   process.exit(1)
+}).then(() => {
+  if (loggers.memoryTransport.logs.length) {
+    console.error("Found errors which were logged: ", loggers.memoryTransport.logs)
+    process.exit(1)
+  }
 })

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -46,6 +46,11 @@ const options = yargs
       "When strips3 is set to true, the value passed into this argument will replace the s3 prefix on static assets",
     type:         "string",
     demandOption: false
+  })
+  .option("verbose", {
+    describe:     "Write error logging and other extra output",
+    type:         "boolean",
+    demandOption: false
   }).argv
 
 const run = async () => {
@@ -70,10 +75,12 @@ run()
   })
   .then(() => {
     if (loggers.memoryTransport.logs.length) {
-      console.error(
-        "Found errors which were logged: ",
-        loggers.memoryTransport.logs
-      )
+      if (options.verbose) {
+        console.error(
+          "Found errors which were logged: ",
+          loggers.memoryTransport.logs
+        )
+      }
       process.exit(1)
     }
   })

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -62,16 +62,21 @@ const run = async () => {
   })
 }
 
-run().catch(err => {
-  console.error("Error:", err, Object.keys(err))
-  loggers.fileLogger.log({
-    level:   "error",
-    message: err.message
-  })
-  process.exit(1)
-}).then(() => {
-  if (loggers.memoryTransport.logs.length) {
-    console.error("Found errors which were logged: ", loggers.memoryTransport.logs)
+run()
+  .catch(err => {
+    console.error("Error:", err, Object.keys(err))
+    loggers.fileLogger.log({
+      level:   "error",
+      message: err.message
+    })
     process.exit(1)
-  }
-})
+  })
+  .then(() => {
+    if (loggers.memoryTransport.logs.length) {
+      console.error(
+        "Found errors which were logged: ",
+        loggers.memoryTransport.logs
+      )
+      process.exit(1)
+    }
+  })

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -64,7 +64,7 @@ const run = async () => {
 
 run()
   .catch(err => {
-    console.error("Error:", err, Object.keys(err))
+    console.error("Error:", err)
     loggers.fileLogger.log({
       level:   "error",
       message: err.message

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -64,7 +64,6 @@ const run = async () => {
 
 run()
   .catch(err => {
-    console.error("Error:", err, Object.keys(err))
     loggers.fileLogger.log({
       level:   "error",
       message: err.message

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -64,6 +64,7 @@ const run = async () => {
 
 run()
   .catch(err => {
+    console.error("Error:", err, Object.keys(err))
     loggers.fileLogger.log({
       level:   "error",
       message: err.message

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -23,7 +23,7 @@ const { readdir, mkdir, readFile, unlink, writeFile } = fsPromises
 
 const writeBoilerplate = async outputPath => {
   for (const file of BOILERPLATE_MARKDOWN) {
-    if (!await directoryExists(file.path)) {
+    if (!(await directoryExists(file.path))) {
       const filePath = path.join(outputPath, file.path)
       const content = `---\n${yaml.safeDump(file.content)}---\n`
       await mkdir(filePath, { recursive: true })
@@ -37,10 +37,10 @@ const scanCourses = async (inputPath, outputPath, options = {}) => {
     This function scans the input directory for course folders
   */
   // Make sure that the input and output arguments have been passed and they are directories
-  if (!await directoryExists(inputPath)) {
+  if (!(await directoryExists(inputPath))) {
     throw new Error("Invalid input directory")
   }
-  if (!await directoryExists(outputPath)) {
+  if (!(await directoryExists(outputPath))) {
     throw new Error("Invalid output directory")
   }
 
@@ -52,8 +52,11 @@ const scanCourses = async (inputPath, outputPath, options = {}) => {
     : (await readdir(inputPath)).filter(course => !course.startsWith("."))
   const numCourses = jsonPath
     ? courseList.length
-    : Promise.all(courseList.map(file => path.join(inputPath, file)).map(path => directoryExists(path)))
-      .length
+    : Promise.all(
+      courseList
+        .map(file => path.join(inputPath, file))
+        .map(path => directoryExists(path))
+    ).length
   const coursesPath = path.join(outputPath, "courses")
   if (numCourses > 0) {
     // populate the course uid mapping
@@ -130,7 +133,7 @@ const writeMarkdownFilesRecursive = async (outputPath, markdownData) => {
   for (const section of markdownData) {
     const sectionPath = path.join(outputPath, section["name"])
     const sectionDirPath = path.dirname(sectionPath)
-    if (!await directoryExists(sectionDirPath)) {
+    if (!(await directoryExists(sectionDirPath))) {
       await mkdir(sectionDirPath, { recursive: true })
     }
     if (await fileExists(sectionPath)) {
@@ -151,7 +154,7 @@ const writeSectionFiles = async (key, section, outputPath) => {
       try {
         const filePath = path.join(outputPath, file["name"])
         const fileDirPath = path.dirname(filePath)
-        if (!await directoryExists(fileDirPath)) {
+        if (!(await directoryExists(fileDirPath))) {
           await mkdir(fileDirPath, { recursive: true })
         }
         if (await fileExists(filePath)) {

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -121,10 +121,7 @@ const getMasterJsonFileName = async coursePath => {
   }
   //  If we made it here, the master json file wasn't found
   const courseError = `${coursePath} - ${MISSING_COURSE_ERROR_MESSAGE}`
-  loggers.fileLogger.log({
-    level:   "error",
-    message: courseError
-  })
+  loggers.fileLogger.error(courseError)
   progressBar.increment()
 }
 
@@ -165,10 +162,7 @@ const writeSectionFiles = async (key, section, outputPath) => {
         }
         await fsPromises.writeFile(filePath, file["data"])
       } catch (err) {
-        loggers.fileLogger.log({
-          level:   "error",
-          message: err
-        })
+        loggers.fileLogger.error(err)
       }
     }
   }

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -96,7 +96,7 @@ const scanCourse = async (inputPath, outputPath, course) => {
   const masterJsonFile = await getMasterJsonFileName(coursePath)
   if (masterJsonFile) {
     const courseData = JSON.parse(await fsPromises.readFile(masterJsonFile))
-    const markdownData = markdownGenerators.generateMarkdownFromJson(courseData)
+    const markdownData = markdownGenerators.generateMarkdownFromJson(courseData, course)
     await writeMarkdownFilesRecursive(
       path.join(outputPath, courseData["short_url"]),
       markdownData

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -96,10 +96,7 @@ const scanCourse = async (inputPath, outputPath, course) => {
   const masterJsonFile = await getMasterJsonFileName(coursePath)
   if (masterJsonFile) {
     const courseData = JSON.parse(await fsPromises.readFile(masterJsonFile))
-    const markdownData = markdownGenerators.generateMarkdownFromJson(
-      courseData,
-      course
-    )
+    const markdownData = markdownGenerators.generateMarkdownFromJson(courseData)
     await writeMarkdownFilesRecursive(
       path.join(outputPath, courseData["short_url"]),
       markdownData

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -96,7 +96,10 @@ const scanCourse = async (inputPath, outputPath, course) => {
   const masterJsonFile = await getMasterJsonFileName(coursePath)
   if (masterJsonFile) {
     const courseData = JSON.parse(await fsPromises.readFile(masterJsonFile))
-    const markdownData = markdownGenerators.generateMarkdownFromJson(courseData, course)
+    const markdownData = markdownGenerators.generateMarkdownFromJson(
+      courseData,
+      course
+    )
     await writeMarkdownFilesRecursive(
       path.join(outputPath, courseData["short_url"]),
       markdownData

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-const fsPromises = require("fs").promises
+const fsPromises = require("./fsPromises")
 const path = require("path")
 const yaml = require("js-yaml")
 const cliProgress = require("cli-progress")

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -28,7 +28,7 @@ const singleCourseRawData = require("fs").readFileSync(
 )
 const singleCourseJsonData = JSON.parse(singleCourseRawData)
 const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-  singleCourseJsonData
+  singleCourseJsonData, singleCourseId
 )
 
 describe("writeBoilerplate", () => {

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -28,8 +28,7 @@ const singleCourseRawData = require("fs").readFileSync(
 )
 const singleCourseJsonData = JSON.parse(singleCourseRawData)
 const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-  singleCourseJsonData,
-  singleCourseId
+  singleCourseJsonData
 )
 
 describe("writeBoilerplate", () => {

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -108,9 +108,9 @@ describe("scanCourses", () => {
     expect(consoleLog).calledWithExactly(NO_COURSES_FOUND_MESSAGE)
   })
 
-  it("calls readdir once", async () => {
+  it("calls readdir nine times, once for courses and once for each course", async () => {
     await fileOperations.scanCourses(inputPath, outputPath)
-    expect(readdirStub).to.be.calledOnce
+    assert.equal(readdirStub.callCount, 9)
   })
 
   it("scans the four test courses and reports to console", async () => {

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -1,4 +1,4 @@
-const fsPromises = require("fs").promises
+const fsPromises = require("./fsPromises")
 const path = require("path")
 const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
@@ -173,13 +173,9 @@ describe("writeMarkdownFilesRecursive", () => {
   const outputPath = tmp.dirSync({ prefix: "output" }).name
 
   beforeEach(async () => {
-    mkDirStub = sandbox.spy(fsPromises, "mkdirStub").returns(Promise.resolve())
-    writeFileStub = sandbox
-      .spy(fsPromises, "writeFileStub")
-      .returns(Promise.resolve())
-    unlinkStub = sandbox
-      .spy(fsPromises, "unlinkStub")
-      .returns(Promise.resolve())
+    mkDirStub = sandbox.spy(fsPromises, "mkdir")
+    writeFileStub = sandbox.spy(fsPromises, "writeFile")
+    unlinkStub = sandbox.spy(fsPromises, "unlink")
     await fileOperations.writeMarkdownFilesRecursive(
       path.join(outputPath, singleCourseId),
       singleCourseMarkdownData

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -1,4 +1,4 @@
-const fs = require("fs")
+const fsPromises = require("fs").promises
 const path = require("path")
 const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
@@ -23,7 +23,9 @@ const singleCourseMasterJsonPath = path.join(
   singleCourseId,
   "e395587c58555f1fe564e8afd75899e6_master.json"
 )
-const singleCourseRawData = fs.readFileSync(singleCourseMasterJsonPath)
+const singleCourseRawData = require("fs").readFileSync(
+  singleCourseMasterJsonPath
+)
 const singleCourseJsonData = JSON.parse(singleCourseRawData)
 const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
   singleCourseJsonData
@@ -33,18 +35,18 @@ describe("writeBoilerplate", () => {
   it("writes the files as expected", async () => {
     const outputPath = tmp.dirSync({ prefix: "output" }).name
     await fileOperations.writeBoilerplate(outputPath)
-    BOILERPLATE_MARKDOWN.forEach(file => {
+    for (const file of BOILERPLATE_MARKDOWN) {
       const expectedContent = `---\n${yaml.safeDump(file.content)}---\n`
-      const tmpFileContents = fs.readFileSync(
+      const tmpFileContents = await fsPromises.readFile(
         path.join(outputPath, file.path, file.name)
       )
       assert.equal(tmpFileContents, expectedContent)
-    })
+    }
   })
 })
 
 describe("scanCourses", () => {
-  let readdirSync, lstatSync, consoleLog
+  let readdirStub, lstatStub, consoleLog
   const sandbox = sinon.createSandbox()
   const inputPath = "test_data/courses"
   const outputPath = tmp.dirSync({ prefix: "output" }).name
@@ -67,8 +69,8 @@ describe("scanCourses", () => {
   )
 
   beforeEach(() => {
-    readdirSync = sandbox.spy(fs, "readdirSync")
-    lstatSync = sandbox.spy(fs, "lstatSync")
+    readdirStub = sandbox.spy(fsPromises, "readdir")
+    lstatStub = sandbox.spy(fsPromises, "lstat")
     consoleLog = sandbox.stub(console, "log")
   })
 
@@ -76,52 +78,64 @@ describe("scanCourses", () => {
     sandbox.restore()
   })
 
-  it("throws an error when you call it with no input directory", () => {
-    assert.throws(() => fileOperations.scanCourses(null, outputPath))
+  it("throws an error when you call it with no input directory", async () => {
+    try {
+      await fileOperations.scanCourses(null, outputPath)
+      assert.fail("No error thrown")
+    } catch (err) {
+      // all good
+    }
   })
 
-  it("throws an error when you call it with no output directory", () => {
-    assert.throws(() => fileOperations.scanCourses(inputPath, null))
+  it("throws an error when you call it with no output directory", async () => {
+    try {
+      await fileOperations.scanCourses(inputPath, null)
+      assert.fail("No error thrown")
+    } catch (err) {
+      // all good
+    }
   })
 
-  it("displays an error when you call it with an empty courses.json", () => {
-    fileOperations.scanCourses(inputPath, outputPath, {
+  it("displays an error when you call it with an empty courses.json", async () => {
+    await fileOperations.scanCourses(inputPath, outputPath, {
       courses: "test_data/courses_blank.json"
     })
     expect(consoleLog).calledWithExactly(NO_COURSES_FOUND_MESSAGE)
   })
 
-  it("displays an error when you call it with an empty input directory", () => {
-    fileOperations.scanCourses("test_data/empty", outputPath)
+  it("displays an error when you call it with an empty input directory", async () => {
+    await fileOperations.scanCourses("test_data/empty", outputPath)
     expect(consoleLog).calledWithExactly(NO_COURSES_FOUND_MESSAGE)
   })
 
-  it("calls readdirSync once", () => {
-    fileOperations.scanCourses(inputPath, outputPath)
-    expect(readdirSync).to.be.calledOnce
+  it("calls readdir once", async () => {
+    await fileOperations.scanCourses(inputPath, outputPath)
+    expect(readdirStub).to.be.calledOnce
   })
 
-  it("scans the four test courses and reports to console", () => {
-    fileOperations.scanCourses(inputPath, outputPath)
+  it("scans the four test courses and reports to console", async () => {
+    await fileOperations.scanCourses(inputPath, outputPath)
     expect(consoleLog).calledWithExactly(logMessage)
   })
 
-  it("calls lstatSync for each test course", () => {
-    fileOperations.scanCourses(inputPath, outputPath)
-    expect(lstatSync).to.be.calledWithExactly(course1Path)
-    expect(lstatSync).to.be.calledWithExactly(course2Path)
-    expect(lstatSync).to.be.calledWithExactly(course3Path)
-    expect(lstatSync).to.be.calledWithExactly(course4Path)
+  it("calls lstatSync for each test course", async () => {
+    await fileOperations.scanCourses(inputPath, outputPath)
+    expect(lstatStub).to.be.calledWithExactly(course1Path)
+    expect(lstatStub).to.be.calledWithExactly(course2Path)
+    expect(lstatStub).to.be.calledWithExactly(course3Path)
+    expect(lstatStub).to.be.calledWithExactly(course4Path)
   })
 })
 
 describe("scanCourse", () => {
-  let readFileSync, generateMarkdownFromJson
+  let readFileStub, generateMarkdownFromJson
   const sandbox = sinon.createSandbox()
   const outputPath = tmp.dirSync({ prefix: "output" }).name
 
   beforeEach(async () => {
-    readFileSync = sandbox.stub(fs, "readFileSync").returns(singleCourseRawData)
+    readFileStub = sandbox
+      .stub(fsPromises, "readFile")
+      .returns(Promise.resolve(singleCourseRawData))
     generateMarkdownFromJson = sandbox.spy(
       markdownGenerators,
       "generateMarkdownFromJson"
@@ -133,8 +147,8 @@ describe("scanCourse", () => {
     sandbox.restore()
   })
 
-  it("calls readFileSync on the master json file", () => {
-    expect(readFileSync).to.be.calledWithExactly(singleCourseMasterJsonPath)
+  it("calls readFileSync on the master json file", async () => {
+    expect(readFileStub).to.be.calledWithExactly(singleCourseMasterJsonPath)
   })
 
   it("calls generateMarkdownFromJson on the course data", () => {
@@ -154,15 +168,19 @@ describe("getMasterJsonFileName", () => {
 })
 
 describe("writeMarkdownFilesRecursive", () => {
-  let mkDirSync, writeFileSync, unlinkSync
+  let mkDirStub, writeFileStub, unlinkStub
   const sandbox = sinon.createSandbox()
   const outputPath = tmp.dirSync({ prefix: "output" }).name
 
-  beforeEach(() => {
-    mkDirSync = sandbox.spy(fs, "mkdirSync")
-    writeFileSync = sandbox.spy(fs, "writeFileSync")
-    unlinkSync = sandbox.spy(fs, "unlinkSync")
-    fileOperations.writeMarkdownFilesRecursive(
+  beforeEach(async () => {
+    mkDirStub = sandbox.spy(fsPromises, "mkdirStub").returns(Promise.resolve())
+    writeFileStub = sandbox
+      .spy(fsPromises, "writeFileStub")
+      .returns(Promise.resolve())
+    unlinkStub = sandbox
+      .spy(fsPromises, "unlinkStub")
+      .returns(Promise.resolve())
+    await fileOperations.writeMarkdownFilesRecursive(
       path.join(outputPath, singleCourseId),
       singleCourseMarkdownData
     )
@@ -174,7 +192,7 @@ describe("writeMarkdownFilesRecursive", () => {
   })
 
   it("calls mkDirSync to create sections folder", () => {
-    expect(mkDirSync).to.be.calledWith(
+    expect(mkDirStub).to.be.calledWith(
       path.join(outputPath, singleCourseId, "sections")
     )
   })
@@ -189,7 +207,7 @@ describe("writeMarkdownFilesRecursive", () => {
               path.join("sections", page["short_url"], "_index.md") ===
               file["name"]
           )[0]
-          expect(mkDirSync).to.be.calledWith(
+          expect(mkDirStub).to.be.calledWith(
             helpers.pathToChildRecursive(
               path.join(outputPath, singleCourseId, "sections"),
               child,
@@ -204,7 +222,7 @@ describe("writeMarkdownFilesRecursive", () => {
     singleCourseMarkdownData
       .filter(file => file["name"] !== "_index.md")
       .forEach(file => {
-        expect(writeFileSync).to.be.calledWithExactly(
+        expect(writeFileStub).to.be.calledWithExactly(
           path.join(outputPath, singleCourseId, file["name"]),
           file["data"]
         )
@@ -218,7 +236,7 @@ describe("writeMarkdownFilesRecursive", () => {
                   singleCourseJsonData
                 )}.md` === child["name"]
             )[0]
-            expect(writeFileSync).to.be.calledWithExactly(
+            expect(writeFileStub).to.be.calledWithExactly(
               `${helpers.pathToChildRecursive(
                 path.join(outputPath, singleCourseId, "sections"),
                 childJson,
@@ -231,15 +249,15 @@ describe("writeMarkdownFilesRecursive", () => {
       })
   })
 
-  it("calls unlinkSync to remove files if they already exist", () => {
-    fileOperations.writeMarkdownFilesRecursive(
+  it("calls unlinkSync to remove files if they already exist", async () => {
+    await fileOperations.writeMarkdownFilesRecursive(
       path.join(outputPath, singleCourseId),
       singleCourseMarkdownData
     )
     singleCourseMarkdownData
       .filter(file => file["name"] !== "_index.md")
       .forEach(file => {
-        expect(unlinkSync).to.be.calledWithExactly(
+        expect(unlinkStub).to.be.calledWithExactly(
           path.join(outputPath, singleCourseId, file["name"])
         )
         if (file["children"].length > 0) {
@@ -252,7 +270,7 @@ describe("writeMarkdownFilesRecursive", () => {
                   singleCourseJsonData
                 )}.md` === child["name"]
             )[0]
-            expect(unlinkSync).to.be.calledWithExactly(
+            expect(unlinkStub).to.be.calledWithExactly(
               `${helpers.pathToChildRecursive(
                 path.join(outputPath, singleCourseId, "sections"),
                 childJson,

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -28,7 +28,8 @@ const singleCourseRawData = require("fs").readFileSync(
 )
 const singleCourseJsonData = JSON.parse(singleCourseRawData)
 const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-  singleCourseJsonData, singleCourseId
+  singleCourseJsonData,
+  singleCourseId
 )
 
 describe("writeBoilerplate", () => {

--- a/src/fsPromises.js
+++ b/src/fsPromises.js
@@ -1,0 +1,20 @@
+const fs = require("fs").promises
+
+const withStackTrace = fn => async (...args) => {
+  let error
+  try {
+    // Create stack trace here. fs functions don't have stack traces by default for performance,
+    // but they are very useful for error handling.
+    error = new Error()
+    return await fn(...args)
+  } catch (err) {
+    error.message = err
+    throw error
+  }
+}
+
+const _exports = {}
+for (const key of Object.keys(fs)) {
+  _exports[key] = withStackTrace(fs[key])
+}
+module.exports = _exports

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -254,7 +254,7 @@ const resolveUids = (htmlStr, page, courseData) => {
       }
     )
   } catch (err) {
-    loggers.fileLogger.error(err.message)
+    loggers.fileLogger.error(err)
   }
   return htmlStr
 }
@@ -354,7 +354,7 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
       }
     })
   } catch (err) {
-    loggers.fileLogger.error(err.message)
+    loggers.fileLogger.error(err)
   }
   return htmlStr.replace(/http:\/\/ocw.mit.edu/g, "")
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,7 @@
 const _ = require("lodash")
 const path = require("path")
 
-const { lstat, mkdir, unlink, writeFile } = require("./fsPromises")
+const fsPromises = require("./fsPromises")
 const DEPARTMENTS_JSON = require("./departments.json")
 const {
   AWS_REGEX,
@@ -19,7 +19,7 @@ const distinct = (value, index, self) => {
 
 const directoryExists = async directory => {
   try {
-    return (await lstat(directory)).isDirectory()
+    return (await fsPromises.lstat(directory)).isDirectory()
   } catch (err) {
     // this will happen if we don't have access to the directory or if it doesn't exist
     return false
@@ -28,7 +28,7 @@ const directoryExists = async directory => {
 
 const fileExists = async path => {
   try {
-    return (await lstat(path)).isFile()
+    return (await fsPromises.lstat(path)).isFile()
   } catch (err) {
     // this will happen if we don't have access to the file or if it doesn't exist
     return false
@@ -38,11 +38,11 @@ const fileExists = async path => {
 const createOrOverwriteFile = async (file, body) => {
   const dirName = path.dirname(file)
   if (!(await directoryExists(dirName))) {
-    await mkdir(dirName, { recursive: true })
+    await fsPromises.mkdir(dirName, { recursive: true })
   } else if (await fileExists(file)) {
-    await unlink(file)
+    await fsPromises.unlink(file)
   }
-  await writeFile(file, body)
+  await fsPromises.writeFile(file, body)
 }
 
 const findDepartmentByNumber = departmentNumber =>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -19,14 +19,21 @@ const distinct = (value, index, self) => {
 
 const directoryExists = async directory => {
   try {
-    return directory && (await lstat(directory)).isDirectory()
+    return (await lstat(directory)).isDirectory()
   } catch (err) {
     // this will happen if we don't have access to the directory or if it doesn't exist
     return false
   }
 }
 
-const fileExists = async path => (await lstat(path)).isFile()
+const fileExists = async path => {
+  try {
+    return (await lstat(path)).isFile()
+  } catch (err) {
+    // this will happen if we don't have access to the file or if it doesn't exist
+    return false
+  }
+}
 
 const createOrOverwriteFile = async (file, body) => {
   const dirName = path.dirname(file)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,7 @@
 const _ = require("lodash")
-const { lstat, mkdir, unlink, writeFile } = require("fs").promises
 const path = require("path")
 
+const { lstat, mkdir, unlink, writeFile } = require("./fsPromises")
 const DEPARTMENTS_JSON = require("./departments.json")
 const {
   AWS_REGEX,
@@ -17,9 +17,14 @@ const distinct = (value, index, self) => {
   return self.indexOf(value) === index
 }
 
-const directoryExists = async directory =>
-  directory &&
-  (await lstat(directory)).isDirectory()
+const directoryExists = async directory => {
+  try {
+    return directory && (await lstat(directory)).isDirectory()
+  } catch (err) {
+    // this will happen if we don't have access to the directory or if it doesn't exist
+    return false
+  }
+}
 
 const fileExists = async path => (await lstat(path)).isFile()
 

--- a/src/loggers.js
+++ b/src/loggers.js
@@ -1,4 +1,19 @@
 const winston = require("winston")
+const TransportStream = require('winston-transport')
+
+class MemoryTransport extends TransportStream {
+  constructor() {
+    super()
+    this.logs = []
+  }
+
+  log(info, callback) {
+    this.logs.push(info)
+    callback()
+  }
+}
+
+const memoryTransport = new MemoryTransport()
 
 const fileLogger = winston.createLogger({
   level:       "error",
@@ -12,10 +27,12 @@ const fileLogger = winston.createLogger({
     new winston.transports.File({
       filename: "ocw-to-hugo.info.log",
       level:    "info"
-    })
+    }),
+    memoryTransport
   ]
 })
 
 module.exports = {
-  fileLogger
+  fileLogger,
+  memoryTransport
 }

--- a/src/loggers.js
+++ b/src/loggers.js
@@ -1,5 +1,5 @@
 const winston = require("winston")
-const TransportStream = require('winston-transport')
+const TransportStream = require("winston-transport")
 
 class MemoryTransport extends TransportStream {
   constructor() {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -236,7 +236,7 @@ const fixLinks = (htmlStr, page, courseData) => {
   return htmlStr
 }
 
-const generateMarkdownFromJson = courseData => {
+const generateMarkdownFromJson = (courseData, course) => {
   /**
     This function takes JSON data parsed from a master.json file and returns markdown data
     */
@@ -251,7 +251,7 @@ const generateMarkdownFromJson = courseData => {
   return [
     {
       name: "_index.md",
-      data: generateCourseHomeMarkdown(courseData)
+      data: generateCourseHomeMarkdown(courseData, course)
     },
     ...rootSections.map(generateMarkdownRecursive, this)
   ]
@@ -347,13 +347,17 @@ const generateMarkdownRecursive = page => {
   }
 }
 
-const generateCourseHomeMarkdown = courseData => {
+const generateCourseHomeMarkdown = (courseData, course) => {
   /**
     Generate the front matter metadata for the course home page given course_data JSON
     */
   const courseHomePage = courseData["course_pages"].find(
     coursePage => coursePage["type"] === "CourseHomeSection"
   )
+  if (!courseHomePage) {
+    loggers.fileLogger.error(`Missing home page for ${course}`)
+    return null
+  }
   const courseDescription = courseData["description"]
     ? turndownService.turndown(
       fixLinks(courseData["description"], courseHomePage, courseData)

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -136,10 +136,7 @@ turndownService.addRule("inlinecodeblockfix", {
         content = content.replace(`\\\`${match}'`, match)
       })
     } catch (err) {
-      loggers.fileLogger.log({
-        level:   "error",
-        message: err
-      })
+      loggers.fileLogger.error(err)
     }
     return `\`${content}\``
   }
@@ -327,10 +324,7 @@ const generateMarkdownRecursive = page => {
             }
           }
         } catch (err) {
-          loggers.fileLogger.log({
-            level:   "error",
-            message: err
-          })
+          loggers.fileLogger.error(err)
           return null
         }
       })
@@ -345,10 +339,7 @@ const generateMarkdownRecursive = page => {
             }
           }
         } catch (err) {
-          loggers.fileLogger.log({
-            level:   "error",
-            message: err
-          })
+          loggers.fileLogger.error(err)
           return null
         }
       })
@@ -427,10 +418,7 @@ const generateCourseHomeMarkdown = courseData => {
       frontMatter
     )}---\n${courseDescription}\n${otherInformationText}`
   } catch (err) {
-    loggers.fileLogger.log({
-      level:   "error",
-      message: err
-    })
+    loggers.fileLogger.error(err)
     return null
   }
 }
@@ -524,10 +512,7 @@ const generateCourseSectionMarkdown = (page, courseData) => {
       turndownService.turndown(fixLinks(page["text"] || "", page, courseData))
     )}${generateCourseFeaturesMarkdown(page, courseData)}`
   } catch (err) {
-    loggers.fileLogger.log({
-      level:   "error",
-      message: err
-    })
+    loggers.fileLogger.error(err)
     return page["text"]
   }
 }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -132,9 +132,12 @@ turndownService.addRule("inlinecodeblockfix", {
       // eslint seems to think the escaped backtick in the regex is useless, but it's not
       // eslint-disable-next-line no-useless-escape
       const backTickSingleQuoteWrap = new RegExp(/(?<=\`)(.*?)(?=')/g)
-      content.match(backTickSingleQuoteWrap).forEach(match => {
-        content = content.replace(`\\\`${match}'`, match)
-      })
+      const matches = content.match(backTickSingleQuoteWrap)
+      if (matches) {
+        for (const match of matches) {
+          content = content.replace(`\\\`${match}'`, match)
+        }
+      }
     } catch (err) {
       loggers.fileLogger.error(err)
     }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -449,7 +449,7 @@ const generateCourseSectionFrontMatter = (
     courseSectionFrontMatter["menu"] = {
       [courseId]: {
         identifier: pageId,
-        name:       shortTitle,
+        name:       shortTitle || "",
         weight:     menuIndex
       }
     }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -236,7 +236,7 @@ const fixLinks = (htmlStr, page, courseData) => {
   return htmlStr
 }
 
-const generateMarkdownFromJson = (courseData, course) => {
+const generateMarkdownFromJson = courseData => {
   /**
     This function takes JSON data parsed from a master.json file and returns markdown data
     */
@@ -251,7 +251,7 @@ const generateMarkdownFromJson = (courseData, course) => {
   return [
     {
       name: "_index.md",
-      data: generateCourseHomeMarkdown(courseData, course)
+      data: generateCourseHomeMarkdown(courseData)
     },
     ...rootSections.map(generateMarkdownRecursive, this)
   ]
@@ -347,17 +347,13 @@ const generateMarkdownRecursive = page => {
   }
 }
 
-const generateCourseHomeMarkdown = (courseData, course) => {
+const generateCourseHomeMarkdown = courseData => {
   /**
     Generate the front matter metadata for the course home page given course_data JSON
     */
   const courseHomePage = courseData["course_pages"].find(
     coursePage => coursePage["type"] === "CourseHomeSection"
   )
-  if (!courseHomePage) {
-    loggers.fileLogger.error(`Missing home page for ${course}`)
-    return null
-  }
   const courseDescription = courseData["description"]
     ? turndownService.turndown(
       fixLinks(courseData["description"], courseHomePage, courseData)

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -521,7 +521,7 @@ const generateCourseSectionMarkdown = (page, courseData) => {
     */
   try {
     return `${helpers.unescapeBackticks(
-      turndownService.turndown(fixLinks(page["text"], page, courseData))
+      turndownService.turndown(fixLinks(page["text"] || "", page, courseData))
     )}${generateCourseFeaturesMarkdown(page, courseData)}`
   } catch (err) {
     loggers.fileLogger.log({

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -361,6 +361,23 @@ describe("generateCourseSectionFrontMatter", () => {
       ]
     )
   })
+
+  it("handles missing short_page_title correctly", async () => {
+    const yaml = markdownGenerators
+      .generateCourseSectionFrontMatter(
+        "Syllabus",
+        undefined,
+        "syllabus",
+        null,
+        true,
+        false,
+        false,
+        10,
+        false,
+        singleCourseJsonData["short_url"]
+      )
+    assert.notInclude(yaml, "undefined")
+  })
 })
 
 describe("generateCourseFeatures", () => {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -51,7 +51,7 @@ const courseFeaturesFrontMatter = markdownGenerators.generateCourseFeaturesMarkd
 describe("generateMarkdownFromJson", () => {
   it("contains the course home page and other expected sections", () => {
     const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-      singleCourseJsonData
+      singleCourseJsonData, singleCourseId
     )
     const expectedSections = singleCourseJsonData["course_pages"]
       .filter(
@@ -154,7 +154,7 @@ describe("generateCourseHomeMarkdown", () => {
     getConsolidatedTopics = sandbox.spy(helpers, "getConsolidatedTopics")
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
-      singleCourseJsonData
+      singleCourseJsonData, singleCourseId
     )
     courseHomeFrontMatter = yaml.safeLoad(courseHomeMarkdown.split("---\n")[1])
   })
@@ -449,6 +449,15 @@ describe("generateCourseSectionMarkdown", () => {
         )
         .includes("\\`")
     )
+  })
+
+  it("handles missing page text gracefully", () => {
+    const page = {
+      ...coursePagesWithText[0],
+      text: undefined
+    }
+    const markdown = markdownGenerators.generateCourseSectionMarkdown(page, singleCourseJsonData)
+    assert.equal(markdown, "")
   })
 })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -51,8 +51,7 @@ const courseFeaturesFrontMatter = markdownGenerators.generateCourseFeaturesMarkd
 describe("generateMarkdownFromJson", () => {
   it("contains the course home page and other expected sections", () => {
     const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-      singleCourseJsonData,
-      singleCourseId
+      singleCourseJsonData
     )
     const expectedSections = singleCourseJsonData["course_pages"]
       .filter(
@@ -155,8 +154,7 @@ describe("generateCourseHomeMarkdown", () => {
     getConsolidatedTopics = sandbox.spy(helpers, "getConsolidatedTopics")
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
-      singleCourseJsonData,
-      singleCourseId
+      singleCourseJsonData
     )
     courseHomeFrontMatter = yaml.safeLoad(courseHomeMarkdown.split("---\n")[1])
   })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -51,7 +51,8 @@ const courseFeaturesFrontMatter = markdownGenerators.generateCourseFeaturesMarkd
 describe("generateMarkdownFromJson", () => {
   it("contains the course home page and other expected sections", () => {
     const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-      singleCourseJsonData, singleCourseId
+      singleCourseJsonData,
+      singleCourseId
     )
     const expectedSections = singleCourseJsonData["course_pages"]
       .filter(
@@ -154,7 +155,8 @@ describe("generateCourseHomeMarkdown", () => {
     getConsolidatedTopics = sandbox.spy(helpers, "getConsolidatedTopics")
     safeDump = sandbox.spy(yaml, "safeDump")
     courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
-      singleCourseJsonData, singleCourseId
+      singleCourseJsonData,
+      singleCourseId
     )
     courseHomeFrontMatter = yaml.safeLoad(courseHomeMarkdown.split("---\n")[1])
   })
@@ -363,19 +365,18 @@ describe("generateCourseSectionFrontMatter", () => {
   })
 
   it("handles missing short_page_title correctly", async () => {
-    const yaml = markdownGenerators
-      .generateCourseSectionFrontMatter(
-        "Syllabus",
-        undefined,
-        "syllabus",
-        null,
-        true,
-        false,
-        false,
-        10,
-        false,
-        singleCourseJsonData["short_url"]
-      )
+    const yaml = markdownGenerators.generateCourseSectionFrontMatter(
+      "Syllabus",
+      undefined,
+      "syllabus",
+      null,
+      true,
+      false,
+      false,
+      10,
+      false,
+      singleCourseJsonData["short_url"]
+    )
     assert.notInclude(yaml, "undefined")
   })
 })
@@ -456,7 +457,10 @@ describe("generateCourseSectionMarkdown", () => {
       ...coursePagesWithText[0],
       text: undefined
     }
-    const markdown = markdownGenerators.generateCourseSectionMarkdown(page, singleCourseJsonData)
+    const markdown = markdownGenerators.generateCourseSectionMarkdown(
+      page,
+      singleCourseJsonData
+    )
     assert.equal(markdown, "")
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
In general, error handling is better handled and some `fs` functions are converted to use promises:
 - `fsPromises` is created which wraps `fs.promises` with a function wrapper to create a stack trace for easier tracking of file system errors. All filesystem "sync" functions should be removed from the project in favor of these promise variants. I tried to make these changes as 1-to-1 as possible for easy review.
 - `existsSync` has no promise equivalent because it was deprecated. Instead I added `fileExists` in `helpers.js`. We should get rid of almost all of these existence checks anyway, for security and performance reasons (#82). 
 - Certain file error logging was removed just for redundancy's sake. Errors should generally be thrown and propagated, and then caught and reported in the run function. Other file error logging should still be there in cases where it's not appropriate to throw an error.
 - If any errors were logged in the file logger, a non-zero exit code will be returned after the process completes and written to stderr. The logger was modified to store the logs in memory.
 - `generateCourseSectionMarkdown` was modified to prevent null from being passed to turndown, which caused an error message
(see other notes in comments on this PR)

I'm not sure how this affects performance, but there are some tradeoffs between error handling and performance. We should prioritize error handling wherever possible. There are probably changes we can do to make the project more efficient without removing error handling.

#### How should this be manually tested?
Run `./src/bin/index.js -i ./test_data/courses -o ./test_data/output -c ./test_data/courses.json` on master and on this PR and compare the output directories. There should only be one difference, a "null" which was written out. I think this is a bug which is fixed but let me know if that "null" string should be there.
