### PR TITLE
Use first_published_to_production instead

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -394,9 +394,9 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
     course_image_caption_text: courseData["image_caption_text"]
       ? courseData["image_caption_text"]
       : "",
-    publishdate: courseData["last_published_to_production"]
+    publishdate: courseData["first_published_to_production"]
       ? moment(
-        courseData["last_published_to_production"],
+        courseData["first_published_to_production"],
         INPUT_COURSE_DATE_FORMAT
       ).format()
       : "",

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -338,10 +338,10 @@ describe("generateCourseHomeMarkdown", () => {
     assert.include(courseHomeMarkdown, "title: Course Home")
   })
 
-  it("parses the last published date and reformats as ISO-8601", () => {
+  it("parses the first published date and reformats as ISO-8601", () => {
     courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown({
       ...singleCourseJsonData,
-      last_published_to_production: "2020/01/30 21:09:39.493 Universal"
+      first_published_to_production: "2020/01/30 21:09:39.493 Universal"
     })
     assert.include(courseHomeMarkdown, "publishdate: '2020-01-30T21:09:39")
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #114 

#### What's this PR do?
Changes to use `first_published_to_production` for the `publishdate` so we can better sort course cards.

#### How should this be manually tested?
Create a parsed JSON file from https://github.com/mitodl/ocw-data-parser/pull/84 (or just add the field manually). In the output markdown frontmatter, make sure the `publishdate` matches up with the `first_published_to_production` date for one of the courses.
