### PR TITLE
Fix path joining for PDFs

### DIFF
--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -162,12 +162,12 @@ describe("scanCourses", () => {
     )
   })
 
-  it("calls readdir eleven times, once for courses and once for each course", async () => {
+  it("calls readdir many times, once for courses and once for each course", async () => {
     await fileOperations.scanCourses(inputPath, outputPath)
     assert.equal(readdirStub.callCount, 15)
   }).timeout(5000)
 
-  it("scans the four test courses and reports to console", async () => {
+  it("scans the test courses and reports to console", async () => {
     await fileOperations.scanCourses(inputPath, outputPath)
     expect(consoleLog).calledWithExactly(logMessage)
   }).timeout(5000)

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -75,7 +75,7 @@ describe("scanCourses", () => {
   const sandbox = sinon.createSandbox()
   const inputPath = "test_data/courses"
   const outputPath = tmp.dirSync({ prefix: "output" }).name
-  const logMessage = "Converting 6 courses to Hugo markdown..."
+  const logMessage = "Converting 7 courses to Hugo markdown..."
   const course1Name =
     "1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012"
   const course1Path = path.join(inputPath, course1Name)
@@ -164,7 +164,7 @@ describe("scanCourses", () => {
 
   it("calls readdir eleven times, once for courses and once for each course", async () => {
     await fileOperations.scanCourses(inputPath, outputPath)
-    assert.equal(readdirStub.callCount, 13)
+    assert.equal(readdirStub.callCount, 15)
   }).timeout(5000)
 
   it("scans the four test courses and reports to console", async () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -209,9 +209,10 @@ const resolveUidForLink = (url, courseData, courseUidsLookup, pagePath) => {
     // a course_file has been found for this UID
     if (linkedFile["file_type"] === "application/pdf") {
       // create a link to the generated PDF viewer page for this PDF file
-      const pdfPath = `${pagePath.replace("/_index.md", "/")}${
+      const pdfPath = path.join(
+        pagePath.replace("/_index.md", "/"),
         linkedFile["id"]
-      }`
+      )
       return `${GETPAGESHORTCODESTART}${stripPdfSuffix(
         pdfPath
       )}${GETPAGESHORTCODEEND}`


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #173 

#### What's this PR do?
Fixes path joining for PDFs within sub sections

#### How should this be manually tested?
Convert `18-01-single-variable-calculus-fall-2006` and verify that the PDF links on `sections/readings/course-reader/` work correctly.

