### PR TITLE
Handle an empty string for instructors

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -399,10 +399,10 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
       ).format()
       : "",
     course_info: {
-      instructors: courseData["instructors"].map(
+      instructors: courseData["instructors"] ? courseData["instructors"].map(
         instructor =>
           `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
-      ),
+      ) : [],
       departments:     helpers.getDepartments(courseData),
       course_features: courseData["course_features"].map(courseFeature =>
         helpers.getCourseFeatureObject(courseFeature)

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -399,10 +399,12 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
       ).format()
       : "",
     course_info: {
-      instructors: courseData["instructors"] ? courseData["instructors"].map(
-        instructor =>
-          `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
-      ) : [],
+      instructors: courseData["instructors"]
+        ? courseData["instructors"].map(
+          instructor =>
+            `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
+        )
+        : [],
       departments:     helpers.getDepartments(courseData),
       course_features: courseData["course_features"].map(courseFeature =>
         helpers.getCourseFeatureObject(courseFeature)

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -289,6 +289,13 @@ describe("generateCourseHomeMarkdown", () => {
     })
     assert.include(courseHomeMarkdown, "publishdate: '2020-01-30T21:09:39")
   })
+
+  it("handles an empty string for instructors", () => {
+    markdownGenerators.generateCourseHomeMarkdown({
+      ...singleCourseJsonData,
+      instructors: ""
+    })
+  })
 })
 
 describe("generateCourseSectionFrontMatter", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Handles an empty string for instructors in the master JSON. This should be fixed in https://github.com/mitodl/ocw-data-parser/pull/64 but it will take a little while to run that on all courses so this is here as a quicker temporary fix. At some point after we can revert this fix.

#### How should this be manually tested?
Set `instructors: ""` in your master JSON or use a file which already has this value, then convert the courses.
