### PR TITLE
Refactor resolveRelativeLinks

### DIFF
--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -265,7 +265,7 @@ describe("resolveRelativeLinks", () => {
     })
     const text = `${assignmentsPage["text"]} <a href="/courses/mathematics/18-01-single-variable-calculus-fall-2006/exams/prfinalsol.pdf" />`
     delete singleCourseJsonData.course_files[0].file_location
-    const result = helpers.resolveRelativeLinks(text, singleCourseJsonData)
+    helpers.resolveRelativeLinks(text, singleCourseJsonData)
   })
 })
 


### PR DESCRIPTION

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
I did some refactoring of `resolveRelativeLinks` during my work on #157  to make it easier to make changes in the future, and it looks like there are some bug fixes too.

#### How should this be manually tested?
Convert the example courses using the master branch and this one, and compare the results. You should see mostly identical files, except:
 - course `20-020-introduction-to-biological-engineering-design-spring-2009` has a few markdown files where a `GETPAGESHORTCODE` instance used to be added to certain image URLs. I think that was a bug where the prefix of the image URL matched a course page URL. I think at the moment we aren't doing any processing on image URLs, just regular links.
 - `6-042j-mathematics-for-computer-science-spring-2015` has one file `vertical-dcc88d262213.md` which has a similar image link issue, but there is also a link which is being processed correctly where it didn't use to be. To test this, go to the [production](https://ocwnext.odl.mit.edu/courses/6-042j-mathematics-for-computer-science-spring-2015/sections/probability/tp11-2/vertical-dcc88d262213/) page and scroll to the bottom. There should be a link called "BackIntro to Discrete Probability", but the link is broken. If you look at the same link on your local instance it should work correctly.