### PR TITLE
Handle external course links

### DIFF
--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -10,6 +10,7 @@ tmp.setGracefulCleanup()
 const loggers = require("./loggers")
 const markdownGenerators = require("./markdown_generators")
 const helpers = require("./helpers")
+const fileOperations = require("./file_operations")
 
 const testDataPath = "test_data/courses"
 const singleCourseId =
@@ -45,9 +46,10 @@ describe("markdown generators", () => {
     imageGalleryImages,
     videoGalleryPages,
     courseImageFeaturesFrontMatter,
-    courseVideoFeaturesFrontMatter
+    courseVideoFeaturesFrontMatter,
+    pathLookup
 
-  beforeEach(() => {
+  beforeEach(async () => {
     singleCourseRawData = fs.readFileSync(singleCourseParsedJsonPath)
     singleCourseJsonData = JSON.parse(singleCourseRawData)
     imageGalleryCourseRawData = fs.readFileSync(
@@ -75,16 +77,20 @@ describe("markdown generators", () => {
       page => page["is_media_gallery"]
     )
 
+    pathLookup = await fileOperations.buildPathsForAllCourses(
+      "test_data/courses",
+      [singleCourseId, videoGalleryCourseId, imageGalleryCourseId]
+    )
     courseImageFeaturesFrontMatter = markdownGenerators.generateCourseFeaturesMarkdown(
       imageGalleryPages[0],
       imageGalleryCourseJsonData,
-      {}
+      pathLookup
     )
 
     courseVideoFeaturesFrontMatter = markdownGenerators.generateCourseFeaturesMarkdown(
       videoGalleryPages[0],
       videoGalleryCourseJsonData,
-      {}
+      pathLookup
     )
   })
 
@@ -92,7 +98,8 @@ describe("markdown generators", () => {
     let singleCourseMarkdownData
     beforeEach(() => {
       singleCourseMarkdownData = markdownGenerators.generateMarkdownFromJson(
-        singleCourseJsonData
+        singleCourseJsonData,
+        pathLookup
       )
     })
     const assertCourseIdRecursive = (sectionMarkdownData, courseId) => {
@@ -211,7 +218,8 @@ describe("markdown generators", () => {
 
     it("sets the instructor_insights layout on Instructor Insights pages", () => {
       const markdownData = markdownGenerators.generateMarkdownFromJson(
-        imageGalleryCourseJsonData
+        imageGalleryCourseJsonData,
+        pathLookup
       )
       markdownData.forEach(sectionMarkdownData => {
         const frontMatter = yaml.safeLoad(
@@ -231,7 +239,8 @@ describe("markdown generators", () => {
 
     it("sets a parent_title property on second tier pages", () => {
       const markdownData = markdownGenerators.generateMarkdownFromJson(
-        imageGalleryCourseJsonData
+        imageGalleryCourseJsonData,
+        pathLookup
       )
       markdownData.forEach(sectionMarkdownData => {
         const frontMatter = yaml.safeLoad(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes an issue found in the release where external course links were not being resolved correctly. For example, see the 15.060 link under prerequisites: https://ocwnext-rc.odl.mit.edu/courses/15-071-the-analytics-edge-spring-2017/sections/syllabus/
The link is pointing to the current course, not 15.060. 

#### How should this be manually tested?
Convert two courses in the same batch: `15-071-the-analytics-edge-spring-2017` and `15-060-data-models-and-decisions-fall-2014`. The same link on `15-071-the-analytics-edge-spring-2017/sections/syllabus` should now point correctly to `/courses/15-060-data-models-and-decisions-fall-2014`

