### PR TITLE
Fix bug with missing file_location

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -317,19 +317,23 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
           if (page.includes(".") && !page.includes(".htm")) {
             // page has a file extension and isn't HTML
             courseData["course_files"].forEach(media => {
-              if (
-                media["file_type"] === "application/pdf" &&
-                media["file_location"].includes(page)
-              ) {
-                // construct url to Hugo PDF viewer page
-                const newUrl = `${GETPAGESHORTCODESTART}${path.join(
-                  newUrlBase,
-                  page.replace(".pdf", "")
-                )}${GETPAGESHORTCODEEND}`
-                htmlStr = htmlStr.replace(url, newUrl)
-              } else if (media["file_location"].includes(page)) {
-                // write link directly to file
-                htmlStr = stripS3(htmlStr.replace(url, media["file_location"]))
+              if (media["file_location"]) {
+                if (
+                  media["file_type"] === "application/pdf" &&
+                  media["file_location"].includes(page)
+                ) {
+                  // construct url to Hugo PDF viewer page
+                  const newUrl = `${GETPAGESHORTCODESTART}${path.join(
+                    newUrlBase,
+                    page.replace(".pdf", "")
+                  )}${GETPAGESHORTCODEEND}`
+                  htmlStr = htmlStr.replace(url, newUrl)
+                } else if (media["file_location"].includes(page)) {
+                  // write link directly to file
+                  htmlStr = stripS3(
+                    htmlStr.replace(url, media["file_location"])
+                  )
+                }
               }
             })
           } else {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #89 

#### What's this PR do?
Adds a check in case `media['file_location']` doesn't exist, and adds a test for it

#### How should this be manually tested?
See issue for repro instructions