### PR TITLE
add instructor_insights layout

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -78,8 +78,8 @@ const generateMarkdownRecursive = (page, courseUidsLookup, courseData) => {
   const parent = hasParent ? parents[0] : null
   const inRootNav = page["parent_uid"] === courseData["uid"]
   const isInstructorInsightsSection =
-    page["short_url"] === "instructor-insights" ||
-    (hasParent && parent["short_url"] === "instructor-insights")
+    page["type"] === "ThisCourseAtMITSection" ||
+    (hasParent && parent["type"] === "ThisCourseAtMITSection")
   const layout = isInstructorInsightsSection
     ? "instructor_insights"
     : "course_section"

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -79,7 +79,9 @@ const generateMarkdownRecursive = (page, courseUidsLookup, courseData) => {
   const inRootNav = page["parent_uid"] === courseData["uid"]
   const isInstructorInsightsSection =
     page["type"] === "ThisCourseAtMITSection" ||
-    (hasParent && parent["type"] === "ThisCourseAtMITSection")
+    page["short_url"] === "instructor-insights" ||
+    (hasParent && parent["type"] === "ThisCourseAtMITSection") ||
+    (hasParent && parent["short_url"] === "instructor-insights")
   const layout = isInstructorInsightsSection
     ? "instructor_insights"
     : "course_section"

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -77,8 +77,15 @@ const generateMarkdownRecursive = (page, courseUidsLookup, courseData) => {
   const hasParent = parents.length > 0
   const parent = hasParent ? parents[0] : null
   const inRootNav = page["parent_uid"] === courseData["uid"]
+  const isInstructorInsightsSection =
+    page["short_url"] === "instructor-insights" ||
+    (hasParent && parent["short_url"] === "instructor-insights")
+  const layout = isInstructorInsightsSection
+    ? "instructor_insights"
+    : "course_section"
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
+    layout,
     page["short_page_title"],
     page["uid"],
     hasParent ? parent["uid"] : null,
@@ -218,6 +225,7 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
 
 const generateCourseSectionFrontMatter = (
   title,
+  layout,
   shortTitle,
   pageId,
   parentId,
@@ -235,7 +243,7 @@ const generateCourseSectionFrontMatter = (
     title:     title,
     course_id: courseId,
     type:      "course",
-    layout:    "course_section"
+    layout:    layout
   }
 
   if (inRootNav || listInLeftNav) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -297,6 +297,7 @@ describe("generateCourseSectionFrontMatter", () => {
       markdownGenerators
         .generateCourseSectionFrontMatter(
           "Syllabus",
+          "course_section",
           "Syllabus",
           "syllabus",
           null,
@@ -336,6 +337,7 @@ describe("generateCourseSectionFrontMatter", () => {
       markdownGenerators
         .generateCourseSectionFrontMatter(
           "Syllabus",
+          "course_section",
           "Syllabus",
           "syllabus",
           null,
@@ -355,6 +357,7 @@ describe("generateCourseSectionFrontMatter", () => {
       markdownGenerators
         .generateCourseSectionFrontMatter(
           "Syllabus",
+          "course_section",
           "Syllabus",
           "syllabus",
           null,
@@ -377,6 +380,7 @@ describe("generateCourseSectionFrontMatter", () => {
   it("handles missing short_page_title correctly", async () => {
     const yaml = markdownGenerators.generateCourseSectionFrontMatter(
       "Syllabus",
+      "course_section",
       "Syllabus",
       "syllabus",
       null,

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -193,6 +193,26 @@ describe("generateMarkdownFromJson", () => {
       assertCourseIdRecursive(sectionMarkdownData, singleCourseId)
     })
   })
+
+  it("sets the instructor_insights layout on Instructor Insights pages", () => {
+    const markdownData = markdownGenerators.generateMarkdownFromJson(
+      imageGalleryCourseJsonData
+    )
+    markdownData.forEach(sectionMarkdownData => {
+      const frontMatter = yaml.safeLoad(
+        sectionMarkdownData["data"].split("---\n")[1]
+      )
+      if (frontMatter["uid"] === "1c2cb2ad1c70fd66f19e20103dc94595") {
+        assert.equal(frontMatter["layout"], "instructor_insights")
+        sectionMarkdownData["children"].forEach(child => {
+          const childFrontMatter = yaml.safeLoad(
+            child["data"].split("---\n")[1]
+          )
+          assert.equal(childFrontMatter["layout"], "instructor_insights")
+        })
+      }
+    })
+  })
 })
 
 describe("generateCourseHomeMarkdown", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/9

#### What's this PR do?
This PR sets the `layout` front matter value on Instructor Insights pages to `instructor_insights` so that a layout may be defined specifically for these pages in `ocw-course-hugo-theme`.

#### How should this be manually tested?
Convert any course that contains an Instructor Insights section (for example, `6-034-artificial-intelligence-fall-2010`) and ensure that the markdown representing that section and any children has the front matter `layout` property set to `instructor_insights`.
