### PR TITLE
use leftnav for menu name

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -248,14 +248,14 @@ const generateCourseSectionFrontMatter = (
 
   if (inRootNav || listInLeftNav) {
     courseSectionFrontMatter["menu"] = {
-      [courseId]: {
+      leftnav: {
         identifier: pageId,
         name:       shortTitle || "",
         weight:     menuIndex
       }
     }
     if (parentId) {
-      courseSectionFrontMatter["menu"][courseId]["parent"] = parentId
+      courseSectionFrontMatter["menu"]["leftnav"]["parent"] = parentId
     }
   }
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -429,12 +429,7 @@ describe("markdown generators", () => {
     })
 
     it("sets the menu index to 10", () => {
-      assert.equal(
-        10,
-        courseSectionFrontMatter["menu"]["leftnav"][
-          "weight"
-        ]
-      )
+      assert.equal(10, courseSectionFrontMatter["menu"]["leftnav"]["weight"])
     })
 
     it("calls yaml.safeDump once", () => {
@@ -480,12 +475,7 @@ describe("markdown generators", () => {
           )
           .replace(/---\n/g, "")
       )
-      assert.equal(
-        10,
-        courseSectionFrontMatter["menu"]["leftnav"][
-          "weight"
-        ]
-      )
+      assert.equal(10, courseSectionFrontMatter["menu"]["leftnav"]["weight"])
     })
 
     it("handles missing short_page_title correctly", async () => {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -431,7 +431,7 @@ describe("markdown generators", () => {
     it("sets the menu index to 10", () => {
       assert.equal(
         10,
-        courseSectionFrontMatter["menu"][singleCourseJsonData["short_url"]][
+        courseSectionFrontMatter["menu"]["leftnav"][
           "weight"
         ]
       )
@@ -482,7 +482,7 @@ describe("markdown generators", () => {
       )
       assert.equal(
         10,
-        courseSectionFrontMatter["menu"][singleCourseJsonData["short_url"]][
+        courseSectionFrontMatter["menu"]["leftnav"][
           "weight"
         ]
       )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/224

#### What's this PR do?
This PR changes the left navigation menu to be keyed off of `leftnav` rather than the course ID.  Previously, when the output of this project was used by `hugo-course-publisher`, all courses were built as a single Hugo site.  This required us to key the left navigation for each course on its course id to keep the entries unique.  Since courses all run in an isolated Hugo build now, we can simply key this on `leftnav`.  This will make it more straightforward to construct a menu for any given course in `ocw-studio` because it will be stored in and referenced from a single key that describes what it is and where it goes; `leftnav`.

#### How should this be manually tested?
Refer to the readme if you have never used this project before.  Generate markdown for any amount of courses and inspect the output.  For pages that have a menu entry (Syllabus, Readings, etc.) the menu should be keyed with `leftnav` as follows:

```
menu:
  leftnav:
    identifier: 84c97d818a96ffdfd496fd27a12c2c97
    name: Calendar
    weight: 20
```

#### Any background context you want to provide?
Check the related issue for other PR's in repos that use this project.  They'll need to be merged at the same time as this PR.
