### PR TITLE
Add course info links

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/mitodl/ocw-to-hugo#readme",
   "dependencies": {
+    "@mitodl/course-search-utils": "^1.1.4",
     "aws-sdk": "^2.671.0",
     "cli-progress": "^3.4.0",
     "dotenv": "^8.2.0",

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -25,12 +25,13 @@ const generateDataTemplate = courseData => {
         INPUT_COURSE_DATE_FORMAT
       ).format()
       : "",
-    instructors: courseData["instructors"]
-      ? courseData["instructors"].map(
-        instructor =>
-          `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
-      )
-      : [],
+    instructors: (courseData["instructors"] ?? []).map(instructor => {
+      const name = `${instructor["first_name"]} ${instructor["last_name"]}`
+      return {
+        instructor: `Prof. ${name}`,
+        url:        helpers.makeCourseInfoUrl(name, "q")
+      }
+    }),
     departments:     helpers.getDepartments(courseData),
     course_features: courseData["course_features"].map(courseFeature =>
       helpers.getCourseFeatureObject(courseFeature)
@@ -38,7 +39,10 @@ const generateDataTemplate = courseData => {
     topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
     course_numbers: helpers.getCourseNumbers(courseData),
     term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,
-    level:          courseData["course_level"]
+    level:          {
+      level: courseData["course_level"],
+      url:   helpers.makeCourseInfoUrl(courseData["course_level"], "level")
+    }
   }
 }
 

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -25,7 +25,7 @@ const generateDataTemplate = courseData => {
         INPUT_COURSE_DATE_FORMAT
       ).format()
       : "",
-    instructors: (courseData["instructors"] ?? []).map(instructor => {
+    instructors: (courseData["instructors"] || []).map(instructor => {
       const name = `${instructor["first_name"]} ${instructor["last_name"]}`
       return {
         instructor: `Prof. ${name}`,

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -74,17 +74,33 @@ describe("generateDataTemplate", () => {
 
   it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {
     singleCourseJsonData["instructors"].forEach((instructor, index) => {
-      const expectedValue = `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`
+      const expectedParams = encodeURIComponent(
+        `"${instructor["first_name"]} ${instructor["last_name"]}"`
+      )
+      const expectedValue = {
+        instructor: `Prof. ${instructor["first_name"]} ${instructor["last_name"]}`,
+        url:        `/search/?q=${expectedParams}`
+      }
       const foundValue = courseDataTemplate["instructors"][index]
-      assert.equal(expectedValue, foundValue)
+      assert.deepEqual(expectedValue, foundValue)
     })
   })
 
-  it("sets the department property to the deparentment found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
-    assert.equal("Mechanical Engineering", courseDataTemplate["departments"][0])
-    assert.equal(
-      "Aeronautics and Astronautics",
-      courseDataTemplate["departments"][1]
+  it("sets the department property to the department found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
+    assert.deepEqual(
+      [
+        {
+          department: "Mechanical Engineering",
+          url:        `/search/?d=${encodeURIComponent("Mechanical Engineering")}`
+        },
+        {
+          department: "Aeronautics and Astronautics",
+          url:        `/search/?d=${encodeURIComponent(
+            "Aeronautics and Astronautics"
+          )}`
+        }
+      ],
+      courseDataTemplate["departments"]
     )
   })
 
@@ -117,8 +133,14 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets the level property on the course data template to course_level in the course json data", () => {
-    const expectedValue = singleCourseJsonData["course_level"]
+    const level = singleCourseJsonData["course_level"]
     const foundValue = courseDataTemplate["level"]
-    assert.equal(expectedValue, foundValue)
+    assert.deepEqual(
+      {
+        level: level,
+        url:   "/search/?l=Undergraduate"
+      },
+      foundValue
+    )
   })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -68,14 +68,9 @@ const findDepartmentByNumber = departmentNumber =>
   DEPARTMENTS_LOOKUP.get(departmentNumber.toString())
 
 const getDepartments = courseData => {
-  const extraCourseNumbers = courseData["extra_course_number"] || []
-  let departmentNumbers = [
-    courseData["department_number"],
-    ...extraCourseNumbers.map(
-      extraCourseNumber =>
-        extraCourseNumber["linked_course_number_col"].split(".")[0]
-    )
-  ]
+  let departmentNumbers = getCourseNumbers(courseData).map(
+    number => number.split(".")[0]
+  )
   // deduplicate and remove numbers that don't match with our list
   departmentNumbers = [...new Set(departmentNumbers)].filter(
     findDepartmentByNumber
@@ -93,17 +88,13 @@ const getExternalLinks = courseData => {
 }
 
 const getCourseNumbers = courseData => {
-  let courseNumbers = [
-    `${courseData["department_number"]}.${courseData["master_course_number"]}`
-  ]
-  if (courseData["extra_course_number"]) {
-    courseNumbers = courseNumbers.concat(
-      courseData["extra_course_number"].map(
-        extraCourseNumber => extraCourseNumber["linked_course_number_col"]
-      )
+  const extraCourseNumbers = courseData["extra_course_number"] || []
+  return [
+    `${courseData["department_number"]}.${courseData["master_course_number"]}`,
+    ...extraCourseNumbers.map(
+      extraCourseNumber => extraCourseNumber["linked_course_number_col"]
     )
-  }
-  return courseNumbers
+  ]
 }
 
 const getCourseFeatureObject = courseFeature => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -68,7 +68,7 @@ const findDepartmentByNumber = departmentNumber =>
   DEPARTMENTS_LOOKUP.get(departmentNumber.toString())
 
 const getDepartments = courseData => {
-  const extraCourseNumbers = courseData["extra_course_number"] ?? []
+  const extraCourseNumbers = courseData["extra_course_number"] || []
   let departmentNumbers = [
     courseData["department_number"],
     ...extraCourseNumbers.map(

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -44,14 +44,16 @@ describe("findDepartmentByNumber", () => {
 
 describe("getDepartments", () => {
   it("returns the expected departments for a given course json input", () => {
-    assert.equal(
-      helpers.getDepartments(singleCourseJsonData)[0],
-      "Mechanical Engineering"
-    )
-    assert.equal(
-      helpers.getDepartments(singleCourseJsonData)[1],
-      "Aeronautics and Astronautics"
-    )
+    assert.deepEqual(helpers.getDepartments(singleCourseJsonData), [
+      {
+        department: "Mechanical Engineering",
+        url:        `/search/?d=${encodeURIComponent("Mechanical Engineering")}`
+      },
+      {
+        department: "Aeronautics and Astronautics",
+        url:        `/search/?d=${encodeURIComponent("Aeronautics and Astronautics")}`
+      }
+    ])
   })
 })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -317,22 +317,49 @@ describe("markdown generators", () => {
           topic:     "Engineering",
           subtopics: [
             {
-              specialities: ["Systems Design"],
-              subtopic:     "Systems Engineering"
+              specialities: [
+                {
+                  speciality: "Systems Design",
+                  url:        `/search/?t=${encodeURIComponent("Systems Design")}`
+                }
+              ],
+              subtopic: "Systems Engineering",
+              url:      `/search/?t=${encodeURIComponent("Systems Engineering")}`
             },
             {
-              specialities: ["Robotics and Control Systems"],
-              subtopic:     "Electrical Engineering"
+              specialities: [
+                {
+                  speciality: "Robotics and Control Systems",
+                  url:        `/search/?t=${encodeURIComponent(
+                    "Robotics and Control Systems"
+                  )}`
+                }
+              ],
+              subtopic: "Electrical Engineering",
+              url:      `/search/?t=${encodeURIComponent("Electrical Engineering")}`
             },
             {
-              specialities: ["Ocean Exploration"],
-              subtopic:     "Ocean Engineering"
+              specialities: [
+                {
+                  speciality: "Ocean Exploration",
+                  url:        `/search/?t=${encodeURIComponent("Ocean Exploration")}`
+                }
+              ],
+              subtopic: "Ocean Engineering",
+              url:      `/search/?t=${encodeURIComponent("Ocean Engineering")}`
             },
             {
-              specialities: ["Mechanical Design"],
-              subtopic:     "Mechanical Engineering"
+              specialities: [
+                {
+                  speciality: "Mechanical Design",
+                  url:        `/search/?t=${encodeURIComponent("Mechanical Design")}`
+                }
+              ],
+              subtopic: "Mechanical Engineering",
+              url:      `/search/?t=${encodeURIComponent("Mechanical Engineering")}`
             }
-          ]
+          ],
+          url: `/search/?t=${encodeURIComponent("Engineering")}`
         }
       ])
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,14 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
+"@mitodl/course-search-utils@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.1.4.tgz#8605feda9be1f58ae889bedb10de28c53b2682a2"
+  integrity sha512-UIhn8+3cvJzIqiNRAPyQ07XOjOLgat5hjOLJRX9DMg8Dplh1TlBvgfvOnzr8Ssk/FMaI9FawYvK/bVZA32r+4w==
+  dependencies:
+    query-string "^6.13.1"
+    ramda "^0.27.1"
+
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -909,6 +917,11 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -1335,6 +1348,11 @@ file-entry-cache@^5.0.1:
   integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
   dependencies:
     flat-cache "^2.0.1"
+
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
 
 find-cache-dir@^3.2.0:
   version "3.3.1"
@@ -2537,6 +2555,16 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+query-string@^6.13.1:
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
+  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -2551,6 +2579,11 @@ ramda@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.0.tgz#915dc29865c0800bf3f69b8fd6c279898b59de43"
   integrity sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==
+
+ramda@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 ranges-apply@^3.2.3:
   version "3.2.3"
@@ -2894,6 +2927,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
   integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -2903,6 +2941,11 @@ stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-collapse-leading-whitespace@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #243 

#### What's this PR do?
Adds information about URLs to parts of the output JSON. Some of these changes are breaking so there will be an upcoming PR in ocw-course-hugo-theme to tweak the syntax and make use of the URLs.

#### How should this be manually tested?
There are four parts of the course JSON which have been changed. You should see these changes:
 - topics: `topics` and `subtopics` will have an additional `url` field, and `specialities` will not be a list of strings but a list of `{ speciality, url }`
 - departments: This will not be a list of strings anymore but instead a list of `{ department, url }`
 - instructors: Likewise, this will become `{ instructor, url }`
 - level: This becomes `{ level, url }`

