### PR TITLE
[draft] implement caching of converted markdown, data between builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# ocw-to-hugo's cource cache
+.cache
+
 # C extensions
 *.so
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# ocw-to-hugo's cource cache
-.cache
-
 # C extensions
 *.so
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "markdown-doc-builder": "^1.3.0",
     "moment": "^2.29.1",
     "string-strip-html": "^6.1.1",
+    "tar": "^6.0.5",
     "title-case": "^3.0.2",
     "tmp": "^0.2.1",
     "turndown": "^7.0.0",

--- a/src/aws_sync.js
+++ b/src/aws_sync.js
@@ -7,7 +7,7 @@ require("dotenv").config()
 const cliProgress = require("cli-progress")
 const loggers = require("./loggers")
 
-const { createOrOverwriteFile } = require("./helpers")
+const { createOrOverwriteFile } = require("./fs_utils")
 
 const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -59,6 +59,11 @@ const options = yargs
     type:         "boolean",
     demandOption: false
   }).argv
+  .option("no-cache", {
+    describe: "Skip the cache and convert all input courses",
+    type: "boolean",
+    demandOption: false
+  })
 
 helpers.runOptions = options
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -58,12 +58,12 @@ const options = yargs
       "Recursively remove the contents of the destination directory before conversion",
     type:         "boolean",
     demandOption: false
-  }).argv
-  .option("no-cache", {
-    describe: "Skip the cache and convert all input courses",
-    type: "boolean",
-    demandOption: false
   })
+  .option("no-cache", {
+    describe:     "Skip the cache and convert all input courses",
+    type:         "boolean",
+    demandOption: false
+  }).argv
 
 helpers.runOptions = options
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,50 @@
+const fs = require("fs")
+const path = require("path")
+const tar = require("tar")
+
+const isDirectory = pathname => fs.statSync(pathname).isDirectory()
+
+// returns an array of all files and directories within a directory
+const directoryTree = pathname =>
+  fs.readdirSync(pathname).reduce((acc, child) => {
+    const childPathname = path.join(pathname, child)
+
+    return isDirectory(childPathname)
+      ? acc.concat(childPathname, directoryTree(childPathname))
+      : acc.concat(childPathname)
+  }, [])
+
+// scan all files and directories in a path to get the most recent modified time
+const lastModifiedDate = pathname =>
+  directoryTree(pathname)
+    .map(pathname => fs.statSync(pathname).mtime)
+    .reduce((latest, current) => (latest < current ? current : latest))
+
+const ensureCacheDir = () => {
+  if (!fs.existsSync(".cache")) {
+    fs.mkdirSync(".cache")
+  }
+}
+
+const cacheCourseContent = (markdownPath, courseKey, cacheName) => {
+  ensureCacheDir()
+
+  tar.c(
+    {
+      gzip: true,
+      C: markdownPath
+    },
+    [ courseKey ]
+  ).pipe(fs.createWriteStream(
+    `.cache/${courseKey}_markdown.tgz`
+  ))
+}
+
+const cacheCourseData = (dataTemplatePath, courseKey) => {
+  fs.copyFileSync(
+    dataTemplatePath,
+    `.cache/${courseKey}.json`
+  )
+}
+
+module.exports = { cacheCourseContent, cacheCourseData } 

--- a/src/cache.js
+++ b/src/cache.js
@@ -25,7 +25,6 @@ const stale = async (courseId, inputPath) => {
   const haveCacheEntry = await fileExists(courseContentCachePath(courseId))
 
   if (!haveCacheEntry) {
-    console.log(`${courseId} is missing`);
     return true
   }
 
@@ -35,11 +34,6 @@ const stale = async (courseId, inputPath) => {
   ).mtime
 
   const stale = courseLastModified > cacheLastModified
-  if (stale) {
-    console.log(`${courseId} cache miss`);
-  }  else {
-    console.log(`${courseId} cache hit`);
-  }
   return stale
 }
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -4,6 +4,7 @@ const os = require("os")
 const tar = require("tar")
 
 const { lastModifiedDate } = require("./fs_utils")
+const { MARKDOWN_PATH } = require("./paths")
 
 const cacheDirectory = () => path.resolve(os.homedir(), ".cache", "ocw-to-hugo")
 
@@ -18,23 +19,23 @@ const ensureCacheDir = () => {
 const courseContentCachePath = courseKey =>
   path.resolve(CACHE_DIR, `${courseKey}_markdown.tgz`)
 
-const saveCourseContent = async (markdownPath, courseKey) => {
+const saveCourseContent = async (courseKey) => {
   ensureCacheDir()
 
   await tar.c(
     {
       gzip: true,
-      C:    markdownPath,
+      C:    MARKDOWN_PATH,
       file: courseContentCachePath(courseKey)
     },
     [courseKey]
   )
 }
 
-const loadCourseContent = (markdownPath, courseKey) => {
+const loadCourseContent = (courseKey) => {
   fs.createReadStream(courseContentCachePath(courseKey)).pipe(
     tar.x({
-      C: markdownPath // alias for cwd:'some-dir', also ok
+      C: MARKDOWN_PATH // alias for cwd:'some-dir', also ok
     })
   )
 }

--- a/src/cache.js
+++ b/src/cache.js
@@ -4,7 +4,7 @@ const os = require("os")
 const tar = require("tar")
 
 const { lastModifiedDate } = require("./fs_utils")
-const { MARKDOWN_PATH } = require("./paths")
+const { MARKDOWN_DIR } = require("./paths")
 
 const cacheDirectory = () => path.resolve(os.homedir(), ".cache", "ocw-to-hugo")
 
@@ -25,7 +25,7 @@ const saveCourseContent = async (courseKey) => {
   await tar.c(
     {
       gzip: true,
-      C:    MARKDOWN_PATH,
+      C:    MARKDOWN_DIR,
       file: courseContentCachePath(courseKey)
     },
     [courseKey]
@@ -35,7 +35,7 @@ const saveCourseContent = async (courseKey) => {
 const loadCourseContent = (courseKey) => {
   fs.createReadStream(courseContentCachePath(courseKey)).pipe(
     tar.x({
-      C: MARKDOWN_PATH // alias for cwd:'some-dir', also ok
+      C: MARKDOWN_DIR // alias for cwd:'some-dir', also ok
     })
   )
 }

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -16,7 +16,7 @@ const helpers = require("./helpers")
 const cache = require("./cache")
 const { directoryExists, createOrOverwriteFile } = require("./fs_utils")
 
-const { courseContentPath, dataTemplatePath } = require("./paths")
+const { courseContentPath, dataTemplatePath, getMasterJsonFileName } = require("./paths")
 
 const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },
@@ -129,30 +129,13 @@ const scanCourse = async (inputPath, outputPath, course, courseUidsLookup) => {
     } else {
       await cache.load(courseId)
     }
-  }
-}
-
-const getMasterJsonFileName = async coursePath => {
-  /*
-    This function scans a course directory for a master json file and returns it
-  */
-  if (await directoryExists(coursePath)) {
-    // If the item is indeed a directory, read all files in it
-    const contents = await fsPromises.readdir(coursePath)
-    const fileName = contents.find(file => RegExp(".*_parsed.json$").test(file))
-    if (fileName) {
-      return path.join(coursePath, fileName)
+  } else {
+    if (helpers.runOptions.courses) {
+      const courseError = `${inputDataPath} - ${MISSING_COURSE_ERROR_MESSAGE}`
+      // if the script is filtering on courses, this should be a fatal error
+      throw new Error(courseError)
     }
   }
-  //  If we made it here, the master json file wasn't found
-  const courseError = `${coursePath} - ${MISSING_COURSE_ERROR_MESSAGE}`
-  if (helpers.runOptions.courses) {
-    // if the script is filtering on courses, this should be a fatal error
-    throw new Error(courseError)
-  }
-
-  // else, skip this one and go to the next course
-  progressBar.increment()
 }
 
 const writeMarkdownFilesRecursive = async (outputPath, markdownData) => {

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -16,7 +16,7 @@ const helpers = require("./helpers")
 const cache = require("./cache")
 const { directoryExists, createOrOverwriteFile } = require("./fs_utils")
 
-const { MARKDOWN_PATH } = require("./paths")
+const { MARKDOWN_DIR } = require("./paths")
 
 const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },
@@ -117,7 +117,7 @@ const scanCourse = async (inputPath, outputPath, course, courseUidsLookup) => {
     const dataTemplate = dataTemplateGenerators.generateDataTemplate(courseData)
 
     await writeMarkdownFilesRecursive(
-      path.join(MARKDOWN_PATH, courseData["short_url"]),
+      path.join(MARKDOWN_DIR, courseData["short_url"]),
       markdownData
     )
     // cache.loadCourseContent(

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -16,6 +16,8 @@ const helpers = require("./helpers")
 const cache = require("./cache")
 const { directoryExists, createOrOverwriteFile } = require("./fs_utils")
 
+const { MARKDOWN_PATH } = require("./paths")
+
 const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },
   cliProgress.Presets.shades_classic
@@ -103,11 +105,10 @@ const scanCourse = async (inputPath, outputPath, course, courseUidsLookup) => {
   /*
     This function scans a course directory for a master json file and processes it
   */
-  const markdownPath = path.join(outputPath, "content", "courses")
   const courseMarkdownPath = path.join(inputPath, course)
   const masterJsonFile = await getMasterJsonFileName(courseMarkdownPath)
-  if (masterJsonFile) {
 
+  if (masterJsonFile) {
     const courseData = JSON.parse(await fsPromises.readFile(masterJsonFile))
     const markdownData = markdownGenerators.generateMarkdownFromJson(
       courseData,
@@ -116,7 +117,7 @@ const scanCourse = async (inputPath, outputPath, course, courseUidsLookup) => {
     const dataTemplate = dataTemplateGenerators.generateDataTemplate(courseData)
 
     await writeMarkdownFilesRecursive(
-      path.join(markdownPath, courseData["short_url"]),
+      path.join(MARKDOWN_PATH, courseData["short_url"]),
       markdownData
     )
     // cache.loadCourseContent(
@@ -125,7 +126,6 @@ const scanCourse = async (inputPath, outputPath, course, courseUidsLookup) => {
     // )
 
     cache.saveCourseContent(
-      markdownPath,
       courseData["short_url"],
     )
 

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -16,7 +16,7 @@ const helpers = require("./helpers")
 const cache = require("./cache")
 const { directoryExists, createOrOverwriteFile } = require("./fs_utils")
 
-const { markdownDir, dataTemplatePath } = require("./paths")
+const { courseContentPath, dataTemplatePath } = require("./paths")
 
 const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },
@@ -86,7 +86,6 @@ const scanCourses = async (inputPath, outputPath) => {
   console.log(`Converting ${numCourses} courses to Hugo markdown...`)
   progressBar.start(numCourses, 0)
   for (const course of courseList) {
-    // caching logic will go here
     await scanCourse(inputPath, outputPath, course, courseUidsLookup)
     progressBar.increment()
   }
@@ -106,14 +105,13 @@ const scanCourse = async (inputPath, outputPath, course, courseUidsLookup) => {
     This function scans a course directory for a master json file and processes it
   */
   const inputDataPath = path.join(inputPath, course)
-  console.log(inputDataPath)
   const masterJsonFile = await getMasterJsonFileName(inputDataPath)
 
   if (masterJsonFile) {
     const courseData = JSON.parse(await fsPromises.readFile(masterJsonFile))
     const courseId = courseData["short_url"]
 
-    if (cache.stale(courseId, inputDataPath)) {
+    if (await cache.stale(courseId, inputDataPath)) {
       const markdownData = markdownGenerators.generateMarkdownFromJson(
         courseData,
         courseUidsLookup

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -14,7 +14,7 @@ const helpers = require("./helpers")
 const fileOperations = require("./file_operations")
 const markdownGenerators = require("./markdown_generators")
 const dataTemplateGenerators = require("./data_template_generators")
-const { fileExists } = require("./helpers")
+const { fileExists, createOrOverwriteFile } = require("./fs_utils")
 
 const testDataPath = "test_data/courses"
 const singleCourseId =
@@ -59,10 +59,7 @@ describe("writeBoilerplate", () => {
   it("clears the destination directory if the argument is passed to do so", async () => {
     const outputPath = tmp.dirSync({ prefix: "output" }).name
     const testFilePath = path.join(outputPath, "test.txt")
-    await helpers.createOrOverwriteFile(
-      testFilePath,
-      "this file should be removed"
-    )
+    await createOrOverwriteFile(testFilePath, "this file should be removed")
     await fileOperations.writeBoilerplate(outputPath, true)
     const testFileExists = await fileExists(testFilePath)
     assert.isFalse(testFileExists)

--- a/src/fs_utils.js
+++ b/src/fs_utils.js
@@ -1,0 +1,54 @@
+const fsPromises = require("./fsPromises")
+const fs = require("fs")
+const path = require("path")
+
+const directoryExists = async directory => {
+  try {
+    return (await fsPromises.lstat(directory)).isDirectory()
+  } catch (err) {
+    // this will happen if we don't have access to the directory or if it doesn't exist
+    return false
+  }
+}
+
+const fileExists = async path => {
+  try {
+    return (await fsPromises.lstat(path)).isFile()
+  } catch (err) {
+    // this will happen if we don't have access to the file or if it doesn't exist
+    return false
+  }
+}
+
+const createOrOverwriteFile = async (file, body) => {
+  const dirName = path.dirname(file)
+  await fsPromises.mkdir(dirName, { recursive: true })
+  await fsPromises.writeFile(file, body)
+}
+
+const isDirectory = pathname => fs.statSync(pathname).isDirectory()
+
+// returns an array of all files and directories within a directory
+const directoryTree = pathname =>
+  fs.readdirSync(pathname).reduce((acc, child) => {
+    const childPathname = path.join(pathname, child)
+
+    return isDirectory(childPathname)
+      ? acc.concat(childPathname, directoryTree(childPathname))
+      : acc.concat(childPathname)
+  }, [])
+
+// scan all files and directories in a path to get the most recent modified time
+const lastModifiedDate = pathname =>
+  directoryTree(pathname)
+    .map(pathname => fs.statSync(pathname).mtime)
+    .reduce((latest, current) => (latest < current ? current : latest))
+
+module.exports = {
+  directoryExists,
+  fileExists,
+  createOrOverwriteFile,
+  isDirectory,
+  directoryTree,
+  lastModifiedDate
+}

--- a/src/fs_utils.js
+++ b/src/fs_utils.js
@@ -20,10 +20,15 @@ const fileExists = async path => {
   }
 }
 
-const createOrOverwriteFile = async (file, body) => {
-  const dirName = path.dirname(file)
+const ensureDirnameExists = async (filePath) => {
+  const dirName = path.dirname(filePath)
   await fsPromises.mkdir(dirName, { recursive: true })
-  await fsPromises.writeFile(file, body)
+}
+
+
+const createOrOverwriteFile = async (filePath, body) => {
+  await ensureDirnameExists(filePath)
+  await fsPromises.writeFile(filePath, body)
 }
 
 const isDirectory = pathname => fs.statSync(pathname).isDirectory()
@@ -48,6 +53,7 @@ module.exports = {
   directoryExists,
   fileExists,
   createOrOverwriteFile,
+  ensureDirnameExists,
   isDirectory,
   directoryTree,
   lastModifiedDate

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,6 @@
 const _ = require("lodash")
 const path = require("path")
 
-const fsPromises = require("./fsPromises")
 const DEPARTMENTS_JSON = require("./departments.json")
 const {
   AWS_REGEX,
@@ -15,31 +14,6 @@ const runOptions = {}
 const distinct = (value, index, self) => {
   return self.indexOf(value) === index
 }
-
-const directoryExists = async directory => {
-  try {
-    return (await fsPromises.lstat(directory)).isDirectory()
-  } catch (err) {
-    // this will happen if we don't have access to the directory or if it doesn't exist
-    return false
-  }
-}
-
-const fileExists = async path => {
-  try {
-    return (await fsPromises.lstat(path)).isFile()
-  } catch (err) {
-    // this will happen if we don't have access to the file or if it doesn't exist
-    return false
-  }
-}
-
-const createOrOverwriteFile = async (file, body) => {
-  const dirName = path.dirname(file)
-  await fsPromises.mkdir(dirName, { recursive: true })
-  await fsPromises.writeFile(file, body)
-}
-
 const findDepartmentByNumber = departmentNumber =>
   DEPARTMENTS_JSON.find(
     department => department["depNo"] === departmentNumber.toString()
@@ -397,9 +371,6 @@ const unescapeBackticks = text => text.replace(/\\`/g, "&grave;")
 
 module.exports = {
   distinct,
-  directoryExists,
-  createOrOverwriteFile,
-  fileExists,
   findDepartmentByNumber,
   getDepartments,
   getCourseNumbers,

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,0 +1,14 @@
+const { runOptions } = require("./helpers")
+
+// module for declaring key filepaths in one place
+const MARKDOWN_PATH = path.join(
+  runOptions.output,
+  "content",
+  "courses"
+)
+
+const DATA_TEMPLATE_DIR = path.join(
+  runOptions.output,
+  "data",
+  "courses"
+)

--- a/src/paths.js
+++ b/src/paths.js
@@ -8,7 +8,7 @@ const markdownDir = () =>
 
 const courseContentPath = courseId => path.join(markdownDir(), courseId)
 
-const dataTemplateDir = path.join(helpers.runOptions.output, "data", "courses")
+const dataTemplateDir = () => path.join(helpers.runOptions.output, "data", "courses")
 
 const dataTemplatePath = courseId =>
   path.join(dataTemplateDir(), `${courseId}.json`)

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,7 +1,7 @@
 const { runOptions } = require("./helpers")
 
 // module for declaring key filepaths in one place
-const MARKDOWN_PATH = path.join(
+const MARKDOWN_DIR = path.join(
   runOptions.output,
   "content",
   "courses"

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,5 +1,8 @@
 const path = require("path")
 const os = require("os")
+const fsPromises = require("./fsPromises")
+const { directoryExists, isDirectory } = require("./fs_utils")
+const fs = require("fs")
 
 const helpers = require("./helpers")
 
@@ -22,6 +25,23 @@ const courseContentCachePath = courseKey =>
 const dataTemplateCachePath = courseId =>
   path.resolve(CACHE_DIR, `${courseId}.json`)
 
+const parsed_regex = /.*_parsed.json$/
+const getMasterJsonFileName = async coursePath => {
+  /*
+    This function scans a course directory for a master json file and returns it
+  */
+  if (await directoryExists(coursePath)) {
+  // if (isDirectory(coursePath)) {
+    // If the item is indeed a directory, read all files in it
+    const contents = await fsPromises.readdir(coursePath)
+    // const contents = fs.readdirSync(coursePath)
+    const fileName = contents.find(file => parsed_regex.test(file))
+    if (fileName) {
+      return path.join(coursePath, fileName)
+    }
+  }
+}
+
 module.exports = {
   markdownDir,
   courseContentPath,
@@ -29,5 +49,6 @@ module.exports = {
   dataTemplatePath,
   CACHE_DIR,
   courseContentCachePath,
-  dataTemplateCachePath
+  dataTemplateCachePath,
+  getMasterJsonFileName
 }

--- a/src/paths.js
+++ b/src/paths.js
@@ -1,14 +1,33 @@
-const { runOptions } = require("./helpers")
+const path = require("path")
+const os = require("os")
 
-// module for declaring key filepaths in one place
-const MARKDOWN_DIR = path.join(
-  runOptions.output,
-  "content",
-  "courses"
-)
+const helpers = require("./helpers")
 
-const DATA_TEMPLATE_DIR = path.join(
-  runOptions.output,
-  "data",
-  "courses"
-)
+const markdownDir = () =>
+  path.join(helpers.runOptions.output, "content", "courses")
+
+const courseContentPath = courseId => path.join(markdownDir(), courseId)
+
+const dataTemplateDir = path.join(helpers.runOptions.output, "data", "courses")
+
+const dataTemplatePath = courseId =>
+  path.join(dataTemplateDir(), `${courseId}.json`)
+
+const cacheDirectory = () => path.resolve(os.homedir(), ".cache", "ocw-to-hugo")
+const CACHE_DIR = cacheDirectory()
+
+const courseContentCachePath = courseKey =>
+  path.resolve(CACHE_DIR, `${courseKey}_markdown.tgz`)
+
+const dataTemplateCachePath = courseId =>
+  path.resolve(CACHE_DIR, `${courseId}.json`)
+
+module.exports = {
+  markdownDir,
+  courseContentPath,
+  dataTemplateDir,
+  dataTemplatePath,
+  CACHE_DIR,
+  courseContentCachePath,
+  dataTemplateCachePath
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,6 +493,11 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -1114,6 +1119,13 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1626,12 +1638,32 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minipass@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mkdirp@0.5.4, mkdirp@^0.5.1:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
   integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^6.2.2:
   version "6.2.3"
@@ -2563,6 +2595,18 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tar@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
+  integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 text-hex@1.0.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
@@ -2794,6 +2838,11 @@ y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
draft implementation of caching. basically this saves converted courses as gzipped tar archives and copies the course data JSON files to the cache directory (`~/.cache/ocw-to-hugo` for now). then when running a conversion it checks to see if the input data is older than the cached archive. If the input data is older than the archive it inflates the archive in the output directory instead of running the conversion. This saves us from having to run the expensive html -> markdown conversion for courses which haven't changed since the last time the program has been run.

note that, as a draft implementation, things are still messy:

- I freely mixed async and sync `fs` methods
- no tests have been written
- options like `--no-cache` (to turn the functionality off altogether) and an option for setting the cache location aren't set up