### PR TITLE
use course_feature_tags

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -3,7 +3,7 @@ const moment = require("moment")
 const { INPUT_COURSE_DATE_FORMAT } = require("./constants")
 const helpers = require("./helpers")
 
-const generateDataTemplate = courseData => {
+const generateDataTemplate = (courseData, pathLookup) => {
   return {
     course_id:        courseData["short_url"],
     course_title:     courseData["title"],
@@ -33,8 +33,8 @@ const generateDataTemplate = courseData => {
       }
     }),
     departments:     helpers.getDepartments(courseData),
-    course_features: courseData["course_features"].map(courseFeature =>
-      helpers.getCourseFeatureObject(courseFeature)
+    course_features: courseData["course_feature_tags"].map(courseFeature =>
+      helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
     ),
     topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
     course_numbers: helpers.getCourseNumbers(courseData),

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -33,9 +33,11 @@ const generateDataTemplate = (courseData, pathLookup) => {
       }
     }),
     departments:     helpers.getDepartments(courseData),
-    course_features: courseData["course_feature_tags"].map(courseFeature =>
-      helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
-    ),
+    course_features: courseData["course_feature_tags"]
+      ? courseData["course_feature_tags"].map(courseFeature =>
+        helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
+      )
+      : [],
     topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
     course_numbers: helpers.getCourseNumbers(courseData),
     term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -6,6 +6,7 @@ const { assert, expect } = require("chai").use(require("sinon-chai"))
 const tmp = require("tmp")
 
 const { INPUT_COURSE_DATE_FORMAT } = require("./constants")
+const fileOperations = require("./file_operations")
 const { generateDataTemplate } = require("./data_template_generators")
 const helpers = require("./helpers")
 
@@ -22,11 +23,15 @@ const singleCourseJsonData = JSON.parse(singleCourseRawData)
 
 describe("generateDataTemplate", () => {
   const sandbox = sinon.createSandbox()
-  let consoleLog, courseDataTemplate
+  let consoleLog, courseDataTemplate, pathLookup
 
-  beforeEach(() => {
+  beforeEach(async () => {
     consoleLog = sandbox.stub(console, "log")
-    courseDataTemplate = generateDataTemplate(singleCourseJsonData)
+    pathLookup = await fileOperations.buildPathsForAllCourses(
+      "test_data/courses",
+      [singleCourseId]
+    )
+    courseDataTemplate = generateDataTemplate(singleCourseJsonData, pathLookup)
   })
 
   afterEach(() => {
@@ -104,9 +109,13 @@ describe("generateDataTemplate", () => {
     )
   })
 
-  it("sets the course_features property to the instructors found in the instuctors node of the course json data", () => {
+  it("sets the course_features property to the instructors found in the instuctors node of the course json data", async () => {
     singleCourseJsonData["course_features"].forEach((courseFeature, index) => {
-      const expectedValue = helpers.getCourseFeatureObject(courseFeature)
+      const expectedValue = helpers.getCourseFeatureObject(
+        courseFeature,
+        singleCourseJsonData,
+        pathLookup
+      )
       const foundValue = courseDataTemplate["course_features"][index]
       sinon.assert.match(expectedValue, foundValue)
     })

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -109,8 +109,8 @@ describe("generateDataTemplate", () => {
     )
   })
 
-  it("sets the course_features property to the instructors found in the instuctors node of the course json data", async () => {
-    singleCourseJsonData["course_features"].forEach((courseFeature, index) => {
+  it("sets the course_features property to the instructors found in the instuctors node of the course json data", () => {
+    singleCourseJsonData["course_feature_tags"].forEach((courseFeature, index) => {
       const expectedValue = helpers.getCourseFeatureObject(
         courseFeature,
         singleCourseJsonData,

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -110,15 +110,17 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets the course_features property to the instructors found in the instuctors node of the course json data", () => {
-    singleCourseJsonData["course_feature_tags"].forEach((courseFeature, index) => {
-      const expectedValue = helpers.getCourseFeatureObject(
-        courseFeature,
-        singleCourseJsonData,
-        pathLookup
-      )
-      const foundValue = courseDataTemplate["course_features"][index]
-      sinon.assert.match(expectedValue, foundValue)
-    })
+    singleCourseJsonData["course_feature_tags"].forEach(
+      (courseFeature, index) => {
+        const expectedValue = helpers.getCourseFeatureObject(
+          courseFeature,
+          singleCourseJsonData,
+          pathLookup
+        )
+        const foundValue = courseDataTemplate["course_features"][index]
+        sinon.assert.match(expectedValue, foundValue)
+      }
+    )
   })
 
   it("sets the topics property on the course data template to a consolidated list of topics from the course_collections property of the course json data", () => {

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -152,7 +152,8 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         pathLookup
       )
       const dataTemplate = dataTemplateGenerators.generateDataTemplate(
-        courseData
+        courseData,
+        pathLookup
       )
       await writeMarkdownFilesRecursive(
         path.join(outputPath, courseData["short_url"], "content"),

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -236,7 +236,8 @@ describe("file operations", () => {
         pathLookup
       )
       expect(generateDataTemplate).to.be.calledOnceWithExactly(
-        singleCourseJsonData
+        singleCourseJsonData,
+        pathLookup
       )
     }).timeout(5000)
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -97,15 +97,15 @@ const getCourseNumbers = courseData => {
   ]
 }
 
-const getCourseFeatureObject = courseFeature => {
-  const feature = courseFeature["ocw_feature"]
-  const subfeature = courseFeature["ocw_subfeature"]
+const getCourseFeatureObject = (courseFeature, courseData, pathLookup) => {
+  const feature = courseFeature["feature"]
+  const url = courseFeature["ocw_feature_url"]
   const featureObject = {}
   if (feature) {
     featureObject["feature"] = feature
   }
-  if (subfeature) {
-    featureObject["subfeature"] = subfeature
+  if (url) {
+    featureObject["url"] = resolveUidForLink(url, courseData, pathLookup)
   }
   return featureObject
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -105,7 +105,11 @@ const getCourseFeatureObject = (courseFeature, courseData, pathLookup) => {
     featureObject["feature"] = feature
   }
   if (url) {
-    featureObject["url"] = resolveUidForLink(url, courseData, pathLookup)
+    featureObject["url"] = resolveUidForLink(
+      url,
+      courseData,
+      pathLookup
+    ).replace(BASEURL_SHORTCODE, "")
   }
   return featureObject
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -98,7 +98,7 @@ const getCourseNumbers = courseData => {
 }
 
 const getCourseFeatureObject = (courseFeature, courseData, pathLookup) => {
-  const feature = courseFeature["feature"]
+  const feature = courseFeature["course_feature_tag"]
   const url = courseFeature["ocw_feature_url"]
   const featureObject = {}
   if (feature) {

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -64,10 +64,17 @@ describe("getCourseNumbers", () => {
   })
 })
 
-describe("getCourseFeatureObject", () => {
-  it("returns the expected object from a course feature object", () => {
+describe("getCourseFeatureObject", async () => {
+  const pathLookup = await fileOperations.buildPathsForAllCourses(
+    "test_data/courses",
+    [testCourse]
+  )
+
+  it("returns the expected object from a course feature object", async () => {
     const featureObject = helpers.getCourseFeatureObject(
-      singleCourseJsonData["course_features"][2]
+      singleCourseJsonData["course_feature_tags"][2],
+      singleCourseJsonData,
+      pathLookup
     )
     assert.equal(featureObject["feature"], "Assignments")
     assert.equal(featureObject["subfeature"], "design with examples")
@@ -75,7 +82,9 @@ describe("getCourseFeatureObject", () => {
 
   it("subfeature is undefined on the course feature object if it's blank in the input data", () => {
     const featureObject = helpers.getCourseFeatureObject(
-      singleCourseJsonData["course_features"][0]
+      singleCourseJsonData["course_feature_tags"][0],
+      singleCourseJsonData,
+      pathLookup
     )
     assert.equal(featureObject["feature"], "Image Gallery")
     assert.equal(featureObject["subfeature"], undefined)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-to-hugo/issues/247

#### What's this PR do?
Recently we made a change to `ocw-data-parser` that consolidates `course_features` down into a smaller list of `course_feature_tags`.  This PR sets up `ocw-to-hugo` to use those in the place of the existing `course_features` list.

#### How should this be manually tested?
 - Convert any course
 - Inspect the data template in the output directory at `data/course.json`
 - Verify that the `course_features` list in the data template now contains a list of objects that each have a `feature` and `url` key, matching the `course_feature_tags` list from the course's parsed JSON
 - Verify that the urls on each feature are absolute links to course sections and there are no unresolved `resolveuid` links

#### Any background context you want to provide?
This PR is blocked by the release of https://github.com/mitodl/ocw-course-hugo-theme/pull/80
