### PR TITLE
table header rows fix

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -64,34 +64,20 @@ turndownService.addRule("table", {
     if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n|\r)/g)) {
       // Get the amount of columns by matching three hyphens and counting
       const totalColumns = content.match(/---/g || []).length
-      // Split headers out on their own so they aren't in one cell
-      return (
-        content
-        /**
-           * First, replace pipe space and double asterisk with a newline
-           * followed by double asterisk
-           */
-
-          .replace(/\| \*\*/g, "\n**")
-          /**
-           * Second, replace double asterisk space pipe followed by a newline
-           * or carriage return with double asterisk double newline.  After the
-           * second newline, re-initialize the table by iterating a pipe followed
-           * by a space and three hyphens for the total amount of columns, finally
-           * closing it out with a single pipe at the end
-           */
-          .replace(
-            /\*\* \|\r?\n|\r/g,
-            `**\n\n${"| ".repeat(totalColumns)}|\n${"| --- ".repeat(
-              totalColumns
-            )}|`
-          )
-          /**
-           * Finally, reconstruct the table by inserting line breaks in between
-           * back-to-back pipes to re-create rows
-           */
-          .replace(/\|\|/g, "|\n|")
-      )
+      // Style headers so that they aren't bound by the width of one cell
+      content.match(/\| \*\*(.*)\*\* \|\r?\n|\r/g).forEach(element => {
+        const headerContent = element
+          .replace(/\| \*\*/g, "")
+          .replace(/\*\* \|\r?\n|\r/g, "")
+        // Wrap header content in the fullwidth-cell shortcode and insert spaces to set line height
+        content = content.replace(
+          element,
+          `| {{< fullwidth-cell >}}**${headerContent}**{{< /fullwidth-cell >}} |${" &nbsp; |".repeat(
+            totalColumns - 1
+          )}\n`
+        )
+      })
+      return content
     } else return content
   }
 })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -501,21 +501,21 @@ describe("generateCourseFeaturesMarkdown", () => {
 
 describe("turndown tables", () => {
   let markdown
-  const tableHTML = `<table summary=\"See table caption for summary.\" class=\"tablewidth100\">
-    <caption class=\"invisible\">Course readings.</caption> <!-- BEGIN TABLE HEADER (for MIT OCW Table Template 2.51) -->
+  const tableHTML = `<table summary="See table caption for summary." class="tablewidth100">
+    <caption class="invisible">Course readings.</caption> <!-- BEGIN TABLE HEADER (for MIT OCW Table Template 2.51) -->
     <thead>
       <tr>
-        <th scope=\"col\">LEC&nbsp;#</th>
-        <th scope=\"col\">TOPICS</th>
-        <th scope=\"col\">READINGS&nbsp;(3D&nbsp;ED.)</th>
-        <th scope=\"col\">READINGS&nbsp;(4TH&nbsp;ED.)</th>
+        <th scope="col">LEC&nbsp;#</th>
+        <th scope="col">TOPICS</th>
+        <th scope="col">READINGS&nbsp;(3D&nbsp;ED.)</th>
+        <th scope="col">READINGS&nbsp;(4TH&nbsp;ED.)</th>
       </tr>
     </thead> <!-- END TABLE HEADER -->
     <tbody>
-      <tr class=\"row\">
-        <td colspan=\"4\"><strong>Control and Scope</strong></td>
+      <tr class="row">
+        <td colspan="4"><strong>Control and Scope</strong></td>
       </tr>
-      <tr class=\"alt-row\">
+      <tr class="alt-row">
         <td>L 1</td>
         <td>Course Overview, Introduction to Java</td>
         <td>&mdash;</td>

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -499,7 +499,49 @@ describe("generateCourseFeaturesMarkdown", () => {
   })
 })
 
-describe("turndown service", () => {
+describe("turndown tables", () => {
+  let markdown
+  const tableHTML = `<table summary=\"See table caption for summary.\" class=\"tablewidth100\">
+    <caption class=\"invisible\">Course readings.</caption> <!-- BEGIN TABLE HEADER (for MIT OCW Table Template 2.51) -->
+    <thead>
+      <tr>
+        <th scope=\"col\">LEC&nbsp;#</th>
+        <th scope=\"col\">TOPICS</th>
+        <th scope=\"col\">READINGS&nbsp;(3D&nbsp;ED.)</th>
+        <th scope=\"col\">READINGS&nbsp;(4TH&nbsp;ED.)</th>
+      </tr>
+    </thead> <!-- END TABLE HEADER -->
+    <tbody>
+      <tr class=\"row\">
+        <td colspan=\"4\"><strong>Control and Scope</strong></td>
+      </tr>
+      <tr class=\"alt-row\">
+        <td>L 1</td>
+        <td>Course Overview, Introduction to Java</td>
+        <td>&mdash;</td>
+        <td>&mdash;</td>
+      </tr>
+    </tbody>
+  </table>`
+
+  beforeEach(() => {
+    markdown = markdownGenerators.turndownService.turndown(tableHTML)
+  })
+
+  it("should include a table definition for 4 columns", () => {
+    assert.isTrue(markdown.includes("| --- | --- | --- | --- |"))
+  })
+
+  it("should properly generate a header with the fullwidth-cell shortcode", () => {
+    assert.isTrue(
+      markdown.includes(
+        "| {{< fullwidth-cell >}}**Control and Scope**{{< /fullwidth-cell >}} | &nbsp; | &nbsp; | &nbsp; |"
+      )
+    )
+  })
+})
+
+describe("other turndown elements", () => {
   it("should not get tripped up on problematic code blocks", () => {
     const problematicHTML =
       "<pre><span><code>stuff\nin\nthe\nblock</span></pre>"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/219

#### What's this PR do?
This PR changes the turndown rule handling tables and how it renders header columns.  Instead of separating them out and recreating the table, we render the header into the first cell and wrap it in a shortcode which renders the header in a div with the class `position-absolute`.  Then, the other cells in the row are rendered with only a `nbsp;` HTML character entity so that the line height is set correctly.  The column sizes remain consistent, and the header text is allowed to flow into the other columns.
