### PR TITLE
remove instructor insights pie charts

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -296,6 +296,23 @@ turndownService.addRule("edu_grading", {
 })
 
 /**
+ * Remove pie charts with the surrunding div of class edu_hours_left
+ **/
+turndownService.addRule("edu_hours_left", {
+  filter: (node, options) => {
+    if (node.nodeName === "DIV" && node.getAttribute("class")) {
+      if (node.getAttribute("class").includes("edu_hours_left")) {
+        return true
+      }
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    return ""
+  }
+})
+
+/**
  * Render h4 tags as an h5 instead
  */
 turndownService.addRule("h4", {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -290,7 +290,7 @@ turndownService.addRule("edu_grading", {
           return true
         }
       })
-      .map(child => turndownService.turndown(child.innerHTML))
+      .map(child => turndownService.turndown(child.outerHTML))
       .join("\n")
   }
 })

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -262,7 +262,7 @@ turndownService.addRule("baseurlshortcode", {
 })
 
 /**
- * Remove pie charts with the surrunding div of class edu_grading
+ * Remove pie charts with the surrounding div of class edu_grading
  **/
 turndownService.addRule("edu_grading", {
   filter: (node, options) => {
@@ -296,7 +296,7 @@ turndownService.addRule("edu_grading", {
 })
 
 /**
- * Remove pie charts with the surrunding div of class edu_hours_left
+ * Remove pie charts with the surrounding div of class edu_hours_left
  **/
 turndownService.addRule("edu_hours_left", {
   filter: (node, options) => {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -274,22 +274,24 @@ turndownService.addRule("edu_grading", {
     return false
   },
   replacement: (content, node, options) => {
-    const replacements = []
-    const children = Array.from(node.childNodes)
-    children.forEach(child => {
-      if (
-        !(
-          child.nodeName === "DIV" && child.childNodes[0].nodeName === "CANVAS"
-        ) &&
-        !(
-          child.nodeName === "DIV" &&
-          child.getAttribute("class") === "edu_breakdown_key"
-        )
-      ) {
-        replacements.push(turndownService.turndown(child.innerHTML))
-      }
-    })
-    return replacements.join("\n")
+    // filter out the pie chart and legend, converting the rest to markdown
+    return Array.from(node.childNodes)
+      .filter(child => {
+        if (
+          !(
+            child.nodeName === "DIV" &&
+            child.childNodes[0].nodeName === "CANVAS"
+          ) &&
+          !(
+            child.nodeName === "DIV" &&
+            child.getAttribute("class") === "edu_breakdown_key"
+          )
+        ) {
+          return true
+        }
+      })
+      .map(child => turndownService.turndown(child.innerHTML))
+      .join("\n")
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -274,7 +274,24 @@ turndownService.addRule("edu_grading", {
     return false
   },
   replacement: (content, node, options) => {
-    return ""
+    const replacements = []
+    const children = Array.from(node.childNodes)
+    children.forEach(child => {
+      if (
+        !(
+          child.nodeName === "DIV" && child.childNodes[0].nodeName === "CANVAS"
+        ) &&
+        !(
+          child.nodeName === "DIV" &&
+          child.getAttribute("class") === "edu_breakdown_key"
+        )
+      ) {
+        replacements.push(turndownService.turndown(child.innerHTML))
+      }
+    })
+    const replacement = replacements.join("\n")
+    loggers.fileLogger.info(replacement)
+    return replacement
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -262,6 +262,23 @@ turndownService.addRule("baseurlshortcode", {
 })
 
 /**
+ * Remove pie charts with the surrunding div of class edu_grading
+ **/
+turndownService.addRule("edu_grading", {
+  filter: (node, options) => {
+    if (node.nodeName === "DIV" && node.getAttribute("class")) {
+      if (node.getAttribute("class").includes("edu_grading")) {
+        return true
+      }
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    return ""
+  }
+})
+
+/**
  * Render h4 tags as an h5 instead
  */
 turndownService.addRule("h4", {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -289,9 +289,7 @@ turndownService.addRule("edu_grading", {
         replacements.push(turndownService.turndown(child.innerHTML))
       }
     })
-    const replacement = replacements.join("\n")
-    loggers.fileLogger.info(replacement)
-    return replacement
+    return replacements.join("\n")
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -109,4 +109,26 @@ describe("turndown", () => {
       `{{< quote "I think stories are an important element of education, and if you strip them out, you don't have much left that can possibly be inspiring." "— Patrick Winston" >}}`
     )
   })
+
+  it("should remove pie charts surrounded in a div with the class edu_grading", async () => {
+    const inputHTML = `<div class="onehalf alpha">
+      <p>The students' grades were based on the following activities:</p>
+      <div class="edu_grading" style="clear: both; position: relative;">
+        <div><canvas width="175" height="175" id="canvas5" style="width: 175px; height: 175px;"></canvas>
+          <script>
+            PIE CHART SCRIPT
+          </script>
+        </div>
+        <div class="edu_breakdown_key" style="float: right; width: 185px; margin-top: -180px;">
+          LEGEND
+        </div>
+      </div>
+      <p>"Spiritual" material refers to lectures not considered part of the core skill set; the "<a
+          href="http://web.mit.edu/fnl/volume/254/winston.html">Right Now</a>" material refers to lectures given by
+        what's-happening-right-now guest lecturers.</p>
+    </div>`
+    const markdown = await html2markdown(inputHTML)
+    assert.include(markdown, "The students' grades were based on the following activities:")
+    assert.include(markdown, `"Spiritual" material refers to lectures not considered part of the core skill set; the "[Right Now](http://web.mit.edu/fnl/volume/254/winston.html)" material refers to lectures given by what's-happening-right-now guest lecturers.`)
+  })
 })

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -110,9 +110,9 @@ describe("turndown", () => {
     )
   })
 
-  it("should remove pie charts surrounded in a div with the class edu_grading", async () => {
+  it("should remove pie charts surrounded in a div with the class edu_grading without removing unrelated content", async () => {
     const inputHTML = `<div class="onehalf alpha">
-      <p>The students' grades were based on the following activities:</p>
+      <p>TOP TEXT</p>
       <div class="edu_grading" style="clear: both; position: relative;">
         <div><canvas width="175" height="175" id="canvas5" style="width: 175px; height: 175px;"></canvas>
           <script>
@@ -122,19 +122,16 @@ describe("turndown", () => {
         <div class="edu_breakdown_key" style="float: right; width: 185px; margin-top: -180px;">
           LEGEND
         </div>
+        <h3 class="subsubhead">SUB HEADER TEXT</h3>
+        <p>INSIDE DIV TEXT</p>
+        <div class="clear">&nbsp;</div>
       </div>
-      <p>"Spiritual" material refers to lectures not considered part of the core skill set; the "<a
-          href="http://web.mit.edu/fnl/volume/254/winston.html">Right Now</a>" material refers to lectures given by
-        what's-happening-right-now guest lecturers.</p>
+      <p>OUTSIDE DIV TEXT</p>
     </div>`
     const markdown = await html2markdown(inputHTML)
-    assert.include(
+    assert.equal(
       markdown,
-      "The students' grades were based on the following activities:"
-    )
-    assert.include(
-      markdown,
-      `"Spiritual" material refers to lectures not considered part of the core skill set; the "[Right Now](http://web.mit.edu/fnl/volume/254/winston.html)" material refers to lectures given by what's-happening-right-now guest lecturers.`
+      "TOP TEXT\n\nSUB HEADER TEXT\nINSIDE DIV TEXT\n\nOUTSIDE DIV TEXT"
     )
   })
 })

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -131,7 +131,7 @@ describe("turndown", () => {
     const markdown = await html2markdown(inputHTML)
     assert.equal(
       markdown,
-      "TOP TEXT\n\nSUB HEADER TEXT\nINSIDE DIV TEXT\n\nOUTSIDE DIV TEXT"
+      "TOP TEXT\n\n### SUB HEADER TEXT\nINSIDE DIV TEXT\n\nOUTSIDE DIV TEXT"
     )
   })
 })

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -134,4 +134,31 @@ describe("turndown", () => {
       "TOP TEXT\n\n### SUB HEADER TEXT\nINSIDE DIV TEXT\n\nOUTSIDE DIV TEXT"
     )
   })
+
+  it("should remove pie charts surrounded in a div with the class edu_hours_left", async () => {
+    const inputHTML = `<div style="clear: both; position: relative;"></div>
+      <div class="edu_hours_left"><canvas id="canvas2" height="100" width="100"
+          style="width: 100px; height: 100px;"></canvas>
+        <script type="text/javascript">
+          var pieData = [{
+              value: 28.6,
+              color: "#eee"
+            },
+            {
+              value: 71.4,
+              color: "#931101"
+            }
+    
+          ];
+          var myPie = new Chart(document.getElementById("canvas2").getContext("2d")).Pie(pieData);
+        </script> 25 hours per week
+      </div>
+      <div class="edu_hours_right">
+        RIGHT TEXT
+      </div>
+      <div class="clear">&nbsp;</div>
+    </div>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, "RIGHT TEXT")
+  })
 })

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -128,7 +128,13 @@ describe("turndown", () => {
         what's-happening-right-now guest lecturers.</p>
     </div>`
     const markdown = await html2markdown(inputHTML)
-    assert.include(markdown, "The students' grades were based on the following activities:")
-    assert.include(markdown, `"Spiritual" material refers to lectures not considered part of the core skill set; the "[Right Now](http://web.mit.edu/fnl/volume/254/winston.html)" material refers to lectures given by what's-happening-right-now guest lecturers.`)
+    assert.include(
+      markdown,
+      "The students' grades were based on the following activities:"
+    )
+    assert.include(
+      markdown,
+      `"Spiritual" material refers to lectures not considered part of the core skill set; the "[Right Now](http://web.mit.edu/fnl/volume/254/winston.html)" material refers to lectures given by what's-happening-right-now guest lecturers.`
+    )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/160

#### What's this PR do?
This PR adds some turndown rules to handle the removal of various pie charts, legends and associated Javascript from instructor insights pages.

#### How should this be manually tested?
Convert some courses that have instructor insights pages (examples can be found [here](https://ocw.mit.edu/courses/instructor-insights/#:~:text=Many%20MIT%20instructors%20share%20their,active%20learning%2C%20and%20engaging%20learners.) and ensure that:

 - No raw Javascript is leaking into the markdown
 - The legend that comes with some pie charts is not rendered
 - Other content surrounding the pie charts *is* rendered

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/107404990-d4c19700-6ad4-11eb-9180-b9da986f75fb.png)

