### PR TITLE
Remove course_info from section pages

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -254,7 +254,6 @@ const generateMarkdownFromJson = (courseData, courseUidsLookup) => {
   /**
     This function takes JSON data parsed from a parsed.json file and returns markdown data
     */
-  this["courseData"] = courseData
   this["menuIndex"] = 0
   const rootSections = courseData["course_pages"].filter(
     page =>
@@ -268,14 +267,13 @@ const generateMarkdownFromJson = (courseData, courseUidsLookup) => {
       data: generateCourseHomeMarkdown(courseData, courseUidsLookup)
     },
     ...rootSections.map(
-      page => generateMarkdownRecursive(page, courseUidsLookup),
+      page => generateMarkdownRecursive(page, courseUidsLookup, courseData),
       this
     )
   ]
 }
 
-const generateMarkdownRecursive = (page, courseUidsLookup) => {
-  const courseData = this["courseData"]
+const generateMarkdownRecursive = (page, courseUidsLookup, courseData) => {
   const children = courseData["course_pages"].filter(
     coursePage => coursePage["parent_uid"] === page["uid"]
   )
@@ -313,7 +311,8 @@ const generateMarkdownRecursive = (page, courseUidsLookup) => {
     page["is_media_gallery"],
     (this["menuIndex"] + 1) * 10,
     page["list_in_left_nav"],
-    courseData["short_url"]
+    courseData["short_url"],
+    courseData
   )
   this["menuIndex"]++
   courseSectionMarkdown += generateCourseSectionMarkdown(
@@ -333,7 +332,7 @@ const generateMarkdownRecursive = (page, courseUidsLookup) => {
         : `${pathToChild}.md`,
     data:     courseSectionMarkdown,
     children: children.map(
-      page => generateMarkdownRecursive(page, courseUidsLookup),
+      page => generateMarkdownRecursive(page, courseUidsLookup, courseData),
       this
     ),
     files: pdfFiles
@@ -371,6 +370,23 @@ const generateMarkdownRecursive = (page, courseUidsLookup) => {
       .filter(media => media)
   }
 }
+
+const generateCourseInfo = courseData => ({
+  instructors: courseData["instructors"]
+    ? courseData["instructors"].map(
+      instructor =>
+        `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
+    )
+    : [],
+  departments:     helpers.getDepartments(courseData),
+  course_features: courseData["course_features"].map(courseFeature =>
+    helpers.getCourseFeatureObject(courseFeature)
+  ),
+  topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
+  course_numbers: helpers.getCourseNumbers(courseData),
+  term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,
+  level:          courseData["course_level"]
+})
 
 const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
   /**
@@ -422,23 +438,8 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
         INPUT_COURSE_DATE_FORMAT
       ).format()
       : "",
-    course_info: {
-      instructors: courseData["instructors"]
-        ? courseData["instructors"].map(
-          instructor =>
-            `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
-        )
-        : [],
-      departments:     helpers.getDepartments(courseData),
-      course_features: courseData["course_features"].map(courseFeature =>
-        helpers.getCourseFeatureObject(courseFeature)
-      ),
-      topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
-      course_numbers: helpers.getCourseNumbers(courseData),
-      term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,
-      level:          courseData["course_level"]
-    },
-    menu: {
+    course_info: generateCourseInfo(courseData),
+    menu:        {
       [courseData["short_url"]]: {
         identifier: "course-home",
         weight:     -10
@@ -472,16 +473,18 @@ const generateCourseSectionFrontMatter = (
   isMediaGallery,
   menuIndex,
   listInLeftNav,
-  courseId
+  courseId,
+  courseData
 ) => {
   /**
     Generate the front matter metadata for a course section given a title and menu index
     */
   const courseSectionFrontMatter = {
-    title:     title,
-    course_id: courseId,
-    type:      "course",
-    layout:    "course_section"
+    title:        title,
+    course_id:    courseId,
+    type:         "course",
+    layout:       "course_section",
+    course_title: courseData["title"]
   }
 
   if (inRootNav || listInLeftNav) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -376,7 +376,8 @@ describe("generateCourseSectionFrontMatter", () => {
           false,
           10,
           false,
-          singleCourseJsonData["short_url"]
+          singleCourseJsonData["short_url"],
+          singleCourseJsonData
         )
         .replace(/---\n/g, "")
     )
@@ -416,7 +417,8 @@ describe("generateCourseSectionFrontMatter", () => {
           false,
           10,
           false,
-          singleCourseJsonData["short_url"]
+          singleCourseJsonData["short_url"],
+          singleCourseJsonData
         )
         .replace(/---\n/g, "")
     )
@@ -436,7 +438,8 @@ describe("generateCourseSectionFrontMatter", () => {
           false,
           10,
           true,
-          singleCourseJsonData["short_url"]
+          singleCourseJsonData["short_url"],
+          singleCourseJsonData
         )
         .replace(/---\n/g, "")
     )
@@ -459,9 +462,18 @@ describe("generateCourseSectionFrontMatter", () => {
       false,
       10,
       false,
-      singleCourseJsonData["short_url"]
+      singleCourseJsonData["short_url"],
+      singleCourseJsonData
     )
     assert.notInclude(yaml, "undefined")
+  })
+
+  it("has a course and section title", () => {
+    assert.equal(courseSectionFrontMatter["title"], "Syllabus")
+    assert.equal(
+      courseSectionFrontMatter["course_title"],
+      "Exploring Sea, Space, & Earth: Fundamentals of Engineering Design"
+    )
   })
 })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -376,8 +376,7 @@ describe("generateCourseSectionFrontMatter", () => {
           false,
           10,
           false,
-          singleCourseJsonData["short_url"],
-          singleCourseJsonData
+          singleCourseJsonData["short_url"]
         )
         .replace(/---\n/g, "")
     )
@@ -417,8 +416,7 @@ describe("generateCourseSectionFrontMatter", () => {
           false,
           10,
           false,
-          singleCourseJsonData["short_url"],
-          singleCourseJsonData
+          singleCourseJsonData["short_url"]
         )
         .replace(/---\n/g, "")
     )
@@ -438,8 +436,7 @@ describe("generateCourseSectionFrontMatter", () => {
           false,
           10,
           true,
-          singleCourseJsonData["short_url"],
-          singleCourseJsonData
+          singleCourseJsonData["short_url"]
         )
         .replace(/---\n/g, "")
     )
@@ -462,30 +459,9 @@ describe("generateCourseSectionFrontMatter", () => {
       false,
       10,
       false,
-      singleCourseJsonData["short_url"],
-      singleCourseJsonData
+      singleCourseJsonData["short_url"]
     )
     assert.notInclude(yaml, "undefined")
-  })
-
-  it("has a course and section title", () => {
-    assert.equal(courseSectionFrontMatter["title"], "Syllabus")
-    assert.equal(
-      courseSectionFrontMatter["course_title"],
-      "Exploring Sea, Space, & Earth: Fundamentals of Engineering Design"
-    )
-  })
-
-  it("has course info", () => {
-    const info = courseSectionFrontMatter["course_info"]
-    assert.deepEqual(info.instructors, ["Prof. Alexandra Techet"])
-    assert.deepEqual(info.departments, [
-      "Mechanical Engineering",
-      "Aeronautics and Astronautics"
-    ])
-    assert.deepEqual(info.course_numbers, ["2.00AJ", "16.00AJ"])
-    assert.equal(info.term, "Spring 2009")
-    assert.equal(info.level, "Undergraduate")
   })
 })
 


### PR DESCRIPTION
Reverts a part of mitodl/ocw-to-hugo#120. It removes `course_info` from course section pages to try to decrease hugo memory use