### PR TITLE
Fix missing home page bug

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -231,7 +231,7 @@ turndownService.addRule("h4", {
 })
 
 const fixLinks = (htmlStr, page, courseData) => {
-  if (htmlStr) {
+  if (htmlStr && page) {
     htmlStr = helpers.resolveUids(htmlStr, page, courseData)
     htmlStr = helpers.resolveRelativeLinks(htmlStr, courseData)
     htmlStr = helpers.resolveYouTubeEmbed(htmlStr, courseData)

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -1,8 +1,6 @@
 const path = require("path")
 const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
-const markdownGenerators = require("./markdown_generators")
-const helpers = require("./helpers")
 const fs = require("fs")
 const yaml = require("js-yaml")
 const markdown = require("markdown-doc-builder").default
@@ -11,6 +9,9 @@ const tmp = require("tmp")
 tmp.setGracefulCleanup()
 
 const { GETPAGESHORTCODESTART, GETPAGESHORTCODEEND } = require("./constants")
+const loggers = require("./loggers")
+const markdownGenerators = require("./markdown_generators")
+const helpers = require("./helpers")
 
 const testDataPath = "test_data/courses"
 const singleCourseId =
@@ -269,6 +270,16 @@ describe("generateCourseHomeMarkdown", () => {
 
   it("calls yaml.safeDump once", () => {
     expect(safeDump).to.be.calledOnce
+  })
+
+  it("doesn't error if the page is missing", () => {
+    sandbox.stub(loggers.memoryTransport, "log").callsFake((...args) => {
+      throw new Error(`Error caught: ${args}`)
+    })
+    courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
+      singleCourseJsonData
+    )
+    assert.include(courseHomeMarkdown, "title: Course Home")
   })
 })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #88 

#### What's this PR do?
If there is no page when `fixLinks` is called, it will just return the input html. It looks like some courses just don't have a page with `CourseHomePage` so I think that's the best we can do.

#### How should this be manually tested?
See repro instructions in issue for #88 and #89 

