### PR TITLE
parent title

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -87,6 +87,7 @@ const generateMarkdownRecursive = (page, courseUidsLookup, courseData) => {
     : "course_section"
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
+    hasParent ? parent["title"] : null,
     layout,
     page["short_page_title"],
     page["uid"],
@@ -227,6 +228,7 @@ const generateCourseHomeMarkdown = (courseData, courseUidsLookup) => {
 
 const generateCourseSectionFrontMatter = (
   title,
+  parentTitle,
   layout,
   shortTitle,
   pageId,
@@ -246,6 +248,10 @@ const generateCourseSectionFrontMatter = (
     course_id: courseId,
     type:      "course",
     layout:    layout
+  }
+
+  if (parentTitle) {
+    courseSectionFrontMatter["parent_title"] = parentTitle
   }
 
   if (inRootNav || listInLeftNav) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -213,6 +213,20 @@ describe("generateMarkdownFromJson", () => {
       }
     })
   })
+
+  it("sets a parent_title property on second tier pages", () => {
+    const markdownData = markdownGenerators.generateMarkdownFromJson(
+      imageGalleryCourseJsonData
+    )
+    markdownData.forEach(sectionMarkdownData => {
+      const frontMatter = yaml.safeLoad(
+        sectionMarkdownData["data"].split("---\n")[1]
+      )
+      if (frontMatter["uid"] === "eb66e88131e84c5dae78ba67407a1fc6") {
+        assert.equal(frontMatter["parent_title"], "Instructor Insights")
+      }
+    })
+  })
 })
 
 describe("generateCourseHomeMarkdown", () => {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -317,6 +317,7 @@ describe("generateCourseSectionFrontMatter", () => {
       markdownGenerators
         .generateCourseSectionFrontMatter(
           "Syllabus",
+          null,
           "course_section",
           "Syllabus",
           "syllabus",
@@ -357,6 +358,7 @@ describe("generateCourseSectionFrontMatter", () => {
       markdownGenerators
         .generateCourseSectionFrontMatter(
           "Syllabus",
+          null,
           "course_section",
           "Syllabus",
           "syllabus",
@@ -377,6 +379,7 @@ describe("generateCourseSectionFrontMatter", () => {
       markdownGenerators
         .generateCourseSectionFrontMatter(
           "Syllabus",
+          null,
           "course_section",
           "Syllabus",
           "syllabus",
@@ -400,6 +403,7 @@ describe("generateCourseSectionFrontMatter", () => {
   it("handles missing short_page_title correctly", async () => {
     const yaml = markdownGenerators.generateCourseSectionFrontMatter(
       "Syllabus",
+      null,
       "course_section",
       "Syllabus",
       "syllabus",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/9

#### What's this PR do?
This PR sets the `parent_title` front matter property on pages that have a parent.

#### How should this be manually tested?
 - Convert a course that has pages with a parent -> child relationship, like `6-034-artificial-intelligence-fall-2010`
 - Inspect the output.  Pages inside the output folder under `content\6-034-artificial-intelligence-fall-2010\sections\instructor-insights\teaching-heuristics` that aren't `_index.md` should have a `parent_title` of `"Instructor Insights"`.
