### PR TITLE
Add lastpublished data to course front matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^8.2.0",
     "js-yaml": "^3.13.1",
     "markdown-doc-builder": "^1.3.0",
+    "moment": "^2.29.1",
     "title-case": "^3.0.2",
     "tmp": "^0.2.1",
     "turndown": "^6.0.0",

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,5 +35,6 @@ module.exports = {
         type:  "courseindex"
       }
     }
-  ]
+  ],
+  INPUT_COURSE_DATE_FORMAT: "YYYY/M/D H:m:s.SSS"
 }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -3,13 +3,15 @@ const yaml = require("js-yaml")
 const markdown = require("markdown-doc-builder").default
 const TurndownService = require("turndown")
 const turndownPluginGfm = require("turndown-plugin-gfm")
+const moment = require("moment")
 const { gfm, tables } = turndownPluginGfm
 
 const {
   REPLACETHISWITHAPIPE,
   GETPAGESHORTCODESTART,
   GETPAGESHORTCODEEND,
-  AWS_REGEX
+  AWS_REGEX,
+  INPUT_COURSE_DATE_FORMAT
 } = require("./constants")
 const helpers = require("./helpers")
 const loggers = require("./loggers")
@@ -389,6 +391,12 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
       : "",
     course_image_caption_text: courseData["image_caption_text"]
       ? courseData["image_caption_text"]
+      : "",
+    publishdate: courseData["last_published_to_production"]
+      ? moment(
+        courseData["last_published_to_production"],
+        INPUT_COURSE_DATE_FORMAT
+      ).format()
       : "",
     course_info: {
       instructors: courseData["instructors"].map(

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -289,7 +289,7 @@ describe("generateCourseHomeMarkdown", () => {
         last_published_to_production: "2020/01/30 21:09:39.493 Universal"
       }
     )
-    assert.include(courseHomeMarkdown, "publishdate: '2020-01-30T21:09:39-05:00'")
+    assert.include(courseHomeMarkdown, "publishdate: '2020-01-30T21:09:39")
   })
 })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -283,12 +283,10 @@ describe("generateCourseHomeMarkdown", () => {
   })
 
   it("parses the last published date and reformats as ISO-8601", () => {
-    courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
-      {
-        ...singleCourseJsonData,
-        last_published_to_production: "2020/01/30 21:09:39.493 Universal"
-      }
-    )
+    courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown({
+      ...singleCourseJsonData,
+      last_published_to_production: "2020/01/30 21:09:39.493 Universal"
+    })
     assert.include(courseHomeMarkdown, "publishdate: '2020-01-30T21:09:39")
   })
 })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -281,6 +281,16 @@ describe("generateCourseHomeMarkdown", () => {
     )
     assert.include(courseHomeMarkdown, "title: Course Home")
   })
+
+  it("parses the last published date and reformats as ISO-8601", () => {
+    courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
+      {
+        ...singleCourseJsonData,
+        last_published_to_production: "2020/01/30 21:09:39.493 Universal"
+      }
+    )
+    assert.include(courseHomeMarkdown, "publishdate: '2020-01-30T21:09:39-05:00'")
+  })
 })
 
 describe("generateCourseSectionFrontMatter", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,6 +1935,11 @@ mocha@^6.2.2:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/hugo-course-publisher/issues/240

#### What's this PR do?
Adds the `last_published_to_production` field from the master JSON as `lastpublished` which can be used for sorting in hugo.

#### How should this be manually tested?
Convert a course and see that the markdown contains the `lastpublished` field in the front matter
