### PR TITLE
fix a typo in the usage string

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -10,7 +10,7 @@ const loggers = require("../loggers")
 
 // Gather arguments
 const options = yargs
-  .usage("Usage: -s <path> -d <path>")
+  .usage("Usage: -i <path> -o <path>")
   .option("i", {
     alias:        "input",
     describe:     "Input directory of courses",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This corrects a typo in the argument names in the CLI usage string

#### How should this be manually tested?
Run `node .` and you should get a usage string that tells you to use `-i` and `-o` instead of `-s` and `-d`.
