### PR TITLE
pad double line breaks with spaces

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -50,6 +50,9 @@ turndownService.addRule("table", {
        * character between two pipes to recreate the rows
        */
       .replace(/\|{{< br >}}\|/g, "|\n|")
+      // Add a padding of a single space around double line breaks
+      // These generally occur if the contents of a table cell are wrapped in a p or div tag
+      .replace(/{{< br >}}{{< br >}}/g, " {{< br >}}{{< br >}} ")
       // Replace the pipe marker we added earlier with the HTML character entity for a pipe
       .replace(/REPLACETHISWITHAPIPE/g, "&#124;")
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -34,8 +34,8 @@ describe("turndown", () => {
       <tr class="alt-row">
         <td>L 2</td>
         <td>Test table section 2</td>
-        <td>&mdash;</td>
-        <td>&mdash;</td>
+        <td><h1>TEST</h1></td>
+        <td><h2>TEST 2</h2></td>
       </tr>
       <tr class="alt-row">
         <td><p><em>italics wrapped in a paragraph</em></p></td>

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -38,9 +38,10 @@ describe("turndown", () => {
         <td>&mdash;</td>
       </tr>
       <tr class="alt-row">
-        <td><h1>TEST</h1></td>
-        <td><h2>TEST 2</h2></td>
-        <td> &nbsp; </td>
+        <td><p><em>italics wrapped in a paragraph</em></p></td>
+        <td><div><em>italics wrapped in a div</em></div></td>
+        <td><p><strong>strong wrapped in a paragrah</strong></p></td>
+        <td><div><strong>strong wrapped in a div</strong></div></td>
       </tr>
     </tbody>
   </table>`
@@ -64,7 +65,15 @@ describe("turndown", () => {
     it("should handle headers properly if they're wrapped in a p tag", () => {
       assert.isTrue(
         markdown.includes(
-          "| {{< td-colspan 4 >}}{{< br >}}{{< br >}}**Wrapped in a paragraph**{{< br >}}{{< br >}}{{< /td-colspan >}} ||||"
+          "| {{< td-colspan 4 >}} {{< br >}}{{< br >}} **Wrapped in a paragraph** {{< br >}}{{< br >}} {{< /td-colspan >}} ||||"
+        )
+      )
+    })
+
+    it("should properly pad line breaks in cells with containers as to not break formatting", () => {
+      assert.isTrue(
+        markdown.includes(
+          "|  {{< br >}}{{< br >}} _italics wrapped in a paragraph_ {{< br >}}{{< br >}}  |  {{< br >}}{{< br >}} _italics wrapped in a div_ {{< br >}}{{< br >}}  |  {{< br >}}{{< br >}} **strong wrapped in a paragrah** {{< br >}}{{< br >}}  |  {{< br >}}{{< br >}} **strong wrapped in a div** {{< br >}}{{< br >}}"
         )
       )
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-to-hugo/issues/218

#### What's this PR do?
When turndown is transforming HTML into markdown, if it finds content wrapped in a paragraph or div tag it will insert two line breaks at the beginning and end of the content it contains.  Inside of tables, these are transformed into line break shortcodes because an actual line break would break the table.  If the content inside it has formatting applied like bold or italics, the `**` or `_` characters end up butted up directly against the line break shortcodes.  This causes the formatting not to be applied correctly.  This PR ensures that in this case these is a padding of one space around the line break shortcodes so it doesn't happen.

#### How should this be manually tested?
 - Convert `21m-542-interdisciplinary-approaches-to-musical-time-january-iap-2010` to markdown
 - On the Syllabus page, `syllabus.md`, inspect the markdown and make sure that double line break shortcodes (`{{< br >}}{{< br >}}`) have a space on either side
 - Clone `ocw-course-hugo-theme` and read the readme if you haven't used it before
 - Spin up a site for `21m-542-interdisciplinary-approaches-to-musical-time-january-iap-2010` locally and inspect the running site
 - Everything that is supposed to be italic should be italic aside from:
```
George Crumb, E_leven Echoes of Autumn_

Maurice Ravel, _Piano Trio in A Minor_
```
This is due to a formatting issue with the source data where the original `em` tag is not properly wrapping "Eleven Echoes of Autumn"
