### PR TITLE
replace headings in tables with shortcodes

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -41,19 +41,19 @@ turndownService.addRule("table", {
     // Regenerate markdown for this table with cell edits
     content = turndownService.turndown(node)
     content = content
-      // First, isolate the table by getting the contents between the first and last pipe
+      // Isolate the table by getting the contents between the first and last pipe
       .substring(content.indexOf("|"), content.lastIndexOf("|"))
-      // Second, replace all newlines and carriage returns with line break shortcodes
+      // Replace all newlines and carriage returns with line break shortcodes
       .replace(/\r?\n|\r/g, "{{< br >}}")
       /**
-       * Third, replace all line break shortcodes in between two pipes with a newline
+       * Replace all line break shortcodes in between two pipes with a newline
        * character between two pipes to recreate the rows
        */
       .replace(/\|{{< br >}}\|/g, "|\n|")
-      // Fourth, replace the pipe marker we added earlier with the HTML character entity for a pipe
+      // Replace the pipe marker we added earlier with the HTML character entity for a pipe
       .replace(/REPLACETHISWITHAPIPE/g, "&#124;")
-    //Lastly, we scan and replace irregular whitespace characters with a non-breaking space character entity
-    content = content
+
+      // Scan and replace irregular whitespace characters with a non-breaking space character entity
       .split("\n")
       .map(row => {
         row = row.replace(IRREGULAR_WHITESPACE_REGEX, "| &nbsp; |")
@@ -64,6 +64,14 @@ turndownService.addRule("table", {
       })
       .join("\n")
     return content
+  }
+})
+
+turndownService.addRule("tableheadings", {
+  filter: node =>
+    node.nodeName.match(/H[1-6]/) && hasParentNodeRecursive(node, "TABLE"),
+  replacement: (content, node, options) => {
+    return `{{< h ${node.nodeName.charAt(1)} >}}${content}{{< /h >}}`
   }
 })
 
@@ -380,6 +388,14 @@ turndownService.addRule("youtube_shortcodes", {
 
 function html2markdown(text) {
   return turndownService.turndown(text)
+}
+
+function hasParentNodeRecursive(node, parentNodeName) {
+  if (node.parentNode) {
+    if (node.parentNode.nodeName === parentNodeName) {
+      return true
+    } else return hasParentNodeRecursive(node.parentNode, parentNodeName)
+  } else return false
 }
 
 module.exports = { html2markdown }

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -38,7 +38,8 @@ describe("turndown", () => {
         <td>&mdash;</td>
       </tr>
       <tr class="alt-row">
-        <td>TEST</td>
+        <td><h1>TEST</h1></td>
+        <td><h2>TEST 2</h2></td>
         <td> &nbsp; </td>
       </tr>
     </tbody>
@@ -70,6 +71,11 @@ describe("turndown", () => {
 
     it("should remove irregular whitespace characters", () => {
       assert.isNull(markdown.match(IRREGULAR_WHITESPACE_REGEX))
+    })
+
+    it("should transform heading tags into heading shortcodes", () => {
+      assert.isTrue(markdown.includes("{{< h 1 >}}TEST{{< /h >}}"))
+      assert.isTrue(markdown.includes("{{< h 2 >}}TEST 2{{< /h >}}"))
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/218

#### What's this PR do?
In markdown, headings are represented by pound signs placed at the beginning of a line, followed by a space and the text you want to appear in the heading.  The amount of pound signs determines the heading level.  For example:
```markdown
# Heading 1
## Heading 2
etc...
```
The main issue with doing this in a markdown table is that a markdown table row cannot have a line break in it.  Since each table row in a markdown table is semantically represented by it being a row of text, a line break would cause the table to break at that point.

This PR instead writes in a call to an `h` shortcode:

```markdown
| SES # | TOPICS |
| --- | --- |
| 1 | {{< h 3 >}}Introduction{{< /h >}}{{< br >}}{{< br >}}Overview of the course — the faculty, objectives, format, and requirements. First lectures: Knowledge use in theory and practice, perspectives from inside and outside academia. ([PDF]({{< baseurl >}}/sections/lecture-notes/lec1)){{< br >}}{{< br >}} |
| 2 | {{< h 3 >}}Models of knowledge production and decision-making{{< /h >}}{{< br >}}{{< br >}}The rational policy/planning model, muddling through, deliberation and social learning.{{< br >}}{{< br >}} |
| 3 | {{< h 3 >}}Agendas and the policy process{{< /h >}}{{< br >}}{{< br >}}The importance of agenda-setting and other "pre-decision" processes in policymaking. The Kingdon model and its critics; the role of narrative.{{< br >}}{{< br >}} |
| 4 | {{< h 3 >}}Frames and persuasion{{< /h >}}{{< br >}}{{< br >}}Storytelling, metaphor, and frames. Alignment among frames, institutional context, and policy and political streams. ([PDF]({{< baseurl >}}/sections/lecture-notes/lec4)){{< br >}}{{< br >}}Guest: Jal Mehta, Harvard Graduate School of Education{{< br >}}{{< br >}} |
| 5 | {{< h 3 >}}Paradigms and fads{{< /h >}}{{< br >}}{{< br >}}Design and urban form, urban utopias, popular culture and the Good City. ([PDF]({{< baseurl >}}/sections/lecture-notes/lec5)){{< br >}}{{< br >}}Guest: Lawrence Vale, MIT{{< br >}}{{< br >}} |
| 6 | {{< h 3 >}}Diffusion of innovation{{< /h >}}{{< br >}}{{< br >}}Creating and diffusing innovation, "structured" diffusion, replication and mimicking. ([PDF]({{< baseurl >}}/sections/lecture-notes/lec6)){{< br >}}{{< br >}} |
| 7 | {{< h 3 >}}Case of anti-poverty policy and research{{< /h >}}{{< br >}}{{< br >}}The Moving to Opportunity experiment as a social policy case, political and fiscal context, images of ghetto poverty, the Hurricane Katrina media effect. ([PDF]({{< baseurl >}}/sections/lecture-notes/lec7)){{< br >}}{{< br >}}Guest: Jeffrey Liebman, Harvard Kennedy School of Government{{< br >}}{{< br >}} |
| 8 | {{< h 3 >}}Science in environmental policy disputes{{< /h >}}{{< br >}}{{< br >}}Science-intensive disputes, "experts for hire", joint fact finding.{{< br >}}{{< br >}}Guest: Lawrence Susskind, MIT and the Consensus Building Institute{{< br >}}{{< br >}} |
| 9 | {{< h 3 >}}Action learning and practice{{< /h >}}{{< br >}}{{< br >}}Action learning, embedded or "social" learning, theories of practice, communities of practice (knowledge networks). ([PDF]({{< baseurl >}}/sections/lecture-notes/lec9)){{< br >}}{{< br >}} |
| 10 | {{< h 3 >}}The politics and use of evaluation research{{< /h >}}{{< br >}}{{< br >}}Truth tests and utility tests, demonstration theory of social change, media and public consumption. ([PDF]({{< baseurl >}}/sections/lecture-notes/lec10)){{< br >}}{{< br >}} |
| 11 | {{< h 3 >}}Research writing for non-academic readers{{< /h >}}{{< br >}}{{< br >}}Research briefs, communication channels, writing support, editing styles. ([PDF]({{< baseurl >}}/sections/lecture-notes/lec11)){{< br >}}{{< br >}} |
| 12 | Student briefs and knowledge-in-use cases. |
| 13 | Course review.
```
This allows the table structure to remain unbroken while still specifying that certain text should be a heading.

#### How should this be manually tested?
 - Convert a course that has a table in it with cells that contain headings, like `21m-542-interdisciplinary-approaches-to-musical-time-january-iap-2010` from the attached issue
 - Verify that headings inside the markdown table have been converted and that the table structure is still valid, with each table row on its own row of text

#### Any background context you want to provide?
The `ocw-course-hugo-theme` PR that implements the shortcode is here: https://github.com/mitodl/ocw-course-hugo-theme/pull/62

