### PR TITLE
move menus.toml to menus.yaml

### DIFF
--- a/src/config_generators.js
+++ b/src/config_generators.js
@@ -1,13 +1,29 @@
+const yaml = require("js-yaml")
+
 const { getExternalLinks } = require("./helpers")
 
+const generateHugoConfig = () => {
+  return yaml.safeDump({
+    baseUrl:      "/",
+    languageCode: "en-us",
+    title:        "MIT OpenCourseWare",
+    theme:        ["base-theme", "course"]
+  })
+}
+
 const generateExternalLinksMenu = courseData => {
-  return `${getExternalLinks(courseData).map((externalLink, index) => {
-    return `[[leftnav]]\n\tname = "${externalLink["title"]}"\n\turl = "${
-      externalLink["url"]
-    }"\n\tweight = ${index * 10 + 1000}`
-  })}`
+  return yaml.safeDump({
+    leftnav: getExternalLinks(courseData).map((externalLink, index) => {
+      return {
+        name:   externalLink["title"],
+        url:    externalLink["url"],
+        weight: index * 10 + 1000
+      }
+    })
+  })
 }
 
 module.exports = {
+  generateHugoConfig,
   generateExternalLinksMenu
 }

--- a/src/config_generators.js
+++ b/src/config_generators.js
@@ -2,15 +2,6 @@ const yaml = require("js-yaml")
 
 const { getExternalLinks } = require("./helpers")
 
-const generateHugoConfig = () => {
-  return yaml.safeDump({
-    baseUrl:      "/",
-    languageCode: "en-us",
-    title:        "MIT OpenCourseWare",
-    theme:        ["base-theme", "course"]
-  })
-}
-
 const generateExternalLinksMenu = courseData => {
   return yaml.safeDump({
     leftnav: getExternalLinks(courseData).map((externalLink, index) => {
@@ -24,6 +15,5 @@ const generateExternalLinksMenu = courseData => {
 }
 
 module.exports = {
-  generateHugoConfig,
   generateExternalLinksMenu
 }

--- a/src/config_generators.js
+++ b/src/config_generators.js
@@ -2,17 +2,14 @@ const yaml = require("js-yaml")
 
 const { getExternalLinks } = require("./helpers")
 
-const generateExternalLinksMenu = courseData => {
-  return yaml.safeDump({
-    leftnav: getExternalLinks(courseData).map((externalLink, index) => {
-      return {
-        name:   externalLink["title"],
-        url:    externalLink["url"],
-        weight: index * 10 + 1000
-      }
-    })
+const generateExternalLinksMenu = courseData =>
+  yaml.safeDump({
+    leftnav: getExternalLinks(courseData).map((externalLink, index) => ({
+      name:   externalLink["title"],
+      url:    externalLink["url"],
+      weight: index * 10 + 1000
+    }))
   })
-}
 
 module.exports = {
   generateExternalLinksMenu

--- a/src/config_generators_test.js
+++ b/src/config_generators_test.js
@@ -1,9 +1,13 @@
 const fs = require("fs")
+const yaml = require("js-yaml")
 const path = require("path")
 const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
 
-const { generateExternalLinksMenu } = require("./config_generators")
+const {
+  generateExternalLinksMenu,
+  generateHugoConfig
+} = require("./config_generators")
 
 const testDataPath = "test_data/courses"
 const singleCourseId = "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020"
@@ -17,10 +21,11 @@ const singleCourseJsonData = JSON.parse(singleCourseRawData)
 
 describe("generateExternalLinksMenu", () => {
   const sandbox = sinon.createSandbox()
-  let consoleLog, courseExternalLinksMenu
+  let consoleLog, courseHugoConfig, courseExternalLinksMenu
 
   beforeEach(() => {
     consoleLog = sandbox.stub(console, "log")
+    courseHugoConfig = generateHugoConfig()
     courseExternalLinksMenu = generateExternalLinksMenu(singleCourseJsonData)
   })
 
@@ -28,8 +33,27 @@ describe("generateExternalLinksMenu", () => {
     sandbox.restore()
   })
 
+  it("generates the expected Hugo config file", () => {
+    const expectedValue = yaml.safeDump({
+      baseUrl:      "/",
+      languageCode: "en-us",
+      title:        "MIT OpenCourseWare",
+      theme:        ["base-theme", "course"]
+    })
+    assert.equal(expectedValue, courseHugoConfig)
+  })
+
   it("generates the expected menu for the example course", () => {
-    const expectedValue = `[[leftnav]]\n\tname = "Online Publication"\n\turl = "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/"\n\tweight = 1000`
+    const expectedValue = yaml.safeDump({
+      leftnav: [
+        {
+          name: "Online Publication",
+          url:
+            "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/",
+          weight: 1000
+        }
+      ]
+    })
     assert.equal(expectedValue, courseExternalLinksMenu)
   })
 })

--- a/src/config_generators_test.js
+++ b/src/config_generators_test.js
@@ -4,10 +4,7 @@ const path = require("path")
 const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
 
-const {
-  generateExternalLinksMenu,
-  generateHugoConfig
-} = require("./config_generators")
+const { generateExternalLinksMenu } = require("./config_generators")
 
 const testDataPath = "test_data/courses"
 const singleCourseId = "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020"
@@ -21,26 +18,15 @@ const singleCourseJsonData = JSON.parse(singleCourseRawData)
 
 describe("generateExternalLinksMenu", () => {
   const sandbox = sinon.createSandbox()
-  let consoleLog, courseHugoConfig, courseExternalLinksMenu
+  let consoleLog, courseExternalLinksMenu
 
   beforeEach(() => {
     consoleLog = sandbox.stub(console, "log")
-    courseHugoConfig = generateHugoConfig()
     courseExternalLinksMenu = generateExternalLinksMenu(singleCourseJsonData)
   })
 
   afterEach(() => {
     sandbox.restore()
-  })
-
-  it("generates the expected Hugo config file", () => {
-    const expectedValue = yaml.safeDump({
-      baseUrl:      "/",
-      languageCode: "en-us",
-      title:        "MIT OpenCourseWare",
-      theme:        ["base-theme", "course"]
-    })
-    assert.equal(expectedValue, courseHugoConfig)
   })
 
   it("generates the expected menu for the example course", () => {

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -180,6 +180,9 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         path.join(outputPath, courseData["short_url"], "content"),
         markdownData
       )
+      await writeHugoConfig(
+        path.join(outputPath, courseData["short_url"], "config", "_default")
+      )
       await writeExternalLinks(
         path.join(outputPath, courseData["short_url"], "config", "_default"),
         courseData
@@ -238,9 +241,16 @@ const writeDataTemplate = async (outputPath, dataTemplate) => {
   )
 }
 
+const writeHugoConfig = async outputPath => {
+  await helpers.createOrOverwriteFile(
+    path.join(outputPath, "config.yaml"),
+    configGenerators.generateHugoConfig()
+  )
+}
+
 const writeExternalLinks = async (outputPath, courseData) => {
   await helpers.createOrOverwriteFile(
-    path.join(outputPath, "menus.toml"),
+    path.join(outputPath, "menus.yaml"),
     configGenerators.generateExternalLinksMenu(courseData)
   )
 }

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -190,7 +190,6 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         "config",
         "_default"
       )
-      await writeHugoConfig(configDir)
       await writeExternalLinks(configDir, courseData)
     }
   }
@@ -239,13 +238,6 @@ const writeDataTemplate = async (outputPath, dataTemplate) => {
   await helpers.createOrOverwriteFile(
     path.join(outputPath, "course.json"),
     JSON.stringify(dataTemplate, null, 2)
-  )
-}
-
-const writeHugoConfig = async outputPath => {
-  await helpers.createOrOverwriteFile(
-    path.join(outputPath, "config.yaml"),
-    configGenerators.generateHugoConfig()
   )
 }
 

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -180,17 +180,18 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         path.join(outputPath, courseData["short_url"], "content"),
         markdownData
       )
-      await writeHugoConfig(
-        path.join(outputPath, courseData["short_url"], "config", "_default")
-      )
-      await writeExternalLinks(
-        path.join(outputPath, courseData["short_url"], "config", "_default"),
-        courseData
-      )
       await writeDataTemplate(
         path.join(outputPath, courseData["short_url"], "data"),
         dataTemplate
       )
+      const configDir = path.join(
+        outputPath,
+        courseData["short_url"],
+        "config",
+        "_default"
+      )
+      await writeHugoConfig(configDir)
+      await writeExternalLinks(configDir, courseData)
     }
   }
 }

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -166,6 +166,7 @@ describe("file operations", () => {
   describe("scanCourse", () => {
     let readFileStub,
       generateMarkdownFromJson,
+      writeHugoConfig,
       writeExternalLinks,
       generateDataTemplate
     const sandbox = sinon.createSandbox()
@@ -179,6 +180,7 @@ describe("file operations", () => {
         markdownGenerators,
         "generateMarkdownFromJson"
       )
+      writeHugoConfig = sandbox.spy(configGenerators, "generateHugoConfig")
       writeExternalLinks = sandbox.spy(
         configGenerators,
         "generateExternalLinksMenu"
@@ -214,6 +216,16 @@ describe("file operations", () => {
         singleCourseJsonData,
         pathLookup
       )
+    }).timeout(5000)
+
+    it("calls writeHugoConfig", async () => {
+      await fileOperations.scanCourse(
+        testDataPath,
+        outputPath,
+        singleCourseId,
+        pathLookup
+      )
+      expect(writeExternalLinks).to.be.calledOnce
     }).timeout(5000)
 
     it("calls writeExternalLinks on the course data", async () => {

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -142,17 +142,17 @@ describe("file operations", () => {
     it("calls readdir many times, once for courses and once for each course", async () => {
       await fileOperations.scanCourses(inputPath, outputPath)
       assert.equal(readdirStub.callCount, 27)
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("scans the test courses and reports to console", async () => {
       await fileOperations.scanCourses(inputPath, outputPath)
       expect(consoleLog).calledWithExactly(courseLogMessage)
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("reports the correct amount of paths found to the console", async () => {
       await fileOperations.scanCourses(inputPath, outputPath)
       expect(consoleLog).calledWithExactly(pathsLogMessage)
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("calls lstat for each test course", async () => {
       await fileOperations.scanCourses(inputPath, outputPath)
@@ -160,7 +160,7 @@ describe("file operations", () => {
       expect(lstatStub).to.be.calledWithExactly(course2Path)
       expect(lstatStub).to.be.calledWithExactly(course3Path)
       expect(lstatStub).to.be.calledWithExactly(course4Path)
-    }).timeout(5000)
+    }).timeout(10000)
   })
 
   describe("scanCourse", () => {
@@ -203,7 +203,7 @@ describe("file operations", () => {
         pathLookup
       )
       expect(readFileStub).to.be.calledWithExactly(singleCourseMasterJsonPath)
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("calls generateMarkdownFromJson on the course data", async () => {
       await fileOperations.scanCourse(
@@ -216,7 +216,7 @@ describe("file operations", () => {
         singleCourseJsonData,
         pathLookup
       )
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("calls writeHugoConfig", async () => {
       await fileOperations.scanCourse(
@@ -226,7 +226,7 @@ describe("file operations", () => {
         pathLookup
       )
       expect(writeExternalLinks).to.be.calledOnce
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("calls writeExternalLinks on the course data", async () => {
       await fileOperations.scanCourse(
@@ -238,7 +238,7 @@ describe("file operations", () => {
       expect(writeExternalLinks).to.be.calledOnceWithExactly(
         singleCourseJsonData
       )
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("calls generateDataTemplate on the course data", async () => {
       await fileOperations.scanCourse(
@@ -251,7 +251,7 @@ describe("file operations", () => {
         singleCourseJsonData,
         pathLookup
       )
-    }).timeout(5000)
+    }).timeout(10000)
 
     it("skips a course that has been unpublished", async () => {
       readFileStub.restore()
@@ -263,7 +263,7 @@ describe("file operations", () => {
       )
       expect(generateMarkdownFromJson).to.be.not.called
       expect(generateDataTemplate).to.be.not.called
-    }).timeout(5000)
+    }).timeout(10000)
   })
 
   describe("getMasterJsonFileName", () => {

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -166,7 +166,6 @@ describe("file operations", () => {
   describe("scanCourse", () => {
     let readFileStub,
       generateMarkdownFromJson,
-      writeHugoConfig,
       writeExternalLinks,
       generateDataTemplate
     const sandbox = sinon.createSandbox()
@@ -180,7 +179,6 @@ describe("file operations", () => {
         markdownGenerators,
         "generateMarkdownFromJson"
       )
-      writeHugoConfig = sandbox.spy(configGenerators, "generateHugoConfig")
       writeExternalLinks = sandbox.spy(
         configGenerators,
         "generateExternalLinksMenu"
@@ -216,16 +214,6 @@ describe("file operations", () => {
         singleCourseJsonData,
         pathLookup
       )
-    }).timeout(10000)
-
-    it("calls writeHugoConfig", async () => {
-      await fileOperations.scanCourse(
-        testDataPath,
-        outputPath,
-        singleCourseId,
-        pathLookup
-      )
-      expect(writeExternalLinks).to.be.calledOnce
     }).timeout(10000)
 
     it("calls writeExternalLinks on the course data", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/299

#### What's this PR do?
`ocw-studio` is set up to handle yaml configuration files.  For consistency, we should standardize on using yaml configuration across all our Hugo projects.  This PR moves the external menu link config file to a yaml file.

#### How should this be manually tested?
 - Read the readme if you haven't used this utility before
 - Generate markdown for a course with an external link in the nav such as `7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020`
 - Verify that a valid `menus.yaml` file is generated under `config/_default`
