### PR TITLE
add external link to hst-953-collaborative-data-science-for-healthcare-fall-2020/

### DIFF
--- a/src/external_links.json
+++ b/src/external_links.json
@@ -24,6 +24,11 @@
     "title": "Online Publication"
   },
   {
+      "course_id": "hst-953-collaborative-data-science-for-healthcare-fall-2020",
+      "url": "https://openlearninglibrary.mit.edu/courses/course-v1:MITx+HST.953x+3T2020/about",
+      "title": "Online Publication"
+  },
+  {
     "course_id": "res-15-001-mit-sloan-learningedge-fall-2008",
     "url": "https://mitsloan.mit.edu/LearningEdge/Pages/default.aspx",
     "title": "Online Publication"


### PR DESCRIPTION

#### What are the relevant tickets?

None. I just noticed that https://ocwnext.odl.mit.edu/courses/hst-953-collaborative-data-science-for-healthcare-fall-2020/ was missing an external link, as seen on https://ocw.mit.edu/courses/health-sciences-and-technology/hst-953-collaborative-data-science-for-healthcare-fall-2020/

#### What's this PR do?

Adds a link, which is hopefully published along with the course. 

#### How should this be manually tested?

Publish the course. 

