### PR TITLE
add quote shortcode

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -404,6 +404,8 @@ const stripS3 = text => {
   } else return text
 }
 
+const escapeDoubleQuotes = text => text.replace(/"/g, "&quot;")
+
 const unescapeBackticks = text => text.replace(/\\`/g, "&grave;")
 
 const isCoursePublished = courseData => {
@@ -454,6 +456,7 @@ module.exports = {
   resolveYouTubeEmbed,
   htmlSafeText,
   stripS3,
+  escapeDoubleQuotes,
   unescapeBackticks,
   isCoursePublished,
   runOptions,

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -216,7 +216,7 @@ turndownService.addRule("getpageshortcode", {
     return false
   },
   replacement: (content, node, options) => {
-    const children = Array.prototype.slice.call(node.childNodes)
+    const children = Array.from(node.childNodes)
     if (!children.filter(child => child.nodeName === "IMG").length > 0) {
       // if this link doesn't contain an image, escape the content
       // except first make sure there are no pre-escaped square brackets
@@ -251,7 +251,7 @@ turndownService.addRule("quoteshortcode", {
   },
   replacement: (content, node, options) => {
     try {
-      const children = Array.prototype.slice.call(node.childNodes)
+      const children = Array.from(node.childNodes)
       const quoteP = children.find(
         child =>
           child.nodeName === "P" && child.getAttribute("class") === "quote"

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -259,8 +259,8 @@ turndownService.addRule("quoteshortcode", {
       const sigP = children.find(
         child => child.nodeName === "P" && child.getAttribute("class") === "sig"
       )
-      const quote = quoteP.textContent
-      const sig = sigP.textContent
+      const quote = helpers.escapeDoubleQuotes(quoteP.textContent)
+      const sig = helpers.escapeDoubleQuotes(sigP.textContent)
       return `{{< quote "${quote}" "${sig}" >}}`
     } catch (err) {
       loggers.fileLogger.error(err)

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -238,6 +238,37 @@ turndownService.addRule("getpageshortcode", {
 })
 
 /**
+ * Build quote element shortcodes for instructor insights sections
+ **/
+turndownService.addRule("quoteshortcode", {
+  filter: (node, options) => {
+    if (node.nodeName === "DIV" && node.getAttribute("class")) {
+      if (node.getAttribute("class").includes("pullquote")) {
+        return true
+      }
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    try {
+      const children = Array.prototype.slice.call(node.childNodes)    
+      const quoteP = children.find(
+        child => child.nodeName === "P" && child.getAttribute("class") === "quote"
+      )
+      const sigP = children.find(
+        child => child.nodeName === "P" && child.getAttribute("class") === "sig"
+      )
+      const quote = quoteP.textContent
+      const sig = sigP.textContent
+      return `{{% quote "${quote}" "${sig}" %}}`
+    }
+    catch (err) {
+      loggers.fileLogger.error(err)
+    }
+  }
+})
+
+/**
  * Render h4 tags as an h5 instead
  */
 turndownService.addRule("h4", {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -261,7 +261,7 @@ turndownService.addRule("quoteshortcode", {
       )
       const quote = quoteP.textContent
       const sig = sigP.textContent
-      return `{{% quote "${quote}" "${sig}" %}}`
+      return `{{< quote "${quote}" "${sig}" >}}`
     } catch (err) {
       loggers.fileLogger.error(err)
     }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -251,9 +251,10 @@ turndownService.addRule("quoteshortcode", {
   },
   replacement: (content, node, options) => {
     try {
-      const children = Array.prototype.slice.call(node.childNodes)    
+      const children = Array.prototype.slice.call(node.childNodes)
       const quoteP = children.find(
-        child => child.nodeName === "P" && child.getAttribute("class") === "quote"
+        child =>
+          child.nodeName === "P" && child.getAttribute("class") === "quote"
       )
       const sigP = children.find(
         child => child.nodeName === "P" && child.getAttribute("class") === "sig"
@@ -261,8 +262,7 @@ turndownService.addRule("quoteshortcode", {
       const quote = quoteP.textContent
       const sig = sigP.textContent
       return `{{% quote "${quote}" "${sig}" %}}`
-    }
-    catch (err) {
+    } catch (err) {
       loggers.fileLogger.error(err)
     }
   }

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -101,4 +101,17 @@ describe("turndown", () => {
       "{{< simplecast e31edbb0-e4ac-4d9f-aebc-3d613c2f972c >}}"
     )
   })
+
+  it("should return a quote shortcode for instructor insights quotes", async () => {
+    const inputHTML = `<div class="pullquote right">
+      <p class="quote">I think stories are an important element of education, and if you strip them out, you don't have
+        much left that can possibly be inspiring.</p>
+      <p class="sig">&mdash; Patrick Winston</p>
+    </div>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(
+      markdown,
+      `{{< quote "I think stories are an important element of education, and if you strip them out, you don't have much left that can possibly be inspiring." "— Patrick Winston" >}}`
+    )
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/10

#### What's this PR do?
This PR catches a pattern used in Instructor Insights pages that looks like this:

```html
<div class="pullquote right">
  <p class="quote">I think stories are an important element of education, and if you strip them out, you don't have
    much left that can possibly be inspiring.</p>
  <p class="sig">&mdash; Patrick Winston</p>
</div>
```

and turns them into this:

```md
{{< quote "I think stories are an important element of education, and if you strip them out, you don't have much left that can possibly be inspiring." "— Patrick Winston" >}}
```

This will allow us to implement a custom shortcode in `ocw-course-hugo-theme` to layout / style the information how we want.

#### How should this be manually tested?
Convert `6-034-artificial-intelligence-fall-2010` and inspect the output.  Look specifically at the `teaching-heuristics` page and ensure that the quote on that page has been rendered as a shortcode as shown above.
