### PR TITLE
better colspan handling

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,8 +11,10 @@ module.exports = {
   AWS_REGEX: new RegExp(
     /https?:\/\/open-learning-course-data(.*)\.s3\.amazonaws.com/g
   ),
-  INPUT_COURSE_DATE_FORMAT: "YYYY/M/D H:m:s.SSS",
-  SUPPORTED_IFRAME_EMBEDS:  {
+  // eslint-disable-next-line no-irregular-whitespace
+  IRREGULAR_WHITESPACE_REGEX: new RegExp(/(\|   )+\|/g),
+  INPUT_COURSE_DATE_FORMAT:   "YYYY/M/D H:m:s.SSS",
+  SUPPORTED_IFRAME_EMBEDS:    {
     "player.simplecast.com": {
       hugoShortcode: "simplecast",
       getID:         url => url.pathname.replace("/", "")

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -55,6 +55,9 @@ turndownService.addRule("table", {
   }
 })
 
+/**
+ * Catch cells with a colspan attribute and rewrite them with a shortcode
+ **/
 turndownService.addRule("colspan", {
   filter:      node => node.nodeName === "TD" && node.getAttribute("colspan"),
   replacement: (content, node, options) => {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -7,7 +7,8 @@ const {
   AWS_REGEX,
   BASEURL_SHORTCODE,
   SUPPORTED_IFRAME_EMBEDS,
-  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS
+  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
+  IRREGULAR_WHITESPACE_REGEX
 } = require("./constants")
 const helpers = require("./helpers")
 const loggers = require("./loggers")
@@ -51,6 +52,17 @@ turndownService.addRule("table", {
       .replace(/\|{{< br >}}\|/g, "|\n|")
       // Fourth, replace the pipe marker we added earlier with the HTML character entity for a pipe
       .replace(/REPLACETHISWITHAPIPE/g, "&#124;")
+    //Lastly, we scan and replace irregular whitespace characters with a non-breaking space character entity
+    content = content
+      .split("\n")
+      .map(row => {
+        row = row.replace(IRREGULAR_WHITESPACE_REGEX, "| &nbsp; |")
+        if (row.match(/{{< \/td-colspan >}} \|+( &nbsp; \|)/g)) {
+          row = row.replace(" &nbsp; |", "|")
+        }
+        return row
+      })
+      .join("\n")
     return content
   }
 })

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -64,7 +64,7 @@ turndownService.addRule("colspan", {
     const totalColumns = parseInt(node.getAttribute("colspan"))
     return `| {{< td-colspan ${totalColumns} >}}${content}{{< /td-colspan >}} |${"|".repeat(
       totalColumns - 1
-    )}\n`
+    )}`
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -51,32 +51,17 @@ turndownService.addRule("table", {
       .replace(/\|{{< br >}}\|/g, "|\n|")
       // Fourth, replace the pipe marker we added earlier with the HTML character entity for a pipe
       .replace(/REPLACETHISWITHAPIPE/g, "&#124;")
-    /**
-     * This finds table header rows by matching a cell with only one bold string.
-     * Regex breakdown by capturing group:
-     * 1. Positive lookbehind that finds a pipe followed by a space and two asterisks
-     * 2. Matches any amount of alphanumeric characters
-     * 3. Positive lookahead that matches two asterisks followed by a space, a pipe and
-     * a newline or carriage return
-     */
-    if (content.match(/(?<=\| \*\*)(.*?)(?=\*\* \|\r?\n|\r)/g)) {
-      // Get the amount of columns by matching three hyphens and counting
-      const totalColumns = content.match(/---/g || []).length
-      // Style headers so that they aren't bound by the width of one cell
-      content.match(/\| \*\*(.*)\*\* \|\r?\n|\r/g).forEach(element => {
-        const headerContent = element
-          .replace(/\| \*\*/g, "")
-          .replace(/\*\* \|\r?\n|\r/g, "")
-        // Wrap header content in the fullwidth-cell shortcode and insert spaces to set line height
-        content = content.replace(
-          element,
-          `| {{< fullwidth-cell >}}**${headerContent}**{{< /fullwidth-cell >}} |${" &nbsp; |".repeat(
-            totalColumns - 1
-          )}\n`
-        )
-      })
-      return content
-    } else return content
+    return content
+  }
+})
+
+turndownService.addRule("colspan", {
+  filter:      node => node.nodeName === "TD" && node.getAttribute("colspan"),
+  replacement: (content, node, options) => {
+    const totalColumns = parseInt(node.getAttribute("colspan"))
+    return `| {{< td-colspan ${totalColumns} >}}${content}{{< /td-colspan >}} |${"|".repeat(
+      totalColumns - 1
+    )}\n`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -1,6 +1,9 @@
 const { assert } = require("chai").use(require("sinon-chai"))
 const { html2markdown } = require("./turndown")
-const { YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS } = require("./constants")
+const {
+  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
+  IRREGULAR_WHITESPACE_REGEX
+} = require("./constants")
 
 describe("turndown", () => {
   describe("tables", () => {
@@ -34,6 +37,10 @@ describe("turndown", () => {
         <td>&mdash;</td>
         <td>&mdash;</td>
       </tr>
+      <tr class="alt-row">
+        <td>TEST</td>
+        <td> &nbsp; </td>
+      </tr>
     </tbody>
   </table>`
 
@@ -59,6 +66,10 @@ describe("turndown", () => {
           "| {{< td-colspan 4 >}}{{< br >}}{{< br >}}**Wrapped in a paragraph**{{< br >}}{{< br >}}{{< /td-colspan >}} ||||"
         )
       )
+    })
+
+    it("should remove irregular whitespace characters", () => {
+      assert.isNull(markdown.match(IRREGULAR_WHITESPACE_REGEX))
     })
   })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -25,6 +25,15 @@ describe("turndown", () => {
         <td>&mdash;</td>
         <td>&mdash;</td>
       </tr>
+      <tr class="row">
+        <td colspan="4"><p><strong>Wrapped in a paragraph</strong></p></td>
+      </tr>
+      <tr class="alt-row">
+        <td>L 2</td>
+        <td>Test table section 2</td>
+        <td>&mdash;</td>
+        <td>&mdash;</td>
+      </tr>
     </tbody>
   </table>`
 
@@ -36,10 +45,18 @@ describe("turndown", () => {
       assert.isTrue(markdown.includes("| --- | --- | --- | --- |"))
     })
 
-    it("should properly generate a header with the fullwidth-cell shortcode", () => {
+    it("should properly generate a header with the td-colspan shortcode", () => {
       assert.isTrue(
         markdown.includes(
-          "| {{< fullwidth-cell >}}**Control and Scope**{{< /fullwidth-cell >}} | &nbsp; | &nbsp; | &nbsp; |"
+          "| {{< td-colspan 4 >}}**Control and Scope**{{< /td-colspan >}} ||||"
+        )
+      )
+    })
+
+    it("should handle headers properly if they're wrapped in a p tag", () => {
+      assert.isTrue(
+        markdown.includes(
+          "| {{< td-colspan 4 >}}{{< br >}}{{< br >}}**Wrapped in a paragraph**{{< br >}}{{< br >}}{{< /td-colspan >}} ||||"
         )
       )
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/226

#### What's this PR do?
Tables in OCW courses frequently have inline "header" rows which consist of a single cell with a `colspan` equal to the total amount of columns in the table.  There's usually a single `strong` element in them, sometimes wrapped in a `p` tag.  Sometimes there is extra information following the header as well.

The current turndown rule that handles tables looks for a `**` sequence (indicating a bold string created by passing `strong` through turndown) at the beginning and end of the table cell, indicating that a single bold string is the only thing in the cell.  These matches are then replaced with the `fullwidth-cell` shortcode wrapping the title with adjacent blank cells matching the total amount of columns in the table.  This works as long as that stays true, but is not very robust and is easily broken by the other scenario I described above.  Another issue is the `fullwidth-cell` shortcode itself, which forces the text content to span multiple columns by wrapping an absolutely positioned div in a relatively positioned div.  This solution doesn't work for multiple rows of content, as when the text wraps around in the absolutely positioned div, the height of its parent is unaffected.

This PR removes the existing handling of these "title rows" from the "table" markdown rule and adds a new rule.  This rule specifically looks for `td` tags with a `colspan` property.  The output of the turndown rule is a markdown table row with the first cell being populated with a `td-colspan` shortcode.  The `colspan` value from the original table cell is passed into the shortcode, and the same amount of blank cells, minus one, are added to the end.

The new `td-colspan` shortcode that replaces `fullwidth-cell` instead renders a `td` tag with a colspan property.  This places a `td` within another `td`, which is technically not allowed.  The result in the rendered HTML in all browsers I tested was two side by side `td` elements, one empty and one with the title in it along with the `colspan` attribute.  These empty `td` elements are then hidden in `ocw-course-hugo-theme`'s styles by matching on `td:empty`.  Since intentional empty cells have an `&nbsp;` character entity inserted in them, they are not hidden.

#### How should this be manually tested?
 - Read the readme if you are unfamiliar with how to generate markdown from parsed OCW JSON
 - Generate markdown for a course with the title rows I described above, `7-341-designer-immunity-lessons-in-engineering-the-immune-system-spring-2014` is a good example
 - Ensure that the outputted markdown table has a single `td-colspan` shortcode in the first cell on each title row and the value passed in matches the amount of columns in the table

#### Any background context you want to provide?
For more extensive testing, rendering the markdown as a site, see the `ocw-course-hugo-theme` PR that implements the `td-colspan` shortcode [here](https://github.com/mitodl/ocw-course-hugo-theme/pull/55)
