### PR TITLE
don't exit with code 1 unless being run in verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If the `-c` option has been specified, processing will be filtered by the course
 | `--strips3`       | No  | `true or false` | Strip the s3 base URL from all OCW resources |
 | `--staticPrefix`       | No  | `/path/to/static/assets` | When `--strips3` is set to true, replace the s3 base URL with this string |
 | `--rm` | No | `true or false` | Clear the contents of the path passed with `-o` before the conversion run |
+| `--verbose` | No | `true or false` | Run the build in verbose mode, which will print errors encountered during the conversion to the console and exit with a code 1 |
 
 ## Environment Variables
 | Variable | Description  |

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -83,7 +83,6 @@ run()
   .catch(err => {
     console.error("Error:", err)
     loggers.fileLogger.error(err)
-    process.exit(1)
   })
   .then(() => {
     if (loggers.memoryTransport.logs.length) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/265

#### What's this PR do?
The HTML to markdown conversion against the entire OCW library of courses is a naturally error prone process that creates a lot of errors.  These errors are logged to `ocw-to-hugo.error.log` using Winston.  The `--verbose` flag will print these errors to the console, and that is the only situation in which `ocw-to-hugo` should exit with a code 1.  This PR removes a call to `process.exit(1)` in the catch block of the main `run` function, which causes the process to exit with code 1 regardless of `--verbose` being turned on.

#### How should this be manually tested?
 - Sync a parsed OCW JSON bucket locally to your computer, such as `open-learning-course-data-rc`
 - Run `ocw-to-hugo` against the entire folder with a command like `node . -i /path/to/open-learning-course-data -o private/output --rm`
 - Run `EXIT_CODE=$?`, then `echo $EXIT_CODE` and make sure that it returns `0`

