### PR TITLE
Fix AWS etag key error

### DIFF
--- a/src/aws_sync_test.js
+++ b/src/aws_sync_test.js
@@ -44,66 +44,78 @@ describe("downloadCourses", () => {
 
 describe("downloadCourseRecursive", () => {
   const sandbox = sinon.createSandbox()
-  const testCourse =
-    "1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012"
-  const testJson = "bb55dad7f4888f0a1ad004600c5fb1f1_master.json"
-  const testJsonKey = path.join(testCourse, testJson)
-  const testJsonContents = fs.readFileSync(
-    path.join("test_data", "courses", testCourse, testJson)
-  )
-  const coursesDir = tmp.dirSync({
-    prefix: "source"
-  }).name
-  const destinationPath = tmp.dirSync({
-    prefix: "destination"
-  }).name
-  const outputJsonPath = path.join(coursesDir, testCourse, testJson)
-  const bucket = "open-learning-course-data-ci"
-  const bucketParams = {
-    Bucket: bucket,
-    Prefix: testCourse
-  }
-  const listObjectsV2Output = {
-    IsTruncated: false,
-    Contents:    [
-      {
-        Key:          testJsonKey,
-        LastModified: "2020-03-21T00:47:13.000Z",
-        ETag:         "a629d97165f6920838085eeddfccd228",
-        Size:         144523,
-        StorageClass: "STANDARD"
-      }
-    ],
-    Name:           "open-learning-course-data-ci",
-    Prefix:         testCourse,
-    MaxKeys:        1000,
-    CommonPrefixes: [],
-    KeyCount:       1
-  }
-  const getObjectOutput = {
-    AcceptRanges:  "bytes",
-    LastModified:  "2020-03-21T00:47:13.000Z",
-    ContentLength: 144523,
-    ETag:          "a629d97165f6920838085eeddfccd228",
-    VersionId:     "mt5F9IP6xviS16.n.HwOFkldmQGRJb87",
-    ContentType:   "binary/octet-stream",
-    Metadata:      {},
-    Body:          testJsonContents
-  }
-  fs.mkdirSync(path.join(coursesDir, testCourse), {
-    recursive: true
-  })
-  let mockS3, consoleLog
+  let mockS3,
+    consoleLog,
+    testCourse,
+    testJson,
+    testJsonKey,
+    testJsonContents,
+    coursesDir,
+    destinationPath,
+    outputJsonPath,
+    bucket,
+    bucketParams,
+    listObjectsV2Output,
+    getObjectOutput
 
   beforeEach(async () => {
     consoleLog = sandbox.stub(console, "log")
+
+    testCourse =
+      "1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012"
+    testJson = "bb55dad7f4888f0a1ad004600c5fb1f1_master.json"
+    testJsonKey = path.join(testCourse, testJson)
+    testJsonContents = fs.readFileSync(
+      path.join("test_data", "courses", testCourse, testJson)
+    )
+    coursesDir = tmp.dirSync({
+      prefix: "source"
+    }).name
+    destinationPath = tmp.dirSync({
+      prefix: "destination"
+    }).name
+    outputJsonPath = path.join(coursesDir, testCourse, testJson)
+    bucket = "open-learning-course-data-ci"
+    bucketParams = {
+      Bucket: bucket,
+      Prefix: testCourse
+    }
+    listObjectsV2Output = {
+      IsTruncated: false,
+      Contents:    [
+        {
+          Key:          testJsonKey,
+          LastModified: "2020-03-21T00:47:13.000Z",
+          ETag:         "a629d97165f6920838085eeddfccd228",
+          Size:         144523,
+          StorageClass: "STANDARD"
+        }
+      ],
+      Name:           "open-learning-course-data-ci",
+      Prefix:         testCourse,
+      MaxKeys:        1000,
+      CommonPrefixes: [],
+      KeyCount:       1
+    }
+    getObjectOutput = {
+      AcceptRanges:  "bytes",
+      LastModified:  "2020-03-21T00:47:13.000Z",
+      ContentLength: 144523,
+      ETag:          "a629d97165f6920838085eeddfccd228",
+      VersionId:     "mt5F9IP6xviS16.n.HwOFkldmQGRJb87",
+      ContentType:   "binary/octet-stream",
+      Metadata:      {},
+      Body:          testJsonContents
+    }
+    fs.mkdirSync(path.join(coursesDir, testCourse), {
+      recursive: true
+    })
 
     AWSMock.mock("S3", "listObjectsV2", listObjectsV2Output)
 
     AWSMock.mock("S3", "getObject", getObjectOutput)
 
     mockS3 = new AWS.S3()
-    await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
   })
 
   afterEach(() => {
@@ -115,23 +127,37 @@ describe("downloadCourseRecursive", () => {
     AWSMock.restore("S3")
   })
 
-  it("writes the test json file successfully", () => {
+  it("writes the test json file successfully", async () => {
+    await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
     assert.isTrue(fs.existsSync(outputJsonPath))
   })
 
-  it("writes a test json file that matches the one we've fed into the mock", () => {
+  it("writes a test json file that matches the one we've fed into the mock", async () => {
+    await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
     assert.deepEqual(testJsonContents, fs.readFileSync(outputJsonPath))
   })
 
-  it("is able to run scanCourses on the resulting courseDir without an error", () => {
+  it("is able to run scanCourses on the resulting courseDir without an error", async () => {
+    await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
     fileOperations.scanCourses(coursesDir, destinationPath)
   })
 
-  it("calls listObjectsV2 with the bucket params", () => {
+  it("calls listObjectsV2 with the bucket params", async () => {
+    await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
     expect(mockS3.listObjectsV2).to.be.calledWithExactly(bucketParams)
   })
 
-  it("calls getObject with the bucket and key", () => {
+  it("calls getObject with the bucket and key", async () => {
+    await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
+    expect(mockS3.getObject).to.be.calledWithExactly({
+      Bucket: bucket,
+      Key:    testJsonKey
+    })
+  })
+
+  it("handles missing content key", async () => {
+    getObjectOutput.ETag = "missing"
+    await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
     expect(mockS3.getObject).to.be.calledWithExactly({
       Bucket: bucket,
       Key:    testJsonKey


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #96 

#### What's this PR do?
Fixes for the case where the etag doesn't match downloaded content. Instead it will write to the file logger and continue

#### How should this be manually tested?
See #96, but I'm not sure this is easily reproduced
