### PR TITLE
fix path generation log message

### DIFF
--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -144,7 +144,7 @@ const scanCourses = async (inputPath, outputPath) => {
 
   console.log(`Generating paths for ${numCourses} courses...`)
   const pathLookup = await buildPathsForAllCourses(inputPath, courseList)
-  console.log(`Generated ${Object.values(pathLookup).length} paths.`)
+  console.log(`Generated ${Object.values(pathLookup.byUid).length} paths.`)
 
   console.log(`Converting ${numCourses} courses to Hugo markdown...`)
   progressBar.start(numCourses, 0)

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -92,7 +92,8 @@ describe("file operations", () => {
     const sandbox = sinon.createSandbox()
     const inputPath = "test_data/courses"
     const outputPath = tmp.dirSync({ prefix: "output" }).name
-    const logMessage = "Converting 7 courses to Hugo markdown..."
+    const courseLogMessage = "Converting 7 courses to Hugo markdown..."
+    const pathsLogMessage = "Generated 1612 paths."
     const course1Name =
       "1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012"
     const course1Path = path.join(inputPath, course1Name)
@@ -186,7 +187,12 @@ describe("file operations", () => {
 
     it("scans the four test courses and reports to console", async () => {
       await fileOperations.scanCourses(inputPath, outputPath)
-      expect(consoleLog).calledWithExactly(logMessage)
+      expect(consoleLog).calledWithExactly(courseLogMessage)
+    }).timeout(5000)
+
+    it("reports the correct amount of paths found to the console", async () => {
+      await fileOperations.scanCourses(inputPath, outputPath)
+      expect(consoleLog).calledWithExactly(pathsLogMessage)
     }).timeout(5000)
 
     it("calls lstat for each test course", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/202

#### What's this PR do?
This PR fixes a bug where `ocw-to-hugo` would incorrectly say "Generated 2 paths" regardless of the amount of paths generated.

#### How should this be manually tested?
Convert the courses in `open-learning-course-data-production` and ensure that you see `Generated 125443 paths.` in your console and not `Generated 2 paths.`
