### PR TITLE
Generate markdown for bottom text if it exists

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -518,16 +518,32 @@ const generateCourseFeatures = courseData => {
     .toMarkdown()}`
 }
 
+const formatHTMLMarkDown = (page, courseData, courseUidsLookup, section) => {
+  return page[section]
+    ? `\n${helpers.unescapeBackticks(
+      turndownService.turndown(
+        fixLinks(page[section] || "", page, courseData, courseUidsLookup)
+      )
+    )}`
+    : ""
+}
+
 const generateCourseSectionMarkdown = (page, courseData, courseUidsLookup) => {
   /**
     Generate markdown a given course section page
     */
   try {
-    return `${helpers.unescapeBackticks(
-      turndownService.turndown(
-        fixLinks(page["text"] || "", page, courseData, courseUidsLookup)
-      )
-    )}${generateCourseFeaturesMarkdown(page, courseData)}`
+    return `${formatHTMLMarkDown(
+      page,
+      courseData,
+      courseUidsLookup,
+      "text"
+    )}${generateCourseFeaturesMarkdown(page, courseData)}${formatHTMLMarkDown(
+      page,
+      courseData,
+      courseUidsLookup,
+      "bottomtext"
+    )}`
   } catch (err) {
     loggers.fileLogger.error(err)
     return page["text"]

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -476,10 +476,25 @@ describe("generateCourseSectionMarkdown", () => {
     )
   })
 
+  it("renders markdown for top and bottom text", () => {
+    const page = {
+      ...coursePagesWithText[0],
+      text:       '<div id="top">Top Text</div>',
+      bottomtext: '<div id="bottom">Bottom Text</div>'
+    }
+    const markdown = markdownGenerators.generateCourseSectionMarkdown(
+      page,
+      singleCourseJsonData
+    )
+    assert(markdown.includes("Top Text"))
+    assert(markdown.includes("Bottom Text"))
+  })
+
   it("handles missing page text gracefully", () => {
     const page = {
       ...coursePagesWithText[0],
-      text: undefined
+      text:       undefined,
+      bottomtext: undefined
     }
     const markdown = markdownGenerators.generateCourseSectionMarkdown(
       page,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/issues/182

#### What's this PR do?
Inserts markdown for the bottom text of a page (if any)

#### How should this be manually tested?
- Tests should pass
- You can run the latest code for ocw-data-parser on `PROD/EC/EC.711/Spring_2011/ec-711-d-lab-energy-spring-2011/`, feed the output (master json etc), then feed the output into ocw-to-hugo as input.  The file `output/courses/ec-711-d-lab-energy-spring-2011/sections/energy-storage/_index.md` should have some markdown in it corresponding to the `bottemtext` property for that page in the master.json
