### PR TITLE
Change topics to return a list with dicts

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -104,25 +104,45 @@ const getCourseSectionFromFeatureUrl = courseFeature => {
 
 /* eslint-disable camelcase */
 const getConsolidatedTopics = courseCollections => {
-  let topics = {}
-  courseCollections.forEach(courseCollection => {
-    const { ocw_feature, ocw_subfeature, ocw_speciality } = courseCollection
+  const topics = []
+  const topicsLookup = {}
+  const subtopicsLookup = {}
+  for (const courseCollection of courseCollections) {
+    const {
+      ocw_feature: feature,
+      ocw_subfeature: subfeature,
+      ocw_speciality: speciality
+    } = courseCollection
 
-    const collectionTopic = {
-      [ocw_feature]: {}
-    }
-    if (ocw_subfeature) {
-      collectionTopic[ocw_feature][ocw_subfeature] = [ocw_speciality].filter(
-        Boolean
-      )
-    }
-
-    topics = _.mergeWith(topics, collectionTopic, (objValue, srcValue) => {
-      if (_.isArray(objValue)) {
-        return objValue.concat(srcValue)
+    let topicObj = topicsLookup[feature]
+    if (!topicObj) {
+      topicObj = {
+        topic:     feature,
+        subtopics: []
       }
-    })
-  })
+      topics.push(topicObj)
+      topicsLookup[feature] = topicObj
+      subtopicsLookup[feature] = {}
+    }
+
+    if (!subfeature) {
+      continue
+    }
+
+    let subtopicObj = subtopicsLookup[feature][subfeature]
+    if (!subtopicObj) {
+      subtopicObj = {
+        subtopic:     subfeature,
+        specialities: []
+      }
+      topicObj.subtopics.push(subtopicObj)
+      subtopicsLookup[feature][subfeature] = subtopicObj
+    }
+
+    if (speciality) {
+      subtopicObj.specialities.push(speciality)
+    }
+  }
   return topics
 }
 /* eslint-disable camelcase */

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -271,28 +271,32 @@ describe("generateCourseHomeMarkdown", () => {
   })
 
   it("sets the topics property on the course info object to data parsed from course_collections in the course json data", () => {
-    const expectedValues = helpers.getConsolidatedTopics(
+    const topics = helpers.getConsolidatedTopics(
       singleCourseJsonData["course_collections"]
     )
-    const foundValues = courseHomeFrontMatter["course_info"]["topics"]
-    Object.keys(expectedValues).forEach(expectedTopicKey => {
-      assert.isTrue(foundValues.hasOwnProperty(expectedTopicKey))
-      Object.keys(expectedValues[expectedTopicKey]).forEach(
-        expectedSubTopicKey => {
-          assert.isTrue(
-            foundValues[expectedTopicKey].hasOwnProperty(expectedSubTopicKey)
-          )
-          expectedValues[expectedTopicKey][expectedSubTopicKey].forEach(
-            (expectedSpeciality, index) => {
-              assert.equal(
-                expectedSpeciality,
-                foundValues[expectedTopicKey][expectedSubTopicKey][index]
-              )
-            }
-          )
-        }
-      )
-    })
+    assert.deepEqual(topics, [
+      {
+        topic:     "Engineering",
+        subtopics: [
+          {
+            specialities: ["Systems Design"],
+            subtopic:     "Systems Engineering"
+          },
+          {
+            specialities: ["Robotics and Control Systems"],
+            subtopic:     "Electrical Engineering"
+          },
+          {
+            specialities: ["Ocean Exploration"],
+            subtopic:     "Ocean Engineering"
+          },
+          {
+            specialities: ["Mechanical Design"],
+            subtopic:     "Mechanical Engineering"
+          }
+        ]
+      }
+    ])
   })
 
   it("calls getCourseNumbers with the course json data", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
The topics and subtopics are only available in lowercase because hugo converts dict keys to lowercase values. We are using `title` as a workaround, but this doesn't work consistently with search because the search requires case sensitive topic values.

#### How should this be manually tested?
Only the topics should change in converted courses. This will be a breaking change but we can update the corresponding code on hugo-course-publisher so we have a seamless update.
