### PR TITLE
single course output structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If the `-c` option has been specified, processing will be filtered by the course
 | Argument | Required? | Valid values  | Description |
 | :------- | :-------- | :------------ | :------------ |
 | `-i, --input`      | Yes | `/path/to/open-learning-course-data` | Input folder of OCW course folders containing `parsed.json` files and optionally static content |
-| `-o, --output`      | Yes | `/path/to/hugo-markdown-output` | Output path to place `hugo-course-publisher` `content` and `data` folders in |
+| `-o, --output`      | Yes | `/path/to/hugo-markdown-output` | Output path to place processed courses in |
 | `-c, --courses`      | Only if download flag is true  | `/path/to/courses.json` | If enabled, courses processed will be filtered based on the format above |
 | `--download`      | No  | `true or false` | Download `parsed.json` files from a configured S3 bucket and a list of courses passed in with `-c` |
 | `--strips3`       | No  | `true or false` | Strip the s3 base URL from all OCW resources |

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -73,7 +73,8 @@ const run = async () => {
   }
   if (options.rm) {
     console.log(`Removing the contents of ${options.output}...`)
-    await rmdir(`${options.output}/*`, { recursive: true })
+    await rmdir(options.output, { recursive: true })
+    await mkdir(options.output)
   }
   await scanCourses(options.input, options.output)
 }

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -3,7 +3,8 @@
 
 const yargs = require("yargs")
 const { downloadCourses } = require("../aws_sync")
-const { writeBoilerplate, scanCourses } = require("../file_operations")
+const { scanCourses } = require("../file_operations")
+const { rmdir, mkdir } = require("../fsPromises")
 
 const { MISSING_JSON_ERROR_MESSAGE } = require("../constants")
 const loggers = require("../loggers")
@@ -70,7 +71,10 @@ const run = async () => {
   } else if (options.download && !options.courses) {
     throw new Error(MISSING_JSON_ERROR_MESSAGE)
   }
-  await writeBoilerplate(options.output, options.rm)
+  if (options.rm) {
+    console.log(`Removing the contents of ${options.output}...`)
+    await rmdir(`${options.output}/*`, { recursive: true })
+  }
   await scanCourses(options.input, options.output)
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,31 +11,6 @@ module.exports = {
   AWS_REGEX: new RegExp(
     /https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/g
   ),
-  BOILERPLATE_MARKDOWN: [
-    {
-      path:    "content",
-      name:    "_index.md",
-      content: {
-        title: ""
-      }
-    },
-    {
-      path:    "content/search",
-      name:    "_index.md",
-      content: {
-        title: "Search",
-        type:  "search"
-      }
-    },
-    {
-      path:    "content/courses",
-      name:    "_index.md",
-      content: {
-        title: "Courses",
-        type:  "courseindex"
-      }
-    }
-  ],
   INPUT_COURSE_DATE_FORMAT: "YYYY/M/D H:m:s.SSS",
   SUPPORTED_IFRAME_EMBEDS:  {
     "player.simplecast.com": {

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -8,7 +8,6 @@ const cliProgress = require("cli-progress")
 const {
   MISSING_COURSE_ERROR_MESSAGE,
   NO_COURSES_FOUND_MESSAGE,
-  BOILERPLATE_MARKDOWN,
   COURSE_TYPE,
   EMBEDDED_MEDIA_PAGE_TYPE,
   FILE_TYPE,
@@ -23,21 +22,6 @@ const progressBar = new cliProgress.SingleBar(
   { stopOnComplete: true },
   cliProgress.Presets.shades_classic
 )
-
-const writeBoilerplate = async (outputPath, remove) => {
-  if (remove) {
-    console.log(`Removing the contents of ${outputPath}...`)
-    await fsPromises.rmdir(outputPath, { recursive: true })
-  }
-  for (const file of BOILERPLATE_MARKDOWN) {
-    if (!(await directoryExists(file.path))) {
-      const filePath = path.join(outputPath, file.path)
-      const content = `---\n${yaml.safeDump(file.content)}---\n`
-      await fsPromises.mkdir(filePath, { recursive: true })
-      await fsPromises.writeFile(path.join(filePath, file.name), content)
-    }
-  }
-}
 
 const makeUidInfo = courseData => {
   // extract some pieces of information to populate a lookup object for use with resolveUid
@@ -239,7 +223,6 @@ const writeSectionFiles = async (key, section, outputPath) => {
 }
 
 module.exports = {
-  writeBoilerplate,
   scanCourses,
   scanCourse,
   getMasterJsonFileName,

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -142,9 +142,8 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
   /*
     This function scans a course directory for a master json file and processes it
   */
-  const markdownPath = path.join(outputPath, "content", "courses")
-  const courseMarkdownPath = path.join(inputPath, course)
-  const masterJsonFile = await getMasterJsonFileName(courseMarkdownPath)
+  const courseInputPath = path.join(inputPath, course)
+  const masterJsonFile = await getMasterJsonFileName(courseInputPath)
   if (masterJsonFile) {
     const courseData = JSON.parse(await fsPromises.readFile(masterJsonFile))
     if (helpers.isCoursePublished(courseData)) {
@@ -156,11 +155,11 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         courseData
       )
       await writeMarkdownFilesRecursive(
-        path.join(markdownPath, courseData["short_url"]),
+        path.join(outputPath, courseData["short_url"], "content"),
         markdownData
       )
       await writeDataTemplate(
-        path.join(outputPath, "data", "courses"),
+        path.join(outputPath, courseData["short_url"], "data"),
         dataTemplate
       )
     }
@@ -208,7 +207,7 @@ const writeMarkdownFilesRecursive = async (outputPath, markdownData) => {
 
 const writeDataTemplate = async (outputPath, dataTemplate) => {
   await helpers.createOrOverwriteFile(
-    path.join(outputPath, `${dataTemplate["course_id"]}.json`),
+    path.join(outputPath, "course.json"),
     JSON.stringify(dataTemplate)
   )
 }

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -4,23 +4,18 @@ const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
 const tmp = require("tmp")
 const rimraf = require("rimraf")
-const yaml = require("js-yaml")
 
 const {
   FILE_TYPE,
   NO_COURSES_FOUND_MESSAGE,
-  BOILERPLATE_MARKDOWN,
   PAGE_TYPE,
   COURSE_TYPE,
-  EMBEDDED_MEDIA_PAGE_TYPE,
-  EMBEDDED_MEDIA_TYPE,
-  INSTRUCTOR_TYPE
+  EMBEDDED_MEDIA_PAGE_TYPE
 } = require("./constants")
 const helpers = require("./helpers")
 const fileOperations = require("./file_operations")
 const markdownGenerators = require("./markdown_generators")
 const dataTemplateGenerators = require("./data_template_generators")
-const { fileExists } = require("./helpers")
 
 describe("file operations", () => {
   const testDataPath = "test_data/courses"
@@ -48,43 +43,6 @@ describe("file operations", () => {
       singleCourseJsonData,
       pathLookup
     )
-  })
-
-  describe("writeBoilerplate", () => {
-    const sandbox = sinon.createSandbox()
-    let consoleLog
-
-    beforeEach(() => {
-      consoleLog = sandbox.stub(console, "log")
-    })
-
-    afterEach(() => {
-      sandbox.restore()
-    })
-
-    it("writes the files as expected", async () => {
-      const outputPath = tmp.dirSync({ prefix: "output" }).name
-      await fileOperations.writeBoilerplate(outputPath, false)
-      for (const file of BOILERPLATE_MARKDOWN) {
-        const expectedContent = `---\n${yaml.safeDump(file.content)}---\n`
-        const tmpFileContents = await fsPromises.readFile(
-          path.join(outputPath, file.path, file.name)
-        )
-        assert.equal(tmpFileContents, expectedContent)
-      }
-    })
-
-    it("clears the destination directory if the argument is passed to do so", async () => {
-      const outputPath = tmp.dirSync({ prefix: "output" }).name
-      const testFilePath = path.join(outputPath, "test.txt")
-      await helpers.createOrOverwriteFile(
-        testFilePath,
-        "this file should be removed"
-      )
-      await fileOperations.writeBoilerplate(outputPath, true)
-      const testFileExists = await fileExists(testFilePath)
-      assert.isFalse(testFileExists)
-    })
   })
 
   describe("scanCourses", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/214

#### What's this PR do?
This PR removes boilerplate markdown from `ocw-to-hugo`'s output and changes the output structure so that there is simply a folder for each course processed.  Each folder contains a `content` folder with markdown in it and `data` folder with a `course.json` file in it.

#### How should this be manually tested?
 - Make sure you have `ocw-to-hugo` cloned locally and have this branch checked out
 - Convert multiple courses to markdown using the command ` node . -i private/input -o private/output -c course_json_examples/example_courses.json --download --rm`
 - Ensure that the output contains a folder for each course and a content and data folder in those folders.  Each content folder should have markdown and each data folder should contain a single `course.json` folder:
![image](https://user-images.githubusercontent.com/12089658/110358839-c9498900-800a-11eb-912c-da43a684bf13.png)

#### Any background context you want to provide?
This PR changes the output structure of `ocw-to-hugo` and the projects that use it needed to be modified to match.  The PR's for these changes are below:

https://github.com/mitodl/ocw-course-hugo-theme/pull/45
https://github.com/mitodl/ocw-course-hugo-starter/pull/25
