### PR TITLE
undefined pdf file_location bugfix

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -207,7 +207,8 @@ const generateCourseHomePdfMarkdown = (courseData, pathLookup) => {
     .filter(
       file =>
         file["file_type"] === "application/pdf" &&
-        file["parent_uid"] === courseData["uid"]
+        file["parent_uid"] === courseData["uid"] &&
+        file["file_location"]
     )
     .map(file => {
       const { path: parentPath } = pathLookup.byUid[file["parent_uid"]]
@@ -300,6 +301,7 @@ const generatePdfMarkdown = (file, courseData) => {
   /**
   Generate the front matter metadata for a PDF file
   */
+  console.log(`generating pdf markdown for ${courseData["short_url"]} - ${file["title"]}`)
   const pdfFrontMatter = {
     title:         file["title"],
     description:   file["description"],

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -54,7 +54,8 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
   const pdfFiles = courseData["course_files"].filter(
     file =>
       file["file_type"] === "application/pdf" &&
-      file["parent_uid"] === page["uid"]
+      file["parent_uid"] === page["uid"] &&
+      file["file_location"]
   )
   const coursePageEmbeddedMedia = Object.values(
     courseData["course_embedded_media"]
@@ -301,7 +302,6 @@ const generatePdfMarkdown = (file, courseData) => {
   /**
   Generate the front matter metadata for a PDF file
   */
-  console.log(`generating pdf markdown for ${courseData["short_url"]} - ${file["title"]}`)
   const pdfFrontMatter = {
     title:         file["title"],
     description:   file["description"],

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -391,12 +391,17 @@ describe("markdown generators", () => {
     })
 
     it("skips files with no file_location set", () => {
-      const copiedJsonData = JSON.parse(JSON.stringify(courseHomePdfCourseJsonData))
+      const copiedJsonData = JSON.parse(
+        JSON.stringify(courseHomePdfCourseJsonData)
+      )
       copiedJsonData["course_files"].map(file => {
         file["file_location"] = undefined
         return file
       })
-      const pdfMarkdownFiles = markdownGenerators.generateCourseHomePdfMarkdown(copiedJsonData, pathLookup)
+      const pdfMarkdownFiles = markdownGenerators.generateCourseHomePdfMarkdown(
+        copiedJsonData,
+        pathLookup
+      )
       assert.equal(pdfMarkdownFiles.length, 0)
     })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -390,6 +390,16 @@ describe("markdown generators", () => {
       assert.equal(fileName, "/acknowledgements.md")
     })
 
+    it("skips files with no file_location set", () => {
+      const copiedJsonData = JSON.parse(JSON.stringify(courseHomePdfCourseJsonData))
+      copiedJsonData["course_files"].map(file => {
+        file["file_location"] = undefined
+        return file
+      })
+      const pdfMarkdownFiles = markdownGenerators.generateCourseHomePdfMarkdown(copiedJsonData, pathLookup)
+      assert.equal(pdfMarkdownFiles.length, 0)
+    })
+
     it("the various properties of the front matter are what they're expected to be", () => {
       assert.deepEqual(courseHomePdfMarkdown, expectedObject)
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This PR fixes an issue with processing all courses where junk data with no `file_location` property would break the build.

#### How should this be manually tested?
S3 sync `open-learning-course-data-rc` locally and run `ocw-to-hugo` against it on this branch.  The process should complete without error.

