### PR TITLE
lowercase pdf name in links

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -285,7 +285,7 @@ const makePdfLink = (thisCourseId, pathObj, pathLookup) => {
     const pdfPath = path.join(
       makeCourseUrlPrefix(course, thisCourseId),
       parent,
-      id
+      id.toLowerCase()
     )
     return stripPdfSuffix(pdfPath)
   }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -212,7 +212,7 @@ describe("resolveUidMatches", () => {
     )
     const fileResult = result.find(item => item.match[0] === link)
     assert.deepEqual(fileResult, {
-      replacement: `BASEURL_SHORTCODE/sections/field-trip/MIT12_001F14_Field_Trip`,
+      replacement: `BASEURL_SHORTCODE/sections/field-trip/mit12_001f14_field_trip`,
       match:       [link]
     })
   })
@@ -357,7 +357,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_SHORTCODE/sections/study-materials/MIT2_00AJs09_lec02"'
+      'href="BASEURL_SHORTCODE/sections/study-materials/mit2_00ajs09_lec02"'
     )
   })
 
@@ -372,13 +372,13 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="/courses/12-001-introduction-to-geology-fall-2013/sections/field-trip/MIT12_001F14_Field_Trip"'
+      'href="/courses/12-001-introduction-to-geology-fall-2013/sections/field-trip/mit12_001f14_field_trip"'
     )
   })
 
   it("doesn't resolve a link for a PDF in another course if that course is missing", () => {
     const text =
-      '2010. (<a href="/courses/civil-and-environmental-engineering/1-011-project-evaluation-spring-2011/readings/MIT1_011S11_read16a.pdf">PDF</a>'
+      '2010. (<a href="/courses/civil-and-environmental-engineering/1-011-project-evaluation-spring-2011/readings/mit1_011s11_read16a.pdf">PDF</a>'
 
     const result = helpers.resolveRelativeLinkMatches(
       text,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/180
Fixes https://github.com/mitodl/ocw-to-hugo/issues/196

#### What's this PR do?
This PR lowercases all PDF filenames used in the construction of links to PDF viewer pages.  Since we are not using the `getpage` shortcode anymore and therefore aren't getting the Hugo-generated URL to these pages, we need to do other things to conform to the way Hugo is writing these URL's.  The first one was dealing with `baseUrl`, which we have already done.  Hugo also lowercases the text in any URLs it generates, so we need to do that if we are manually generating URLs that link to Hugo generated resources.

#### How should this be manually tested?
Render markdown for a site with PDF links like `18-06-linear-algebra-spring-2010` and click the links.  They should all work on this branch, but not with content generated from `master`.
