### PR TITLE
Move courseUidList to local variable, and flip key and value for performance

### DIFF
--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -63,14 +63,15 @@ const scanCourses = async (inputPath, outputPath, options = {}) => {
   const coursesPath = path.join(outputPath, "courses")
   if (numCourses > 0) {
     // populate the course uid mapping
+    const courseUidsLookup = {}
     for (const course of courseList) {
       const courseUid = await getCourseUid(inputPath, course)
-      helpers.courseUidList[course] = courseUid
+      courseUidsLookup[courseUid] = course
     }
     console.log(`Converting ${numCourses} courses to Hugo markdown...`)
     progressBar.start(numCourses, 0)
     for (const course of courseList) {
-      await scanCourse(inputPath, coursesPath, course)
+      await scanCourse(inputPath, coursesPath, course, courseUidsLookup)
       progressBar.increment()
     }
   } else {
@@ -87,7 +88,7 @@ const getCourseUid = async (inputPath, course) => {
   }
 }
 
-const scanCourse = async (inputPath, outputPath, course) => {
+const scanCourse = async (inputPath, outputPath, course, courseUidsLookup) => {
   /*
     This function scans a course directory for a master json file and processes it
   */
@@ -96,7 +97,10 @@ const scanCourse = async (inputPath, outputPath, course) => {
   const masterJsonFile = await getMasterJsonFileName(coursePath)
   if (masterJsonFile) {
     const courseData = JSON.parse(await fsPromises.readFile(masterJsonFile))
-    const markdownData = markdownGenerators.generateMarkdownFromJson(courseData)
+    const markdownData = markdownGenerators.generateMarkdownFromJson(
+      courseData,
+      courseUidsLookup
+    )
     await writeMarkdownFilesRecursive(
       path.join(outputPath, courseData["short_url"]),
       markdownData

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -140,7 +140,6 @@ describe("scanCourse", () => {
       markdownGenerators,
       "generateMarkdownFromJson"
     )
-    await fileOperations.scanCourse(testDataPath, outputPath, singleCourseId)
   })
 
   afterEach(() => {
@@ -148,12 +147,27 @@ describe("scanCourse", () => {
   })
 
   it("calls readFile on the master json file", async () => {
+    const courseUidLookup = { singleCourseId: "uid" }
+    await fileOperations.scanCourse(
+      testDataPath,
+      outputPath,
+      singleCourseId,
+      courseUidLookup
+    )
     expect(readFileStub).to.be.calledWithExactly(singleCourseMasterJsonPath)
   })
 
-  it("calls generateMarkdownFromJson on the course data", () => {
+  it("calls generateMarkdownFromJson on the course data", async () => {
+    const courseUidLookup = { singleCourseId: "uid" }
+    await fileOperations.scanCourse(
+      testDataPath,
+      outputPath,
+      singleCourseId,
+      courseUidLookup
+    )
     expect(generateMarkdownFromJson).to.be.calledOnceWithExactly(
-      singleCourseJsonData
+      singleCourseJsonData,
+      courseUidLookup
     )
   })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,7 +10,6 @@ const {
 } = require("./constants")
 const loggers = require("./loggers")
 
-const courseUidList = {}
 const runOptions = {}
 
 const distinct = (value, index, self) => {
@@ -168,13 +167,14 @@ const getHugoPathSuffix = (page, courseData) => {
  * @param {string} htmlStr
  * @param {object} page
  * @param {object} courseData
+ * @param {object} courseUidsLookup
  *
  * The purpose of this function is to resolve "resolveuid" links in OCW HTML.
- * It takes 3 parameters; an HTML string to parse, the page that the string came from
- * and the course data object.
+ * It takes 4 parameters; an HTML string to parse, the page that the string came from,
+ * the course data object, and a lookup from uid to course.
  *
  */
-const resolveUids = (htmlStr, page, courseData) => {
+const resolveUids = (htmlStr, page, courseData, courseUidsLookup) => {
   try {
     // get the Hugo path to the page
     const pagePath = `${pathToChildRecursive(
@@ -204,14 +204,7 @@ const resolveUids = (htmlStr, page, courseData) => {
         const linkedFile = courseData["course_files"].find(
           file => file["uid"] === uid
         )
-        // filter courseUidList values on the UID in the URL
-        const linkedCourse = Object.entries(courseUidList).find(
-          ([key, value]) => {
-            if (value === uid) {
-              return key
-            }
-          }
-        )
+        const linkedCourse = courseUidsLookup[uid]
         if (linkedPage) {
           // a course_page has been found for this UID
           const linkPagePath = `${pathToChildRecursive(
@@ -403,6 +396,5 @@ module.exports = {
   htmlSafeText,
   stripS3,
   unescapeBackticks,
-  courseUidList,
   runOptions
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -145,7 +145,8 @@ describe("resolveUids", () => {
     const result = helpers.resolveUids(
       assignmentsPage["text"],
       assignmentsPage,
-      singleCourseJsonData
+      singleCourseJsonData,
+      {}
     )
     assert.isTrue(result.indexOf("resolveuid") === -1)
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #84 

#### What's this PR do?
Adds `courseUidsLookup` as a local variable which is passed in as an explicit argument. key and value are also reversed so that lookups are more efficient.

#### How should this be manually tested?
Convert some courses. Nothing should break.