### PR TITLE
add captions location as a param to youtube shortcode

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -239,10 +239,14 @@ const getYoutubeEmbedCode = media => {
   const youTubeMedia = media["embedded_media"].filter(embeddedMedia => {
     return embeddedMedia["id"] === "Video-YouTube-Stream"
   })
+  const id = youTubeMedia[0].match(/[a-z]+$/i)
+  const youTubeCaptions = media["embedded_media"].find(embeddedMedia => {
+    return embeddedMedia["id"] === `${id}.vtt`
+  })
   return youTubeMedia
     .map(
       embeddedMedia =>
-        `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${embeddedMedia["media_location"]}</div>`
+        `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${embeddedMedia["media_location"]};${youTubeCaptions["technical_location"]}</div>`
     )
     .join("")
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -239,14 +239,14 @@ const getYoutubeEmbedCode = media => {
   const youTubeMedia = media["embedded_media"].filter(embeddedMedia => {
     return embeddedMedia["id"] === "Video-YouTube-Stream"
   })
-  const id = youTubeMedia[0].match(/[a-z]+$/i)
-  const youTubeCaptions = media["embedded_media"].find(embeddedMedia => {
-    return embeddedMedia["id"] === `${id}.vtt`
+  const youTubeCaptions = media["embedded_media"].filter(embeddedMedia => {
+    return embeddedMedia["title"] === "3play caption file" && embeddedMedia["id"].endsWith(".vtt")
   })
+  const location = youTubeCaptions.length ? youTubeCaptions[0]["technical_location"] : ""
   return youTubeMedia
     .map(
       embeddedMedia =>
-        `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${embeddedMedia["media_location"]};${youTubeCaptions["technical_location"]}</div>`
+        `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${embeddedMedia["media_location"]}|${location}</div>`
     )
     .join("")
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -240,9 +240,14 @@ const getYoutubeEmbedCode = media => {
     return embeddedMedia["id"] === "Video-YouTube-Stream"
   })
   const youTubeCaptions = media["embedded_media"].filter(embeddedMedia => {
-    return embeddedMedia["title"] === "3play caption file" && embeddedMedia["id"].endsWith(".vtt")
+    return (
+      embeddedMedia["title"] === "3play caption file" &&
+      embeddedMedia["id"].endsWith(".vtt")
+    )
   })
-  const location = youTubeCaptions.length ? youTubeCaptions[0]["technical_location"] : ""
+  const location = youTubeCaptions.length
+    ? youTubeCaptions[0]["technical_location"]
+    : ""
   return youTubeMedia
     .map(
       embeddedMedia =>

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -615,7 +615,7 @@ describe("resolveYouTubeEmbedMatches", () => {
     match.index = 10
     assert.deepEqual(results, [
       {
-        replacement: '<div class="youtube-placeholder">LnSvSfXUmVs</div>',
+        replacement: '<div class="youtube-placeholder">LnSvSfXUmVs|</div>',
         match
       }
     ])

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -384,7 +384,7 @@ turndownService.addRule("youtube_shortcodes", {
     )
   },
   replacement: (content, node, options) => {
-    const [mediaLocation, captionLocation] = node.textContent.split(";")
+    const [mediaLocation, captionLocation] = node.textContent.split("|")
     return `{{< youtube ${mediaLocation} ${captionLocation}>}}`
   }
 })

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -384,8 +384,8 @@ turndownService.addRule("youtube_shortcodes", {
     )
   },
   replacement: (content, node, options) => {
-    const mediaLocation = node.textContent
-    return `{{< youtube ${mediaLocation} >}}`
+    const [mediaLocation, captionLocation] = node.textContent.split(";")
+    return `{{< youtube ${mediaLocation} ${captionLocation}>}}`
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -385,7 +385,7 @@ turndownService.addRule("youtube_shortcodes", {
   },
   replacement: (content, node, options) => {
     const [mediaLocation, captionLocation] = node.textContent.split("|")
-    return `{{< youtube ${mediaLocation} ${captionLocation}>}}`
+    return `{{< youtube ${mediaLocation} ${captionLocation} >}}`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -258,7 +258,7 @@ describe("turndown", () => {
     const location = "https://example.com"
     const inputHTML = `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${testId}|${location}</div>`
     const markdown = await html2markdown(inputHTML)
-    assert.equal(markdown, `{{< youtube ${testId} ${location}>}}`)
+    assert.equal(markdown, `{{< youtube ${testId} ${location} >}}`)
   })
 
   it(`replaces "approximate students" images with a shortcode`, async () => {

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -193,7 +193,7 @@ describe("turndown", () => {
               value: 71.4,
               color: "#931101"
             }
-    
+
           ];
           var myPie = new Chart(document.getElementById("canvas2").getContext("2d")).Pie(pieData);
         </script> 25 hours per week
@@ -255,9 +255,10 @@ describe("turndown", () => {
 
   it("should properly create youtube shortcodes from placeholder divs", async () => {
     const testId = "F3N5EkMX_ks"
-    const inputHTML = `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${testId}</div>`
+    const location = "https://example.com"
+    const inputHTML = `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${testId}|${location}</div>`
     const markdown = await html2markdown(inputHTML)
-    assert.equal(markdown, `{{< youtube ${testId} >}}`)
+    assert.equal(markdown, `{{< youtube ${testId} ${location}>}}`)
   })
 
   it(`replaces "approximate students" images with a shortcode`, async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fix issue where youtube shortcode is missing a parameter 

#### What's this PR do?
add captions location as a param to youtube shortcode

#### How should this be manually tested?
In the ocw-to-hugo directory, put the following in private/courses.json: 
```{
    "courses": [
        "8-01sc-classical-mechanics-fall-2016",
        "8-01l-physics-i-classical-mechanics-fall-2005",
        "8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002",
        "1-050-solid-mechanics-fall-2004"
    ]
}
```

And then run `node . -i private/input -o private/output --courses private/courses.json --download --rm`
