### PR TITLE
Resolve legacy subtitle URLs

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -414,7 +414,7 @@ const resolveUidMatches = (htmlStr, page, courseData, pathLookup) => {
   return []
 }
 
-const resolveRelativeLink = (url, courseData, pathLookup) => {
+const resolveRelativeLink = (url, courseData, pathLookup, useDirectLink) => {
   // ensure that this is not resolveuid or an external link
   const thisCourseId = courseData["short_url"]
   if (url.includes("resolveuid")) {
@@ -451,7 +451,7 @@ const resolveRelativeLink = (url, courseData, pathLookup) => {
         const paths = pathLookup.byCourse[courseId] || []
         for (const pathObj of paths) {
           if (pathObj.type === FILE_TYPE && page === pathObj.id) {
-            if (pathObj.fileType === "application/pdf") {
+            if (pathObj.fileType === "application/pdf" && !useDirectLink) {
               const pdfLink = makePdfLink(
                 thisCourseId,
                 pathObj,
@@ -516,7 +516,12 @@ const resolveRelativeLinkMatches = (htmlStr, courseData, pathLookup) => {
       .map(match => {
         const url = match.groups.url1 || match.groups.url2
 
-        const replacement = resolveRelativeLink(url, courseData, pathLookup)
+        const replacement = resolveRelativeLink(
+          url,
+          courseData,
+          pathLookup,
+          false
+        )
         if (replacement !== null) {
           return { match, replacement: `href="${replacement}"` }
         }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -565,6 +565,8 @@ describe("resolveRelativeLinkMatches", () => {
       'href="BASEURL_SHORTCODE/sections/signals-systems/objectives"'
     )
   })
+
+  //
   ;["http://ocw.mit.edu", "https://ocw.mit.edu"].forEach(prefix => {
     it(`strips ${prefix} and handles the URL like a relative URL`, () => {
       const text = `<a href="${prefix}/courses/aeronautics-and-astronautics/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/syllabus#Table_organization">Table Organization</a></p> `

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -35,7 +35,7 @@ const generateMarkdownFromJson = (courseData, pathLookup) => {
     {
       name:  "_index.md",
       data:  generateCourseHomeMarkdown(courseData, pathLookup),
-      files: generateCourseHomePdfMarkdown(courseData, pathLookup)
+      files: generatePagePdfMarkdown(courseData, pathLookup)
     },
     ...rootSections.map(
       page => generateMarkdownRecursive(page, courseData, pathLookup),
@@ -248,16 +248,16 @@ const generateCourseHomeMarkdown = (courseData, pathLookup) => {
   }
 }
 
-const generateCourseHomePdfMarkdown = (courseData, pathLookup) => {
+const generatePagePdfMarkdown = (courseData, pathLookup) => {
   /**
-   * Generate markdown files representing PDF viewer pages for PDF's mentioned on the course home page
+   * Generate markdown files representing PDF viewer pages for PDF's mentioned on a page in the site
    */
 
   return courseData["course_files"]
     .filter(
       file =>
         file["file_type"] === "application/pdf" &&
-        file["parent_uid"] === courseData["uid"]
+        pathLookup.byUid[file["parent_uid"]]
     )
     .map(file => {
       const { path: parentPath } = pathLookup.byUid[file["parent_uid"]]
@@ -451,7 +451,7 @@ const generateCourseFeaturesMarkdown = (page, courseData, pathLookup) => {
 module.exports = {
   generateMarkdownFromJson,
   generateCourseHomeMarkdown,
-  generateCourseHomePdfMarkdown,
+  generatePagePdfMarkdown,
   generateCourseSectionFrontMatter,
   generateCourseSectionMarkdown,
   generateCourseFeaturesMarkdown,

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -67,7 +67,8 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
             const replacement = helpers.resolveRelativeLink(
               technicalLocation,
               courseData,
-              pathLookup
+              pathLookup,
+              true
             )
             if (replacement) {
               technicalLocation = replacement

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -290,7 +290,7 @@ describe("markdown generators", () => {
       )
       assert.equal(
         embeddedMedia.embedded_media[6].technical_location,
-        "BASEURL_SHORTCODE/sections/instructor-insights/instructor-interview-meet-the-educator/m_gqolc3clm"
+        "https://open-learning-course-data-production.s3.amazonaws.com/21g-107-chinese-i-streamlined-fall-2014/acf8cbbcf3ada9e7b0d390c8b4f8b1e6_M_gQolc3clM.pdf"
       )
     })
   })

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -119,6 +119,8 @@ describe("markdown generators", () => {
       videoGalleryCourseJsonData,
       pathLookup
     )
+    helpers.runOptions.strips3 = false
+    helpers.runOptions.staticPrefix = ""
   })
 
   describe("generateMarkdownFromJson", () => {
@@ -279,19 +281,35 @@ describe("markdown generators", () => {
       })
     })
 
-    it("resolves urls inside embedded media urls", () => {
-      const markdownData = markdownGenerators.generateMarkdownFromJson(
-        subtitlesCourseJsonData,
-        pathLookup
-      )
-
-      const embeddedMedia = yaml.safeLoad(
-        markdownData[3].media[0].data.split("---\n")[1]
-      )
-      assert.equal(
-        embeddedMedia.embedded_media[6].technical_location,
+    //
+    ;[
+      [
+        true,
+        "https://example.com//21g-107-chinese-i-streamlined-fall-2014/acf8cbbcf3ada9e7b0d390c8b4f8b1e6_M_gQolc3clM.pdf"
+      ],
+      [
+        false,
         "https://open-learning-course-data-production.s3.amazonaws.com/21g-107-chinese-i-streamlined-fall-2014/acf8cbbcf3ada9e7b0d390c8b4f8b1e6_M_gQolc3clM.pdf"
-      )
+      ]
+    ].forEach(([useStripS3, expectedUrl]) => {
+      it(`resolves urls inside embedded media urls when stripS3=${String(
+        useStripS3
+      )}`, () => {
+        helpers.runOptions.strips3 = useStripS3
+        helpers.runOptions.staticPrefix = "https://example.com/"
+        const markdownData = markdownGenerators.generateMarkdownFromJson(
+          subtitlesCourseJsonData,
+          pathLookup
+        )
+
+        const embeddedMedia = yaml.safeLoad(
+          markdownData[3].media[0].data.split("---\n")[1]
+        )
+        assert.equal(
+          embeddedMedia.embedded_media[6].technical_location,
+          expectedUrl
+        )
+      })
     })
   })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -18,6 +18,7 @@ const singleCourseId =
 const imageGalleryCourseId = "12-001-introduction-to-geology-fall-2013"
 const videoGalleryCourseId = "ec-711-d-lab-energy-spring-2011"
 const physicsCourseId = "8-02-physics-ii-electricity-and-magnetism-spring-2007"
+const subtitlesCourseId = "21g-107-chinese-i-streamlined-fall-2014"
 const singleCourseParsedJsonPath = path.join(
   testDataPath,
   singleCourseId,
@@ -28,7 +29,6 @@ const imageGalleryCourseParsedJsonPath = path.join(
   imageGalleryCourseId,
   `${imageGalleryCourseId}_parsed.json`
 )
-
 const videoGalleryCourseParsedJsonPath = path.join(
   testDataPath,
   videoGalleryCourseId,
@@ -38,6 +38,11 @@ const physicsCourseParsedJsonPath = path.join(
   testDataPath,
   physicsCourseId,
   `${physicsCourseId}_parsed.json`
+)
+const subtitlesCourseParsedJsonPath = path.join(
+  testDataPath,
+  subtitlesCourseId,
+  `${subtitlesCourseId}_parsed.json`
 )
 
 describe("markdown generators", () => {
@@ -49,6 +54,8 @@ describe("markdown generators", () => {
     videoGalleryCourseJsonData,
     physicsCourseRawData,
     physicsCourseJsonData,
+    subtitlesCourseRawData,
+    subtitlesCourseJsonData,
     coursePagesWithText,
     imageGalleryPages,
     imageGalleryImages,
@@ -73,6 +80,9 @@ describe("markdown generators", () => {
     physicsCourseRawData = fs.readFileSync(physicsCourseParsedJsonPath)
     physicsCourseJsonData = JSON.parse(physicsCourseRawData)
 
+    subtitlesCourseRawData = fs.readFileSync(subtitlesCourseParsedJsonPath)
+    subtitlesCourseJsonData = JSON.parse(subtitlesCourseRawData)
+
     coursePagesWithText = singleCourseJsonData["course_pages"].filter(
       page => page["text"]
     )
@@ -94,7 +104,8 @@ describe("markdown generators", () => {
         singleCourseId,
         videoGalleryCourseId,
         imageGalleryCourseId,
-        physicsCourseId
+        physicsCourseId,
+        subtitlesCourseId
       ]
     )
     courseImageFeaturesFrontMatter = markdownGenerators.generateCourseFeaturesMarkdown(
@@ -266,6 +277,21 @@ describe("markdown generators", () => {
           assert.equal(frontMatter["parent_title"], "Instructor Insights")
         }
       })
+    })
+
+    it("resolves urls inside embedded media urls", () => {
+      const markdownData = markdownGenerators.generateMarkdownFromJson(
+        subtitlesCourseJsonData,
+        pathLookup
+      )
+
+      const embeddedMedia = yaml.safeLoad(
+        markdownData[3].media[0].data.split("---\n")[1]
+      )
+      assert.equal(
+        embeddedMedia.embedded_media[6].technical_location,
+        "BASEURL_SHORTCODE/sections/instructor-insights/instructor-interview-meet-the-educator/m_gqolc3clm"
+      )
     })
   })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -425,39 +425,55 @@ describe("markdown generators", () => {
     })
   })
 
-  describe("generateCourseHomePdfMarkdown", () => {
-    let fileName, courseHomePdfMarkdown
-
-    const expectedObject = {
-      title:       "acknowledgements.pdf",
-      description:
-        "This resource contains acknowledgements to the persons who helped build this course.",
-      type:          "course",
-      layout:        "pdf",
-      uid:           "d7d1fabcb57a6d4a9cc96f04348dedfd",
-      file_type:     "application/pdf",
-      file_location:
-        "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/d7d1fabcb57a6d4a9cc96f04348dedfd_acknowledgements.pdf",
-      course_id: "8-02-physics-ii-electricity-and-magnetism-spring-2007"
-    }
-
-    beforeEach(() => {
-      const pdfMarkdownFile = markdownGenerators.generateCourseHomePdfMarkdown(
+  describe("generatePagePdfMarkdown", () => {
+    it("creates an acknowledgements.md file", () => {
+      const pdfMarkdownFiles = markdownGenerators.generatePagePdfMarkdown(
         physicsCourseJsonData,
         pathLookup
-      )[0]
-      fileName = pdfMarkdownFile["name"]
-      courseHomePdfMarkdown = yaml.safeLoad(
+      )
+      assert.lengthOf(pdfMarkdownFiles, 180)
+      const pdfMarkdownFile = pdfMarkdownFiles[0]
+      const fileName = pdfMarkdownFile["name"]
+      const markdown = yaml.safeLoad(
         pdfMarkdownFile["data"].replace(/---\n/g, "")
       )
-    })
-
-    it("creates an acknowledgements.md file", () => {
       assert.equal(fileName, "/acknowledgements.md")
+      assert.deepEqual(markdown, {
+        title:       "acknowledgements.pdf",
+        description:
+          "This resource contains acknowledgements to the persons who helped build this course.",
+        type:          "course",
+        layout:        "pdf",
+        uid:           "d7d1fabcb57a6d4a9cc96f04348dedfd",
+        file_type:     "application/pdf",
+        file_location:
+          "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/d7d1fabcb57a6d4a9cc96f04348dedfd_acknowledgements.pdf",
+        course_id: "8-02-physics-ii-electricity-and-magnetism-spring-2007"
+      })
     })
 
-    it("the various properties of the front matter are what they're expected to be", () => {
-      assert.deepEqual(courseHomePdfMarkdown, expectedObject)
+    it("creates a pdf page for a pdf whose parent is not the course home page", () => {
+      const pdfMarkdownFile = markdownGenerators.generatePagePdfMarkdown(
+        physicsCourseJsonData,
+        pathLookup
+      )[1]
+      const fileName = pdfMarkdownFile["name"]
+      const markdown = yaml.safeLoad(
+        pdfMarkdownFile["data"].replace(/---\n/g, "")
+      )
+      assert.equal(fileName, "/sections/readings/summary_w12d2.md")
+      assert.deepEqual(markdown, {
+        title:       "summary_w12d2.pdf",
+        description:
+          "This file talks about how electricity and magnetism interact with each other and also considers finalizing Maxwell?s Equations, their result ? electromagnetic (EM) radiation and how energy flows in electric and magnetic fields.",
+        type:          "course",
+        layout:        "pdf",
+        uid:           "a1bfc34ccf08ddf8474627b9a13d6ca8",
+        file_type:     "application/pdf",
+        file_location:
+          "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/a1bfc34ccf08ddf8474627b9a13d6ca8_summary_w12d2.pdf",
+        course_id: "8-02-physics-ii-electricity-and-magnetism-spring-2007"
+      })
     })
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #287 

#### What's this PR do?
 - Handles URLs starting with `https://ocw.mit.edu` or `http://ocw.mit.edu` are now treated as if they were relative URLs. Previously we just cut off the prefix without making other changes which meant the URLs were likely broken. The link will be resolved to a link to one of our pages, or if it doesn't match anything, the link will be preserved to support `/ans7870` links, `/help` links or other things like that.
 - In addition this also looks through the `technical_location` property of `embedded_media` and resolves URLs there so that the data in the front matter is updated.
 - Looking over the links, I noticed that PDF links were not being generated if the parent_uid was not a course home page. I changed the code to generate links as long as there was a valid parent_uid found, not just for the course home page

#### How should this be manually tested?
Run ocw-to-hugo on master and this branch and compare the directories. 
 - You should see some relative URLs which are updated to be corrected (for example, `/courses/<topic>/<course-id>/` should just be `/courses/<topic>/`.
 - Some new PDF pages will be created and there should be some updated links to them. 
 - Links to `.srt` files should become S3 links. You should be able to copy and paste the link into the browser and download a valid file.
