### PR TITLE
include edu_breakdown_key

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -281,16 +281,23 @@ turndownService.addRule("edu_grading", {
           !(
             child.nodeName === "DIV" &&
             child.childNodes[0].nodeName === "CANVAS"
-          ) &&
-          !(
-            child.nodeName === "DIV" &&
-            child.getAttribute("class") === "edu_breakdown_key"
           )
         ) {
           return true
         }
       })
-      .map(child => turndownService.turndown(child.outerHTML))
+      .map(child => {
+        if (
+          child.nodeName === "DIV" &&
+          child.getAttribute("class") === "edu_breakdown_key"
+        ) {
+          return `${Array.from(child.childNodes)
+            .map(keyItem => {
+              return `- ${keyItem.textContent.trim()}`
+            })
+            .join("\n")}\n`
+        } else return turndownService.turndown(child.outerHTML)
+      })
       .join("\n")
   }
 })

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -120,7 +120,12 @@ describe("turndown", () => {
           </script>
         </div>
         <div class="edu_breakdown_key" style="float: right; width: 185px; margin-top: -180px;">
-          LEGEND
+          <div><img src="/images/educator/edu_b-lab-key.png">
+            Item 1</div>
+          <div><img src="/images/educator/edu_b-lecture-key.png">
+            Item 2</div>
+          <div><img src="/images/educator/edu_b-present-key.png">
+            Item 3</div>
         </div>
         <h3 class="subsubhead">SUB HEADER TEXT</h3>
         <p>INSIDE DIV TEXT</p>
@@ -131,7 +136,7 @@ describe("turndown", () => {
     const markdown = await html2markdown(inputHTML)
     assert.equal(
       markdown,
-      "TOP TEXT\n\n### SUB HEADER TEXT\nINSIDE DIV TEXT\n\nOUTSIDE DIV TEXT"
+      "TOP TEXT\n\n- Item 1\n- Item 2\n- Item 3\n\n### SUB HEADER TEXT\nINSIDE DIV TEXT\n\nOUTSIDE DIV TEXT"
     )
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/189

#### What's this PR do?
This PR modifies the pie chart removal rule for `edu_grading` divs to include the text content of items in `edu_breakdown_key`.

#### How should this be manually tested?
Convert a course with an `edu_grading` pie chart, such as `6-034-artificial-intelligence-fall-2010` and ensure that you see the text content from the key in the resulting markdown.

#### Screenshots (if appropriate)
Original OCW pie chart:
![image](https://user-images.githubusercontent.com/12089658/108240195-9cdfd280-7118-11eb-9dc5-f13c94827ce6.png)

Transformed section rendered using Hugo:
![image](https://user-images.githubusercontent.com/12089658/108240332-bed95500-7118-11eb-8ddf-b5a6943963b2.png)
