### PR TITLE
Change PDF extension handling to be case insensitive

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -431,7 +431,7 @@ const stripSuffix = suffix => text => {
 const stripPdfSuffix = stripSuffix(".pdf")
 
 const replaceSubstring = (text, index, length, substring) =>
-  `${text.substr(0, index)}${substring}${text.substr(index + length)}`
+  `${text.substring(0, index)}${substring}${text.substring(index + length)}`
 
 module.exports = {
   distinct,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -185,6 +185,47 @@ const getHugoPathSuffix = (page, courseData) => {
   return isParent || hasFiles ? "/_index.md" : ""
 }
 
+const resolveUidForLink = (url, courseData, courseUidsLookup, pagePath) => {
+  const urlParts = url.split("/")
+  const uid = urlParts[urlParts.length - 1]
+  // filter course_pages on the UID in the URL
+  const linkedPage = courseData["course_pages"].find(
+    coursePage => coursePage["uid"] === uid
+  )
+  // filter course_files on the UID in the URL
+  const linkedFile = courseData["course_files"].find(
+    file => file["uid"] === uid
+  )
+  const linkedCourse = courseUidsLookup[uid]
+  if (linkedPage) {
+    // a course_page has been found for this UID
+    const linkPagePath = `${pathToChildRecursive(
+      path.join("courses", courseData["short_url"], "sections"),
+      linkedPage,
+      courseData
+    )}${getHugoPathSuffix(linkedPage, courseData)}`
+    return `${GETPAGESHORTCODESTART}${linkPagePath}${GETPAGESHORTCODEEND}`
+  } else if (linkedFile) {
+    // a course_file has been found for this UID
+    if (linkedFile["file_type"] === "application/pdf") {
+      // create a link to the generated PDF viewer page for this PDF file
+      const pdfPath = `${pagePath.replace("/_index.md", "/")}${
+        linkedFile["id"]
+      }`
+      return `${GETPAGESHORTCODESTART}${stripPdfSuffix(
+        pdfPath
+      )}${GETPAGESHORTCODEEND}`
+    } else {
+      // link directly to the static content
+      return stripS3(linkedFile["file_location"])
+    }
+  } else if (linkedCourse) {
+    return `/courses/${linkedCourse}`
+  }
+
+  return url
+}
+
 /**
  * @param {string} htmlStr
  * @param {object} page
@@ -205,64 +246,30 @@ const resolveUids = (htmlStr, page, courseData, courseUidsLookup) => {
       courseData
     )}${getHugoPathSuffix(page, courseData)}`
     // iterate all resolveuid links by regex match
-    Array.from(htmlStr.matchAll(/\.?\/?resolveuid\/.{0,32}/g)).forEach(
-      match => {
-        /**
-         * resolveuid links are formatted as, for example:
-         *
-         * href="./resolveuid/b463875b69d4156b90faaeb0dd7ca66b"
-         *
-         * the UID is the only part we need, so we split the string on "/" and
-         * take the last part
-         */
-        const url = match[0]
-        const urlParts = url.split("/")
-        const uid = urlParts[urlParts.length - 1]
-        // filter course_pages on the UID in the URL
-        const linkedPage = courseData["course_pages"].find(
-          coursePage => coursePage["uid"] === uid
-        )
-        // filter course_files on the UID in the URL
-        const linkedFile = courseData["course_files"].find(
-          file => file["uid"] === uid
-        )
-        const linkedCourse = courseUidsLookup[uid]
-        if (linkedPage) {
-          // a course_page has been found for this UID
-          const linkPagePath = `${pathToChildRecursive(
-            path.join("courses", courseData["short_url"], "sections"),
-            linkedPage,
-            courseData
-          )}${getHugoPathSuffix(linkedPage, courseData)}`
-          htmlStr = htmlStr.replace(
-            url,
-            `${GETPAGESHORTCODESTART}${linkPagePath}${GETPAGESHORTCODEEND}`
-          )
-        }
-        if (linkedFile) {
-          // a course_file has been found for this UID
-          if (linkedFile["file_type"] === "application/pdf") {
-            // create a link to the generated PDF viewer page for this PDF file
-            const pdfPath = `${pagePath.replace("/_index.md", "/")}${
-              linkedFile["id"]
-            }`
-            htmlStr = htmlStr.replace(
-              url,
-              `${GETPAGESHORTCODESTART}${pdfPath.replace(
-                ".pdf",
-                ""
-              )}${GETPAGESHORTCODEEND}`
-            )
-          } else {
-            // link directly to the static content
-            htmlStr = stripS3(htmlStr.replace(url, linkedFile["file_location"]))
-          }
-        }
-        if (linkedCourse) {
-          htmlStr = htmlStr.replace(url, `/courses/${linkedCourse}`)
-        }
-      }
-    )
+    const matches = Array.from(htmlStr.matchAll(/\.?\/?resolveuid\/.{0,32}/g))
+    matches.reverse() // handle last match first so indexes for other matches aren't affected
+    matches.forEach(match => {
+      /**
+       * resolveuid links are formatted as, for example:
+       *
+       * href="./resolveuid/b463875b69d4156b90faaeb0dd7ca66b"
+       *
+       * the UID is the only part we need, so we split the string on "/" and
+       * take the last part
+       */
+      const replacement = resolveUidForLink(
+        match[0],
+        courseData,
+        courseUidsLookup,
+        pagePath
+      )
+      htmlStr = replaceSubstring(
+        htmlStr,
+        match.index,
+        match[0].length,
+        replacement
+      )
+    })
   } catch (err) {
     loggers.fileLogger.error(err)
   }
@@ -335,7 +342,7 @@ const resolveRelativeLinks = (htmlStr, courseData) => {
                   // construct url to Hugo PDF viewer page
                   const newUrl = `${GETPAGESHORTCODESTART}${path.join(
                     newUrlBase,
-                    page.replace(".pdf", "")
+                    stripPdfSuffix(page)
                   )}${GETPAGESHORTCODEEND}`
                   htmlStr = htmlStr.replace(url, newUrl)
                 } else if (media["file_location"].includes(page)) {
@@ -414,6 +421,18 @@ const isCoursePublished = courseData => {
   } else return true
 }
 
+const stripSuffix = suffix => text => {
+  if (text.toLowerCase().endsWith(suffix.toLowerCase())) {
+    return text.slice(0, -suffix.length)
+  }
+  return text
+}
+
+const stripPdfSuffix = stripSuffix(".pdf")
+
+const replaceSubstring = (text, index, length, substring) =>
+  `${text.substr(0, index)}${substring}${text.substr(index + length)}`
+
 module.exports = {
   distinct,
   directoryExists,
@@ -435,5 +454,7 @@ module.exports = {
   stripS3,
   unescapeBackticks,
   isCoursePublished,
-  runOptions
+  runOptions,
+  stripPdfSuffix,
+  replaceSubstring
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -339,3 +339,27 @@ describe("isCoursePublished", () => {
     })
   })
 })
+
+describe("misc functions", () => {
+  it("strips .pdf from the url", () => {
+    assert.equal(helpers.stripPdfSuffix("some text"), "some text")
+    assert.equal(helpers.stripPdfSuffix("some text.pdf"), "some text")
+    assert.equal(helpers.stripPdfSuffix("some text.PDF"), "some text")
+    assert.equal(helpers.stripPdfSuffix("some text.PDF.pdf"), "some text.PDF")
+  })
+
+  it("replaces a substring", () => {
+    assert.equal(
+      helpers.replaceSubstring("there is some text here", 9, 4, "a lot of"),
+      "there is a lot of text here"
+    )
+    assert.equal(
+      helpers.replaceSubstring("there is some text here", 13, 0, " amount of"),
+      "there is some amount of text here"
+    )
+    assert.equal(
+      helpers.replaceSubstring("there is some text here", 9, 5, ""),
+      "there is text here"
+    )
+  })
+})

--- a/src/loggers.js
+++ b/src/loggers.js
@@ -8,7 +8,6 @@ class MemoryTransport extends TransportStream {
   }
 
   log(info, callback) {
-    // console.log(info)
     this.logs.push(info)
     callback()
   }

--- a/src/loggers.js
+++ b/src/loggers.js
@@ -8,6 +8,7 @@ class MemoryTransport extends TransportStream {
   }
 
   log(info, callback) {
+    // console.log(info)
     this.logs.push(info)
     callback()
   }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -115,7 +115,7 @@ const generateMarkdownRecursive = (page, courseUidsLookup, courseData) => {
             return {
               name: `${path.join(
                 pathToChild,
-                file["id"].replace(".pdf", "")
+                helpers.stripPdfSuffix(file["id"])
               )}.md`,
               data: generatePdfMarkdown(file, courseData)
             }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #156 

#### What's this PR do?
Updates `.pdf` string replacement to be case insensitive, and also refactors `resolveUids` to separate the match replacement code from the link resolution code. 

#### How should this be manually tested?
Convert the example courses on master and on this PR. Most content should be identical, but you should see these differences in `16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/sections/thermo-propulsion`:
 - Some links in `_index.md` and `thermodoclist.md`, for example  `.../thermo-propulsion/p4.PDF` should now just be `.../thermo-propulsion/p4`
 - Files that used to look like `p2.PDF.md` should now be `p2.md`, but they are identical
