### PR TITLE
Remove title from boilerplate

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -16,7 +16,7 @@ module.exports = {
       path:    "",
       name:    "_index.md",
       content: {
-        title: "Hugo Course Publisher"
+        title: ""
       }
     },
     {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/hugo-course-publisher/issues/328

#### What's this PR do?
Removes "Hugo Course Publisher" from the title so it doesn't show up. hugo-course-publisher will interpret this to use its own title from the markdown parameters, or else a more sensible default.

#### How should this be manually tested?
Convert a course, then check `_index.md` at the root level and verify that it has an empty title.
