### PR TITLE
approx-students turndown rule

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -344,6 +344,29 @@ turndownService.addRule("edu_breakdown", {
 })
 
 /**
+ * Catch "approx" images and render as HTML instead
+ */
+turndownService.addRule("approx_img", {
+  filter: (node, options) => {
+    if (
+      node.nodeName === "IMG" &&
+      node.getAttribute("src").includes("-approx.png")
+    ) {
+      return true
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    const matches =
+      node.getAttribute("src").match(/(\/|_)[0-9]+-approx.png/g) || []
+    if (matches.length > 0) {
+      const amount = matches[0].substring(1).replace("-approx.png", "")
+      return `{{< approx-students ${amount} >}}`
+    }
+  }
+})
+
+/**
  * Render h4 tags as an h5 instead
  */
 turndownService.addRule("h4", {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -357,10 +357,10 @@ turndownService.addRule("approx_img", {
     return false
   },
   replacement: (content, node, options) => {
-    const matches =
-      node.getAttribute("src").match(/(\/|_)[0-9]+-approx.png/g) || []
-    if (matches.length > 0) {
-      const amount = matches[0].substring(1).replace("-approx.png", "")
+    const match =
+      node.getAttribute("src").match(/(\/|_)(?<amount>[0-9]+)-approx.png/) || []
+    if (match) {
+      const amount = match.groups.amount
       return `{{< approx-students ${amount} >}}`
     }
   }

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -210,4 +210,16 @@ describe("turndown", () => {
     const markdown = await html2markdown(inputHTML)
     assert.equal(markdown, `{{< youtube ${testId} >}}`)
   })
+
+  it(`replaces "approximate students" images with a shortcode`, async () => {
+    const inputHTML = `<img src="/courses/electrical-engineering-and-computer-science/6-034-artificial-intelligence-fall-2010/instructor-insights/300-approx.png" alt="300-approx.png" width="105" height="105">`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, "{{< approx-students 300 >}}")
+  })
+
+  it(`replaces "approximate students" images prefixed with a UID with a shortcode`, async () => {
+    const inputHTML = `<img src="https://open-learning-course-data-production.s3.amazonaws.com/6-034-artificial-intelligence-fall-2010/bb94a5ee3b0f0351808e14b34829d67a_300-approx.png" width="105" height="105">`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, "{{< approx-students 300 >}}")
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-course-hugo-theme/issues/9

#### What's this PR do?
This PR adds a turndown rule to catch images with a file name resembling `###-approx.png` where `###` is any number.  The images are replaced with a call to the `approx-students` shortcode.

#### How should this be manually tested?
Convert a course like `6-034-artificial-intelligence-fall-2010` that has an instructor insights section with the "approximate number of students" image and inspect the output on the instructor insighs page.  You shouldn't see any references to `300-approx.png` and it should instead be replaced with a call to a shortcode that looks like: `{{ approx-students 300 }}`.

This PR is blocked by [this](https://github.com/mitodl/ocw-course-hugo-theme/pull/37) PR merging in the theme as it contains the shortcode being rendered here.
