### PR TITLE
Increase timeout on file_operations tests

### DIFF
--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -147,12 +147,12 @@ describe("scanCourses", () => {
   it("calls readdir nine times, once for courses and once for each course", async () => {
     await fileOperations.scanCourses(inputPath, outputPath)
     assert.equal(readdirStub.callCount, 9)
-  })
+  }).timeout(5000)
 
   it("scans the four test courses and reports to console", async () => {
     await fileOperations.scanCourses(inputPath, outputPath)
     expect(consoleLog).calledWithExactly(logMessage)
-  })
+  }).timeout(5000)
 
   it("calls lstat for each test course", async () => {
     await fileOperations.scanCourses(inputPath, outputPath)
@@ -160,7 +160,7 @@ describe("scanCourses", () => {
     expect(lstatStub).to.be.calledWithExactly(course2Path)
     expect(lstatStub).to.be.calledWithExactly(course3Path)
     expect(lstatStub).to.be.calledWithExactly(course4Path)
-  })
+  }).timeout(5000)
 })
 
 describe("scanCourse", () => {
@@ -191,7 +191,7 @@ describe("scanCourse", () => {
       courseUidLookup
     )
     expect(readFileStub).to.be.calledWithExactly(singleCourseMasterJsonPath)
-  })
+  }).timeout(5000)
 
   it("calls generateMarkdownFromJson on the course data", async () => {
     const courseUidLookup = { singleCourseId: "uid" }
@@ -205,7 +205,7 @@ describe("scanCourse", () => {
       singleCourseJsonData,
       courseUidLookup
     )
-  })
+  }).timeout(5000)
 })
 
 describe("getMasterJsonFileName", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Increases the timeout to 5000 for certain tests in `file_operations_test.js` that can exceed the default of 2000 ms.

#### How should this be manually tested?
The travis tests should not fail with a timeout error.  Restart the travis tests a few times to make sure.
