### PR TITLE
add optional argument to clear destination directory before conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If the `-c` option has been specified, processing will be filtered by the course
 | `--download`      | No  | `true or false` | Download `parsed.json` files from a configured S3 bucket and a list of courses passed in with `-c` |
 | `--strips3`       | No  | `true or false` | Strip the s3 base URL from all OCW resources |
 | `--staticPrefix`       | No  | `/path/to/static/assets` | When `--strips3` is set to true, replace the s3 base URL with this string |
+| `--rm` | No | `true or false` | Clear the contents of the path passed with `-o` before the conversion run |
 
 ## Environment Variables
 | Variable | Description  |

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -55,7 +55,7 @@ const options = yargs
   })
   .option("rm", {
     describe:
-      "Recursively remove the contents of the destination directory before conversoin",
+      "Recursively remove the contents of the destination directory before conversion",
     type:         "boolean",
     demandOption: false
   }).argv

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -52,6 +52,12 @@ const options = yargs
     describe:     "Write error logging and other extra output",
     type:         "boolean",
     demandOption: false
+  })
+  .option("rm", {
+    describe:
+      "Recursively remove the contents of the destination directory before conversoin",
+    type:         "boolean",
+    demandOption: false
   }).argv
 
 helpers.runOptions = options
@@ -62,7 +68,7 @@ const run = async () => {
   } else if (options.download && !options.courses) {
     throw new Error(MISSING_JSON_ERROR_MESSAGE)
   }
-  await writeBoilerplate(options.output)
+  await writeBoilerplate(options.output, options.rm)
   await scanCourses(options.input, options.output)
 }
 

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -20,7 +20,10 @@ const progressBar = new cliProgress.SingleBar(
   cliProgress.Presets.shades_classic
 )
 
-const writeBoilerplate = async outputPath => {
+const writeBoilerplate = async (outputPath, remove) => {
+  if (remove) {
+    await fsPromises.rmdir(outputPath, { recursive: true })
+  }
   for (const file of BOILERPLATE_MARKDOWN) {
     if (!(await directoryExists(file.path))) {
       const filePath = path.join(outputPath, file.path)

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -22,6 +22,7 @@ const progressBar = new cliProgress.SingleBar(
 
 const writeBoilerplate = async (outputPath, remove) => {
   if (remove) {
+    console.log(`Removing the contents of ${outputPath}...`)
     await fsPromises.rmdir(outputPath, { recursive: true })
   }
   for (const file of BOILERPLATE_MARKDOWN) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/129

#### What's this PR do?
This PR adds the `--rm` argument to `ocw-to-hugo`.  If used, the output directory (the directory passed with the `-o` argument) will have its contents recursively removed before the conversion run.

#### How should this be manually tested?
Create a directory with a test file in it, then run `ocw-to-hugo` targeting that directory with `-o` and also pass the `--rm` argument.  After the run is complete, ensure that the test file is gone.

