### PR TITLE
add support for retaining simplecast embeds in markdown

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -36,5 +36,11 @@ module.exports = {
       }
     }
   ],
-  INPUT_COURSE_DATE_FORMAT: "YYYY/M/D H:m:s.SSS"
+  INPUT_COURSE_DATE_FORMAT: "YYYY/M/D H:m:s.SSS",
+  SUPPORTED_IFRAME_EMBEDS:  {
+    "player.simplecast.com": {
+      hugoShortcode: "simplecast",
+      getID:         url => url.pathname.replace("/", "")
+    }
+  }
 }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -701,4 +701,13 @@ describe("other turndown elements", () => {
     const markdown = markdownGenerators.turndownService.turndown(inputHTML)
     assert.equal(markdown, "`test``test``test`")
   })
+
+  it("should return a simplecast shortcode when confronted with a simplecast iframe", () => {
+    const inputHTML = `<iframe scrolling="no" seamless="" src="https://player.simplecast.com/e31edbb0-e4ac-4d9f-aebc-3d613c2f972c?dark=false" width="100%" height="200px" frameborder="no"></iframe>`
+    const markdown = markdownGenerators.turndownService.turndown(inputHTML)
+    assert.equal(
+      markdown,
+      "{{< simplecast e31edbb0-e4ac-4d9f-aebc-3d613c2f972c >}}"
+    )
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #121 

#### What's this PR do?

this adds a turndown rule to find simplecast iframes and write them out in markdown using a shortcode, like this:

```
{{< simplecast $FILE_ID >}}
```

then on the hugo side of things we'll be able to add a shortcode template to render those to a full iframe.

#### How should this be manually tested?

you can test using this course: `15-667-negotiation-and-conflict-management-spring-2001`

it has a section called 'instructor insights' which embeds a simplecast podcast episode. On master it shouldn't render anything related to that, but on this branch you should see a shortcode like the thing above.