### PR TITLE
fix image tag rendering

### DIFF
--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -60,7 +60,9 @@ const options = yargs
     demandOption: false
   }).argv
 
-helpers.runOptions = options
+Object.keys(options).forEach(key => {
+  helpers.runOptions[key] = options[key]
+})
 
 const run = async () => {
   if (options.courses && options.download) {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -172,7 +172,9 @@ turndownService.addRule("stripS3", {
   },
   replacement: (content, node, options) => {
     const attr = node.nodeName === "A" ? "href" : "src"
-    return `[${content}](${helpers.stripS3(node.getAttribute(attr))})`
+    const alt = node.getAttribute("alt")
+    const isImage = node.nodeName === "IMG"
+    return `${isImage ? "!" : ""}[${isImage ? alt : content}](${helpers.stripS3(node.getAttribute(attr))})`
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -175,7 +175,9 @@ if (helpers.runOptions.stripS3) {
       const attr = node.nodeName === "A" ? "href" : "src"
       const alt = node.getAttribute("alt")
       const isImage = node.nodeName === "IMG"
-      return `${isImage ? "!" : ""}[${isImage ? alt : content}](${helpers.stripS3(node.getAttribute(attr))})`
+      return `${isImage ? "!" : ""}[${
+        isImage ? alt : content
+      }](${helpers.stripS3(node.getAttribute(attr))})`
     }
   })
 }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -157,26 +157,28 @@ turndownService.addRule("anchorshortcode", {
 /**
  * Strip open-learning-course-data*.s3.amazonaws.com urls back to being absolute urls
  */
-turndownService.addRule("stripS3", {
-  filter: (node, options) => {
-    if (node.nodeName === "A" && node.getAttribute("href")) {
-      if (node.getAttribute("href").match(AWS_REGEX)) {
-        return true
+if (helpers.runOptions.stripS3) {
+  turndownService.addRule("stripS3", {
+    filter: (node, options) => {
+      if (node.nodeName === "A" && node.getAttribute("href")) {
+        if (node.getAttribute("href").match(AWS_REGEX)) {
+          return true
+        }
+      } else if (node.nodeName === "IMG" && node.getAttribute("src")) {
+        if (node.getAttribute("src").match(AWS_REGEX)) {
+          return true
+        }
       }
-    } else if (node.nodeName === "IMG" && node.getAttribute("src")) {
-      if (node.getAttribute("src").match(AWS_REGEX)) {
-        return true
-      }
+      return false
+    },
+    replacement: (content, node, options) => {
+      const attr = node.nodeName === "A" ? "href" : "src"
+      const alt = node.getAttribute("alt")
+      const isImage = node.nodeName === "IMG"
+      return `${isImage ? "!" : ""}[${isImage ? alt : content}](${helpers.stripS3(node.getAttribute(attr))})`
     }
-    return false
-  },
-  replacement: (content, node, options) => {
-    const attr = node.nodeName === "A" ? "href" : "src"
-    const alt = node.getAttribute("alt")
-    const isImage = node.nodeName === "IMG"
-    return `${isImage ? "!" : ""}[${isImage ? alt : content}](${helpers.stripS3(node.getAttribute(attr))})`
-  }
-})
+  })
+}
 
 // add support for embedded content from various sources
 turndownService.addRule("iframe", {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/165
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/9

#### What's this PR do?
This PR fixes a bug where `img` tags were being transformed into markdown link syntax.  The issue was caused partially by the `strips3` turndown rule being added without checking to see if it was enabled first.  Either way though, when the source tag is `img`, image markdown syntax should be rendered. 

#### How should this be manually tested?
 - Convert `6-034-artificial-intelligence-fall-2010` to markdown
 - Ensure that `6-034-artificial-intelligence-fall-2010/sections/instructor-insights/_index.md` has an image rendered like this:
```
![Man in a blue shirt sounding outside a lab. The man has one arm positioned on his hip. He is smiling.](https://open-learning-course-data-production.s3.amazonaws.com/6-034-artificial-intelligence-fall-2010/c91b44488e85cb8717b2cea9bb11dbd5_PatrickWinston.jpg)  
```
 - Run the above test both with `--strips3 --staticPrefix /coursemedia` and without.  The only difference should be a fully qualified S3 URL when these options are not passed in.  With the options passed in,  the URL should be `/coursemedia/6-034-artificial-intelligence-fall-2010/c91b44488e85cb8717b2cea9bb11dbd5_PatrickWinston.jpg`.


#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/104780521-ee2e2800-574e-11eb-8280-006163d04f32.png)
