### PR TITLE
remove semester breakdown chart

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -313,6 +313,35 @@ turndownService.addRule("edu_hours_left", {
 })
 
 /**
+ * Remove semester breakdown chart
+ **/
+turndownService.addRule("edu_breakdown", {
+  filter: (node, options) => {
+    if (node.nodeName === "DIV") {
+      const children = Array.from(node.childNodes)
+      const header = children.find(child => child.nodeName === "H2")
+      const chart = children.find(
+        child =>
+          child.nodeName === "TABLE" &&
+          child.getAttribute("class") === "edu_breakdown"
+      )
+      const key = children.find(
+        child =>
+          child.nodeName === "DIV" &&
+          child.getAttribute("class") === "edu_breakdown_key"
+      )
+      if (header && chart && key) {
+        return true
+      }
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    return ""
+  }
+})
+
+/**
  * Render h4 tags as an h5 instead
  */
 turndownService.addRule("h4", {

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -161,4 +161,50 @@ describe("turndown", () => {
     const markdown = await html2markdown(inputHTML)
     assert.equal(markdown, "RIGHT TEXT")
   })
+
+  it("should remove the edu_breakdown section, its key and header", async () => {
+    const inputHTML = `<div class="onehalf no_title omega">
+      <h2 style="margin-top: -10px;" class="subhead">Semester Breakdown</h2>
+      <table class="edu_breakdown">
+        <thead>
+          <tr>
+            <th style="padding-bottom: 8px;" class="week_col" scope="col">WEEK</th>
+            <th style="padding-bottom: 8px;" class="day_col" scope="col">M</th>
+            <th style="padding-bottom: 8px;" class="day_col" scope="col">T</th>
+            <th style="padding-bottom: 8px;" class="day_col" scope="col">W</th>
+            <th style="padding-bottom: 8px;" class="day_col" scope="col">Th</th>
+            <th style="padding-bottom: 8px;" class="day_col" scope="col">F</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">1</th>
+            <td><img alt="No classes throughout MIT." src="/images/educator/edu_b-noclass.png"></td>
+            <td><img alt="No session scheduled." src="/images/educator/edu_b-blank.png"></td>
+            <td><img alt="No session scheduled." src="/images/educator/edu_b-blank.png"></td>
+            <td><img alt="No session scheduled." src="/images/educator/edu_b-blank.png"></td>
+            <td><img alt="No session scheduled." src="/images/educator/edu_b-blank.png"></td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="edu_breakdown_key">
+        <div style="float: left;">
+          <div><img
+              alt="Displays the color and pattern used on the preceding table to indicate dates when classes are not held at MIT."
+              src="/images/educator/edu_b-noclass-key.png"> No classes throughout MIT</div>
+          <div><img alt="Displays the color used on the preceding table to indicate dates when class meetings are held."
+              src="/images/educator/edu_b-lecture-key.png"> Class meeting</div>
+        </div>
+        <div style="float: right;">
+          <div><img
+              alt="Displays the color used on the preceding table to indicate dates when no class session is scheduled."
+              src="/images/educator/edu_b-blank-key.png"> No class session scheduled</div>
+          <div><img alt="Displays the symbol used on the preceding table to indicate project presentations are held."
+              src="/images/educator/edu_b-preslab-key.png"> Project presentations</div>
+        </div>
+      </div>
+    </div>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, "")
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/163

#### What's this PR do?
This PR matches the semester breakdown chart section based on a div that contains an `h2` element, a `table` with the class of `edu_breakdown`, 

#### How should this be manually tested?
Convert a course with a semester breakdown in the Instructor Insights section, such as `1-74-land-water-food-and-climate-fall-2020`.  Ensure that the resulting markdown does not contain the semester breakdown section.

#### Screenshots (if appropriate)
Live OCW:
![image](https://user-images.githubusercontent.com/12089658/108255415-4085ae80-712a-11eb-8762-0b40cc75a4a2.png)

This branch's output rendered with Hugo:
![image](https://user-images.githubusercontent.com/12089658/108255505-57c49c00-712a-11eb-8d35-805e725a1249.png)

