### PR TITLE
Exit with non-zero exit code only on verbose, if a non-fatal error occurs

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -80,7 +80,7 @@ run()
           "Found errors which were logged: ",
           loggers.memoryTransport.logs
         )
+        process.exit(1)
       }
-      process.exit(1)
     }
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Since most hugo builds will have some non-fatal error which is logged, the exit code is almost always non-zero. Since this is unhelpful in production but helpful in debugging, we should only exit with a non-zero exit code in this case if 

#### How should this be manually tested?
Convert one of the courses with a CSS error. If `--verbose` is in your command line you should see a non-zero exit code, but if `--verbose` is not there you should not.
