### PR TITLE
Remove "Course Home" from course page title

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -190,7 +190,7 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
     : ""
 
   const frontMatter = {
-    title:     "Course Home",
+    title:     "",
     type:      "course",
     layout:    "course_home",
     course_id: courseData["short_url"],

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -216,8 +216,8 @@ describe("generateCourseHomeMarkdown", () => {
     sandbox.restore()
   })
 
-  it(`sets the title of the page to "Course Home"`, () => {
-    const expectedValue = "Course Home"
+  it(`sets the title of the page to an empty string for course pages`, () => {
+    const expectedValue = ""
     const foundValue = courseHomeFrontMatter["title"]
     assert.equal(expectedValue, foundValue)
   })
@@ -269,7 +269,7 @@ describe("generateCourseHomeMarkdown", () => {
     courseHomeMarkdown = markdownGenerators.generateCourseHomeMarkdown(
       singleCourseJsonData
     )
-    assert.include(courseHomeMarkdown, "title: Course Home")
+    assert.include(courseHomeMarkdown, "title: ''")
   })
 
   it("handles an empty string for instructors", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #141 

#### What's this PR do?
Makes the title an empty string for course pages instead of `Course Home`. hugo-course-publisher will construct the title from course information instead.

#### How should this be manually tested?
Look at the title of a course page and its section pages. They should all have titles where the course home page title starts with the name of the course and the section pages include the name of the course after "Syllabus" or whatever the section page is.