### PR TITLE
Error if master JSON is missing for a course and the user has a course list

### DIFF
--- a/src/aws_sync_test.js
+++ b/src/aws_sync_test.js
@@ -140,7 +140,7 @@ describe("downloadCourseRecursive", () => {
 
   it("is able to run scanCourses on the resulting courseDir without an error", async () => {
     await awsSync.downloadCourseRecursive(mockS3, bucketParams, coursesDir)
-    fileOperations.scanCourses(coursesDir, destinationPath)
+    await fileOperations.scanCourses(coursesDir, destinationPath)
   })
 
   it("calls listObjectsV2 with the bucket params", async () => {

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -7,6 +7,7 @@ const { writeBoilerplate, scanCourses } = require("../file_operations")
 
 const { MISSING_JSON_ERROR_MESSAGE } = require("../constants")
 const loggers = require("../loggers")
+const helpers = require("../helpers")
 
 // Gather arguments
 const options = yargs
@@ -53,6 +54,8 @@ const options = yargs
     demandOption: false
   }).argv
 
+helpers.runOptions = options
+
 const run = async () => {
   if (options.courses && options.download) {
     await downloadCourses(options.courses, options.input)
@@ -60,11 +63,7 @@ const run = async () => {
     throw new Error(MISSING_JSON_ERROR_MESSAGE)
   }
   await writeBoilerplate(options.output)
-  await scanCourses(options.input, options.output, {
-    courses:      options.courses,
-    strips3:      options.strips3,
-    staticPrefix: options.staticPrefix
-  })
+  await scanCourses(options.input, options.output)
 }
 
 run()

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -44,20 +44,22 @@ const scanCourses = async (inputPath, outputPath) => {
   }
 
   const jsonPath = helpers.runOptions.courses
-  const courseList = jsonPath
-    ? JSON.parse(await fsPromises.readFile(jsonPath))["courses"]
-    : (await fsPromises.readdir(inputPath)).filter(
+  let courseList
+  if (jsonPath) {
+    courseList = JSON.parse(await fsPromises.readFile(jsonPath))["courses"]
+  } else {
+    const courseDirectories = (await fsPromises.readdir(inputPath)).filter(
       course => !course.startsWith(".")
     )
-  const numCourses = jsonPath
-    ? courseList.length
-    : (
-      await Promise.all(
-        courseList
-          .map(file => path.join(inputPath, file))
-          .map(path => directoryExists(path))
-      )
-    ).filter(Boolean).length
+    courseList = []
+    for (const directory of courseDirectories) {
+      const absPath = path.join(inputPath, directory)
+      if (await directoryExists(absPath)) {
+        courseList.push(directory)
+      }
+    }
+  }
+  const numCourses = courseList.length
   if (numCourses === 0) {
     console.log(NO_COURSES_FOUND_MESSAGE)
     return


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
 - Right now missing master JSON files cause a course to be skipped. The error is logged but it's not a fatal error. This changes that behavior to make it a fatal error if the user has specified a course list in the command line.
 - options are now set to `helpers.runOptions` and not passed into `scanCourses`
 - Courses which are present in the courses JSON but are missing directories will result in an error, if a courses JSON is set

#### How should this be manually tested?
Remove or rename the master JSON file for a course, then convert it. You should get an error when the processing reaches that course.
