### PR TITLE
Fix course resolveuid links

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -257,8 +257,7 @@ const resolveUids = (htmlStr, page, courseData, courseUidsLookup) => {
           }
         }
         if (linkedCourse) {
-          const linkedCourseId = linkedCourse[0]
-          htmlStr = htmlStr.replace(url, `/courses/${linkedCourseId}`)
+          htmlStr = htmlStr.replace(url, `/courses/${linkedCourse}`)
         }
       }
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #126 

#### What's this PR do?
Fixes a bug introduced in #92 which picked off only the first character of the course id.

#### How should this be manually tested?
Put the parsed JSONs for `7.012` and `7.013` in the same directory, then use ocw-to-hugo to convert these two courses at the same time. Look at `_index.md` in 7.013. You should see a link for 7.012 like this: `[7.012](/courses/7-012-introduction-to-biology-fall-2004)`

