### PR TITLE
Add topicslist for easier rendering in hugo

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -125,6 +125,13 @@ const getConsolidatedTopics = courseCollections => {
   })
   return topics
 }
+
+const getConsolidatedTopicsList = courseCollections =>
+  _.uniq(
+    courseCollections
+      .map(collection => collection.ocw_subfeature || collection.ocw_feature)
+      .filter(Boolean)
+  )
 /* eslint-disable camelcase */
 
 const getYoutubeEmbedCode = media => {
@@ -387,6 +394,7 @@ module.exports = {
   getCourseFeatureObject,
   getCourseSectionFromFeatureUrl,
   getConsolidatedTopics,
+  getConsolidatedTopicsList,
   getYoutubeEmbedCode,
   pathToChildRecursive,
   getHugoPathSuffix,

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -399,7 +399,10 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
       course_features: courseData["course_features"].map(courseFeature =>
         helpers.getCourseFeatureObject(courseFeature)
       ),
-      topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
+      topics:     helpers.getConsolidatedTopics(courseData["course_collections"]),
+      topicslist: helpers.getConsolidatedTopicsList(
+        courseData["course_collections"]
+      ),
       course_numbers: helpers.getCourseNumbers(courseData),
       term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,
       level:          courseData["course_level"]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/hugo-course-publisher/issues/240

#### What's this PR do?
Adds a `topicslist` field to the frontmatter so that a list of topics can be easily generated in the template. The `topics` dictionary isn't easily traversed in hugo without some complicated template logic.

#### How should this be manually tested?
Convert a course and check the output of a course markdown file to see that `topicslist` matches the 
