### PR TITLE
Remove logged error if the course is skipped and no course JSON is set

### DIFF
--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -136,7 +136,7 @@ const getMasterJsonFileName = async coursePath => {
     throw new Error(courseError)
   }
 
-  loggers.fileLogger.error(courseError)
+  // else, skip this one and go to the next course
   progressBar.increment()
 }
 

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -124,11 +124,6 @@ describe("scanCourses", () => {
     const coursesPath = tmp.dirSync({ prefix: "output" }).name
     await fsPromises.mkdir(path.join(coursesPath, course1Name))
     await fileOperations.scanCourses(coursesPath, outputPath)
-    assert.include(
-      loggers.memoryTransport.logs[loggers.memoryTransport.logs.length - 1]
-        .message,
-      `${course1Name} - Specified course was not found`
-    )
   })
 
   it("throws an error when you call it with an empty input directory", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Removes a logging statement which shouldn't be there

#### How should this be manually tested?
Remove a master JSON file from a course directory and convert it without specifying a JSON file, with the `--verbose` flag. You should see no error but the output directory will not have that course in it.