### PR TITLE
open learning library

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -52,6 +52,9 @@ const generateDataTemplate = (courseData, pathLookup) => {
       courseData["other_version_parent_uids"],
       courseData["short_url"],
       pathLookup
+    ),
+    open_learning_library_versions: helpers.getOpenLearningLibraryVersions(
+      courseData["open_learning_library_related"]
     )
   }
 }

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -20,8 +20,7 @@ const singleCourseParsedJsonPath = path.join(
 const singleCourseRawData = fs.readFileSync(singleCourseParsedJsonPath)
 const singleCourseJsonData = JSON.parse(singleCourseRawData)
 
-const physicsCourseId =
-  "8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002"
+const physicsCourseId = "8-01sc-classical-mechanics-fall-2016"
 const physicsCourseParsedJsonPath = path.join(
   testDataPath,
   physicsCourseId,
@@ -38,7 +37,11 @@ describe("generateDataTemplate", () => {
     consoleLog = sandbox.stub(console, "log")
     pathLookup = await fileOperations.buildPathsForAllCourses(
       "test_data/courses",
-      [singleCourseId, physicsCourseId, "8-01sc-classical-mechanics-fall-2016"]
+      [
+        singleCourseId,
+        physicsCourseId,
+        "8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002"
+      ]
     )
     courseDataTemplate = generateDataTemplate(singleCourseJsonData, pathLookup)
     physicsCourseDataTemplate = generateDataTemplate(
@@ -173,9 +176,21 @@ describe("generateDataTemplate", () => {
 
   it("sets the expected text in other_versions", () => {
     const expectedValue = [
-      "[8.01SC CLASSICAL MECHANICS](/courses/8-01sc-classical-mechanics-fall-2016) | SCHOLAR,  FALL 2016"
+      "[8.01X PHYSICS I: CLASSICAL MECHANICS WITH AN EXPERIMENTAL FOCUS](/courses/8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002) |  FALL 2002"
     ]
     const foundValue = physicsCourseDataTemplate["other_versions"]
+    assert.deepEqual(expectedValue, foundValue)
+  })
+
+  it("sets the expected text in open_learning_library_versions", () => {
+    const expectedValue = [
+      "[8.01.1x Mechanics-Kinematics and Dynamics](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.01.1x+3T2018/about) | OPEN LEARNING LIBRARY",
+      "[8.01.2x Mechanics-Momentum and Energy](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.01.2x+3T2018/about) | OPEN LEARNING LIBRARY",
+      "[8.01.3x Mechanics-Rotational Dynamics](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.01.3x+1T2019/about) | OPEN LEARNING LIBRARY",
+      "[8.01.4x Mechanics-Simple Harmonic Motion](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.01.4x+1T2019/about) | OPEN LEARNING LIBRARY"
+    ]
+    const foundValue =
+      physicsCourseDataTemplate["open_learning_library_versions"]
     assert.deepEqual(expectedValue, foundValue)
   })
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -598,7 +598,7 @@ const getOtherVersions = (masterSubjects, courseId, pathLookup) => {
 const getOpenLearningLibraryVersions = openLearningLibraryRelated => {
   return openLearningLibraryRelated
     ? openLearningLibraryRelated.map(openLearningLibraryVersion => {
-      return `[${openLearningLibraryVersion["course"]}](${openLearningLibraryVersion["url"]})`
+      return `[${openLearningLibraryVersion["course"]}](${openLearningLibraryVersion["url"]}) | OPEN LEARNING LIBRARY`
     })
     : []
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -595,6 +595,14 @@ const getOtherVersions = (masterSubjects, courseId, pathLookup) => {
     : []
 }
 
+const getOpenLearningLibraryVersions = openLearningLibraryRelated => {
+  return openLearningLibraryRelated
+    ? openLearningLibraryRelated.map(openLearningLibraryVersion => {
+      return `[${openLearningLibraryVersion["course"]}](${openLearningLibraryVersion["url"]})`
+    })
+    : []
+}
+
 const stripSuffix = suffix => text => {
   if (text.toLowerCase().endsWith(suffix.toLowerCase())) {
     return text.slice(0, -suffix.length)
@@ -638,6 +646,7 @@ module.exports = {
   unescapeBackticks,
   isCoursePublished,
   getOtherVersions,
+  getOpenLearningLibraryVersions,
   runOptions,
   stripPdfSuffix,
   stripSlashPrefix,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/294

#### What's this PR do?
In https://github.com/mitodl/ocw-data-parser/pull/54, we added open_learning_library_related to parsed JSON outputted by ocw-data-parser.  This PR adds the `open_learning_library_versions` property to `course.json`, populated with links generated from this info.

#### How should this be manually tested?
 - Read the readme if you have never used this library before
 - Generate markdown for `8-01sc-classical-mechanics-fall-2016`
 - Verify that the `data/course.json` file in your output directory contains an `open_learning_library_versions` property with an array of links
