### PR TITLE
remove course home from left nav

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -223,13 +223,7 @@ const generateCourseHomeMarkdown = (
     title:     "",
     type:      "course",
     layout:    "course_home",
-    course_id: courseData["short_url"],
-    menu:      {
-      [courseData["short_url"]]: {
-        identifier: pageId,
-        weight:     -10
-      }
-    }
+    course_id: courseData["short_url"]
   }
   try {
     return `---\n${yaml.safeDump(

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -309,15 +309,6 @@ describe("markdown generators", () => {
       ])
     })
 
-    it("sets the menu index of the course home page to -10 to ensure it is at the top", () => {
-      assert.equal(
-        -10,
-        courseHomeFrontMatter["menu"][singleCourseJsonData["short_url"]][
-          "weight"
-        ]
-      )
-    })
-
     it("calls yaml.safeDump once", () => {
       expect(safeDump).to.be.calledOnce
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/162

#### What's this PR do?
This PR removes the Course Home link from the left nav.

#### How should this be manually tested?
Convert some courses, ensure that the course home page (`_index.md`) does not have a menu entry.
