### PR TITLE
fix embedded media nav bug

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -266,6 +266,7 @@ const generateMarkdownRecursive = (page, courseUidsLookup) => {
     courseData["course_embedded_media"]
   )
     .map(embeddedMedia => {
+      embeddedMedia["course_id"] = courseData["short_url"]
       embeddedMedia["type"] = "course"
       embeddedMedia["layout"] = "video"
       return embeddedMedia

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -76,18 +76,19 @@ const courseVideoFeaturesFrontMatter = markdownGenerators.generateCourseFeatures
 )
 
 describe("generateMarkdownFromJson", () => {
-  it("contains the course home page and other expected sections", () => {
-    const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-      singleCourseJsonData
+  const singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
+    singleCourseJsonData
+  )
+  const expectedSections = singleCourseJsonData["course_pages"]
+    .filter(
+      page =>
+        page["parent_uid"] === singleCourseJsonData["uid"] &&
+        page["type"] !== "CourseHomeSection" &&
+        page["type"] !== "DownloadSection"
     )
-    const expectedSections = singleCourseJsonData["course_pages"]
-      .filter(
-        page =>
-          page["parent_uid"] === singleCourseJsonData["uid"] &&
-          page["type"] !== "CourseHomeSection" &&
-          page["type"] !== "DownloadSection"
-      )
-      .map(page => page["short_url"])
+    .map(page => page["short_url"])
+
+  it("contains the course home page and other expected sections", () => {
     const markdownFileNames = singleCourseMarkdownData.map(markdownData => {
       return markdownData["name"]
     })
@@ -164,6 +165,21 @@ describe("generateMarkdownFromJson", () => {
           assert.include(mediaMarkdownFileNames, mediaFilename)
         })
       }
+    })
+  })
+
+  it("puts the course_id in every course page's markdown", () => {
+    expectedSections.forEach(expectedSection => {
+      const filename = `sections/${expectedSection}`
+      const sectionMarkdownData = singleCourseMarkdownData.filter(
+        section =>
+          section["name"] === `${filename}.md` ||
+          section["name"] === `${filename}/_index.md`
+      )[0]
+      const frontMatter = yaml.safeLoad(
+        sectionMarkdownData["data"].split("---\n")[1]
+      )
+      assert.equal(frontMatter["course_id"], singleCourseId)
     })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/hugo-course-publisher/issues/280

#### What's this PR do?
This PR adds the `course_id` property to the front matter in pages generated from the `course_embedded_media` items.  A test was also added to ensure that `course_id` exists on everything, as it's needed to render the nav for any given course.

#### How should this be manually tested?
Run the conversion, then spin up `hugo-course-publisher` against the generated content.  Ensure that pages are generated from `course_embedded_media` have the nav render properly on them, for example:

http://localhost:3000/courses/ec-711-d-lab-energy-spring-2011/sections/intro-energy-basics-human-power/lab-1-human-power/