### PR TITLE
video page baseurl

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -220,9 +220,10 @@ const getYoutubeEmbedCode = media => {
 }
 
 const getVideoPageLink = (media, pathLookup) => {
-  return `<a href = "${pathLookup.byUid[media["uid"]].path}">${
-    media["title"]
-  }</a>`
+  return `<a href = "${path.join(
+    BASEURL_SHORTCODE,
+    pathLookup.byUid[media["uid"]].path
+  )}">${media["title"]}</a>`
 }
 
 const buildPathRecursive = (item, itemsLookup, courseUid, pathLookup) => {

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -610,7 +610,7 @@ describe("resolveYouTubeEmbedMatches", () => {
     assert.deepEqual(results, [
       {
         replacement:
-          '<a href = "/sections/instructor-insights/instructor-interview-course-iteration">Instructor Interview: Incorporating Authentic Text Going Forward</a>',
+          '<a href = "BASEURL_SHORTCODE/sections/instructor-insights/instructor-interview-course-iteration">Instructor Interview: Incorporating Authentic Text Going Forward</a>',
         match
       }
     ])


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This is a follow up PR related to https://github.com/mitodl/ocw-to-hugo/pull/246 that prepends video pages links with the `baseurl` shortcode.  This is necessary so the links to the video pages are generated properly when running hugo with the `--baseUrl` argument.

#### How should this be manually tested?
 - Generate markdown for a course with popup video links, I used `18-03sc-differential-equations-fall-2011`
 - Ensure that video page links are prefixed with `{{< baseurl >}}` (in `18-03sc-differential-equations-fall-2011` examples can be found at `content/sections/unit-i-first-order-differential-equations/first-order-linear-odes/_index.md` relative to the course's output folder)

