### PR TITLE
move nav items to config file

### DIFF
--- a/src/config_generators.js
+++ b/src/config_generators.js
@@ -1,16 +1,21 @@
 const yaml = require("js-yaml")
 
-const { getExternalLinks } = require("./helpers")
+const { getInternalMenuItems, getExternalMenuItems } = require("./helpers")
 
-const generateExternalLinksMenu = courseData =>
-  yaml.safeDump({
-    leftnav: getExternalLinks(courseData).map((externalLink, index) => ({
+const generateMenuItems = courseData => {
+  const internalMenuItems = getInternalMenuItems(courseData)
+  const externalMenuItems = getExternalMenuItems(courseData).map(
+    (externalLink, index) => ({
       name:   externalLink["title"],
       url:    externalLink["url"],
       weight: index * 10 + 1000
-    }))
+    })
+  )
+  return yaml.safeDump({
+    leftnav: internalMenuItems.concat(externalMenuItems)
   })
+}
 
 module.exports = {
-  generateExternalLinksMenu
+  generateMenuItems
 }

--- a/src/config_generators.js
+++ b/src/config_generators.js
@@ -2,8 +2,8 @@ const yaml = require("js-yaml")
 
 const { getInternalMenuItems, getExternalMenuItems } = require("./helpers")
 
-const generateMenuItems = courseData => {
-  const internalMenuItems = getInternalMenuItems(courseData)
+const generateMenuItems = (courseData, pathLookup) => {
+  const internalMenuItems = getInternalMenuItems(courseData, pathLookup)
   const externalMenuItems = getExternalMenuItems(courseData).map(
     (externalLink, index) => ({
       name:   externalLink["title"],

--- a/src/config_generators_test.js
+++ b/src/config_generators_test.js
@@ -4,7 +4,8 @@ const path = require("path")
 const sinon = require("sinon")
 const { assert, expect } = require("chai").use(require("sinon-chai"))
 
-const { generateExternalLinksMenu } = require("./config_generators")
+const { generateMenuItems } = require("./config_generators")
+const fileOperations = require("./file_operations")
 
 const testDataPath = "test_data/courses"
 const singleCourseId = "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020"
@@ -16,13 +17,17 @@ const singleCourseParsedJsonPath = path.join(
 const singleCourseRawData = fs.readFileSync(singleCourseParsedJsonPath)
 const singleCourseJsonData = JSON.parse(singleCourseRawData)
 
-describe("generateExternalLinksMenu", () => {
+describe("generateMenuItems", () => {
   const sandbox = sinon.createSandbox()
-  let consoleLog, courseExternalLinksMenu
+  let consoleLog, courseMenuItems, pathLookup
 
-  beforeEach(() => {
+  beforeEach(async () => {
     consoleLog = sandbox.stub(console, "log")
-    courseExternalLinksMenu = generateExternalLinksMenu(singleCourseJsonData)
+    pathLookup = await fileOperations.buildPathsForAllCourses(
+      "test_data/courses",
+      [singleCourseId]
+    )
+    courseMenuItems = generateMenuItems(singleCourseJsonData, pathLookup)
   })
 
   afterEach(() => {
@@ -33,6 +38,18 @@ describe("generateExternalLinksMenu", () => {
     const expectedValue = yaml.safeDump({
       leftnav: [
         {
+          identifier: "b6c8c090d7079126837f7dda4af627c7",
+          name:       "Syllabus",
+          url:        "/sections/onlinecourse",
+          weight:     10
+        },
+        {
+          identifier: "2c792bd745905d336e5077b0ae1237e1",
+          name:       "Calendar",
+          url:        "/sections/calendar",
+          weight:     20
+        },
+        {
           name: "Online Publication",
           url:
             "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/",
@@ -40,6 +57,6 @@ describe("generateExternalLinksMenu", () => {
         }
       ]
     })
-    assert.equal(expectedValue, courseExternalLinksMenu)
+    assert.equal(expectedValue, courseMenuItems)
   })
 })

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -325,7 +325,7 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         "config",
         "_default"
       )
-      await writeMenuConfig(configDir, courseData)
+      await writeMenuConfig(configDir, courseData, pathLookup)
     }
   }
 }
@@ -376,10 +376,10 @@ const writeDataTemplate = async (outputPath, dataTemplate) => {
   )
 }
 
-const writeMenuConfig = async (outputPath, courseData) => {
+const writeMenuConfig = async (outputPath, courseData, pathLookup) => {
   await helpers.createOrOverwriteFile(
     path.join(outputPath, "menus.yaml"),
-    configGenerators.generateMenuItems(courseData)
+    configGenerators.generateMenuItems(courseData, pathLookup)
   )
 }
 

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -325,7 +325,7 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         "config",
         "_default"
       )
-      await writeExternalLinks(configDir, courseData)
+      await writeMenuConfig(configDir, courseData)
     }
   }
 }
@@ -376,10 +376,10 @@ const writeDataTemplate = async (outputPath, dataTemplate) => {
   )
 }
 
-const writeExternalLinks = async (outputPath, courseData) => {
+const writeMenuConfig = async (outputPath, courseData) => {
   await helpers.createOrOverwriteFile(
     path.join(outputPath, "menus.yaml"),
-    configGenerators.generateExternalLinksMenu(courseData)
+    configGenerators.generateMenuItems(courseData)
   )
 }
 

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -166,7 +166,7 @@ describe("file operations", () => {
   describe("scanCourse", () => {
     let readFileStub,
       generateMarkdownFromJson,
-      writeExternalLinks,
+      generateMenuItems,
       generateDataTemplate
     const sandbox = sinon.createSandbox()
     const outputPath = tmp.dirSync({ prefix: "output" }).name
@@ -179,10 +179,7 @@ describe("file operations", () => {
         markdownGenerators,
         "generateMarkdownFromJson"
       )
-      writeExternalLinks = sandbox.spy(
-        configGenerators,
-        "generateExternalLinksMenu"
-      )
+      generateMenuItems = sandbox.spy(configGenerators, "generateMenuItems")
       generateDataTemplate = sandbox.spy(
         dataTemplateGenerators,
         "generateDataTemplate"
@@ -223,8 +220,9 @@ describe("file operations", () => {
         singleCourseId,
         pathLookup
       )
-      expect(writeExternalLinks).to.be.calledOnceWithExactly(
-        singleCourseJsonData
+      expect(generateMenuItems).to.be.calledOnceWithExactly(
+        singleCourseJsonData,
+        pathLookup
       )
     }).timeout(10000)
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -83,7 +83,56 @@ const getDepartments = courseData => {
   }))
 }
 
-const getExternalLinks = courseData => {
+const getRootSections = courseData => {
+  return courseData["course_pages"].filter(
+    page =>
+      page["parent_uid"] === courseData["uid"] &&
+      page["type"] !== "CourseHomeSection" &&
+      page["type"] !== "SRHomePage" &&
+      page["type"] !== "DownloadSection"
+  )
+}
+
+const getInternalMenuItems = courseData => {
+  this["menuIndex"] = 0
+  this["menuItems"] = []
+  getRootSections(courseData).map(
+    coursePage => generatePageMenuItemsRecursive(coursePage, courseData),
+    this
+  )
+  return this["menuItems"]
+}
+
+const generatePageMenuItemsRecursive = (page, courseData) => {
+  const parents = courseData["course_pages"].filter(
+    coursePage => coursePage["uid"] === page["parent_uid"]
+  )
+  const children = courseData["course_pages"].filter(
+    coursePage => coursePage["parent_uid"] === page["uid"]
+  )
+  const shortTitle = page["short_page_title"]
+  const hasParent = parents.length > 0
+  const parent = hasParent ? parents[0] : null
+  const parentId = hasParent ? parent["uid"] : null
+  const inRootNav = page["parent_uid"] === courseData["uid"]
+  const menuIndex = (this["menuIndex"] + 1) * 10
+  const listInLeftNav = page["list_in_left_nav"]
+  if (inRootNav || listInLeftNav) {
+    const menuItem = {
+      identifier: page["uid"],
+      name:       shortTitle || "",
+      weight:     menuIndex
+    }
+    if (parentId) {
+      menuItem["parent"] = parentId
+    }
+    this["menuIndex"]++
+    this["menuItems"].push(menuItem)
+    children.map(page => generatePageMenuItemsRecursive(page, courseData), this)
+  }
+}
+
+const getExternalMenuItems = courseData => {
   return EXTERNAL_LINKS_JSON.filter(
     externalLink => externalLink["course_id"] === courseData["short_url"]
   )
@@ -690,7 +739,9 @@ module.exports = {
   fileExists,
   findDepartmentByNumber,
   getDepartments,
-  getExternalLinks,
+  getRootSections,
+  getInternalMenuItems,
+  getExternalMenuItems,
   getCourseNumbers,
   getCourseFeatureObject,
   getCourseSectionFromFeatureUrl,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -93,17 +93,18 @@ const getRootSections = courseData => {
   )
 }
 
-const getInternalMenuItems = courseData => {
+const getInternalMenuItems = (courseData, pathLookup) => {
   this["menuIndex"] = 0
   this["menuItems"] = []
   getRootSections(courseData).map(
-    coursePage => generatePageMenuItemsRecursive(coursePage, courseData),
+    coursePage =>
+      generatePageMenuItemsRecursive(coursePage, courseData, pathLookup),
     this
   )
   return this["menuItems"]
 }
 
-const generatePageMenuItemsRecursive = (page, courseData) => {
+const generatePageMenuItemsRecursive = (page, courseData, pathLookup) => {
   const parents = courseData["course_pages"].filter(
     coursePage => coursePage["uid"] === page["parent_uid"]
   )
@@ -121,6 +122,7 @@ const generatePageMenuItemsRecursive = (page, courseData) => {
     const menuItem = {
       identifier: page["uid"],
       name:       shortTitle || "",
+      url:        pathLookup.byUid[page["uid"]]["path"],
       weight:     menuIndex
     }
     if (parentId) {
@@ -128,7 +130,10 @@ const generatePageMenuItemsRecursive = (page, courseData) => {
     }
     this["menuIndex"]++
     this["menuItems"].push(menuItem)
-    children.map(page => generatePageMenuItemsRecursive(page, courseData), this)
+    children.map(
+      page => generatePageMenuItemsRecursive(page, courseData, pathLookup),
+      this
+    )
   }
 }
 

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -1,5 +1,5 @@
 const path = require("path")
-const { assert } = require("chai")
+const { assert, expect } = require("chai")
 const fs = require("fs")
 const tmp = require("tmp")
 const sinon = require("sinon")
@@ -9,6 +9,7 @@ const helpers = require("./helpers")
 const loggers = require("./loggers")
 const fileOperations = require("./file_operations")
 
+const testDataPath = "test_data/courses"
 const testCourse =
   "2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009"
 const singleCourseInputPath = `test_data/courses/${testCourse}`
@@ -32,6 +33,16 @@ const unpublishedCourseRawData = fs.readFileSync(
 )
 const unpublishedCourseJsonData = JSON.parse(unpublishedCourseRawData)
 
+const externalNavCourseId =
+  "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020"
+const externalNavParsedJsonPath = path.join(
+  testDataPath,
+  externalNavCourseId,
+  `${externalNavCourseId}_parsed.json`
+)
+const externalNavRawData = fs.readFileSync(externalNavParsedJsonPath)
+const externalNavCourseJsonData = JSON.parse(externalNavRawData)
+
 describe("findDepartmentByNumber", () => {
   it("returns the expected department for a given department number integer", () => {
     assert.equal(helpers.findDepartmentByNumber(18)["title"], "Mathematics")
@@ -54,6 +65,99 @@ describe("getDepartments", () => {
         url:        `/search/?d=${encodeURIComponent("Aeronautics and Astronautics")}`
       }
     ])
+  })
+})
+
+describe("getRootSections", () => {
+  it("returns the expected root course sections for a given course json input", () => {
+    const rootSections = helpers
+      .getRootSections(singleCourseJsonData)
+      .map(rootSection => rootSection["short_url"])
+    const expectedRootSections = [
+      "syllabus",
+      "calendar",
+      "study-materials",
+      "labs",
+      "assignments",
+      "projects",
+      "related-resources"
+    ]
+    assert.deepEqual(rootSections, expectedRootSections)
+  })
+})
+
+describe("getInternalMenuItems", () => {
+  it("returns the expected menu items for internal course sections", async () => {
+    const pathLookup = await fileOperations.buildPathsForAllCourses(
+      "test_data/courses",
+      [testCourse]
+    )
+    const menuItems = helpers.getInternalMenuItems(
+      singleCourseJsonData,
+      pathLookup
+    )
+    const expectedMenuItems = [
+      {
+        identifier: "14896ec808d2b8ea4b434109ba3fb682",
+        name:       "Syllabus",
+        url:        "/sections/syllabus",
+        weight:     10
+      },
+      {
+        identifier: "94beff3d30e5e7bc06fd9421fe63803d",
+        name:       "Calendar",
+        url:        "/sections/calendar",
+        weight:     20
+      },
+      {
+        identifier: "303c499be5d236b1cde0bb36d615f4e7",
+        name:       "Study Materials",
+        url:        "/sections/study-materials",
+        weight:     30
+      },
+      {
+        identifier: "877f0e43412db8b16e5b2864cf8bf1cc",
+        name:       "Labs",
+        url:        "/sections/labs",
+        weight:     40
+      },
+      {
+        identifier: "1016059a65d256e4e12de4f25591a1b8",
+        name:       "Assignments",
+        url:        "/sections/assignments",
+        weight:     50
+      },
+      {
+        identifier: "293500564c0073c5971dfc2bbf334afc",
+        name:       "Projects",
+        url:        "/sections/projects",
+        weight:     60
+      },
+      {
+        identifier: "9759c68f7ab55cc86388d95ca05794f4",
+        name:       "Related Resources",
+        url:        "/sections/related-resources",
+        weight:     70
+      }
+    ]
+    assert.deepEqual(menuItems, expectedMenuItems)
+  })
+})
+
+describe("getExternalMenuItems", () => {
+  it("returns the expected external nav items for a given course json input", () => {
+    const externalMenuItems = helpers.getExternalMenuItems(
+      externalNavCourseJsonData
+    )
+    const expectedMenuItems = [
+      {
+        course_id: "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020",
+        title:     "Online Publication",
+        url:
+          "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/"
+      }
+    ]
+    assert.deepEqual(externalMenuItems, expectedMenuItems)
   })
 })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -22,14 +22,7 @@ const generateMarkdownFromJson = (courseData, pathLookup) => {
   /**
     This function takes JSON data parsed from a parsed.json file and returns markdown data
     */
-  this["menuIndex"] = 0
-  const rootSections = courseData["course_pages"].filter(
-    page =>
-      page["parent_uid"] === courseData["uid"] &&
-      page["type"] !== "CourseHomeSection" &&
-      page["type"] !== "SRHomePage" &&
-      page["type"] !== "DownloadSection"
-  )
+  const rootSections = helpers.getRootSections(courseData)
 
   return [
     {
@@ -102,7 +95,6 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
   const hasMedia = coursePageEmbeddedMedia.length > 0
   const hasParent = parents.length > 0
   const parent = hasParent ? parents[0] : null
-  const inRootNav = page["parent_uid"] === courseData["uid"]
   const isInstructorInsightsSection =
     page["type"] === "ThisCourseAtMITSection" ||
     page["short_url"] === "instructor-insights" ||
@@ -115,16 +107,10 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
     page["title"],
     hasParent ? parent["title"] : null,
     layout,
-    page["short_page_title"],
     page["uid"],
-    hasParent ? parent["uid"] : null,
-    inRootNav,
     page["is_media_gallery"],
-    (this["menuIndex"] + 1) * 10,
-    page["list_in_left_nav"],
     courseData["short_url"]
   )
-  this["menuIndex"]++
   courseSectionMarkdown += generateCourseSectionMarkdown(
     page,
     courseData,
@@ -250,17 +236,12 @@ const generateCourseSectionFrontMatter = (
   title,
   parentTitle,
   layout,
-  shortTitle,
   pageId,
-  parentId,
-  inRootNav,
   isMediaGallery,
-  menuIndex,
-  listInLeftNav,
   courseId
 ) => {
   /**
-    Generate the front matter metadata for a course section given a title and menu index
+    Generate the front matter metadata for a course section
     */
   const courseSectionFrontMatter = {
     uid:       pageId,
@@ -272,19 +253,6 @@ const generateCourseSectionFrontMatter = (
 
   if (parentTitle) {
     courseSectionFrontMatter["parent_title"] = parentTitle
-  }
-
-  if (inRootNav || listInLeftNav) {
-    courseSectionFrontMatter["menu"] = {
-      leftnav: {
-        identifier: pageId,
-        name:       shortTitle || "",
-        weight:     menuIndex
-      }
-    }
-    if (parentId) {
-      courseSectionFrontMatter["menu"]["leftnav"]["parent"] = parentId
-    }
   }
 
   if (isMediaGallery) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -517,10 +517,6 @@ describe("markdown generators", () => {
       assert.equal("Syllabus", courseSectionFrontMatter["title"])
     })
 
-    it("sets the menu index to 10", () => {
-      assert.equal(10, courseSectionFrontMatter["menu"]["leftnav"]["weight"])
-    })
-
     it("calls yaml.safeDump once", () => {
       expect(safeDump).to.be.calledOnce
     })
@@ -546,38 +542,12 @@ describe("markdown generators", () => {
       expect(courseSectionFrontMatter["menu"]).to.be.undefined
     })
 
-    it("creates a menu entry if list_in_left_nav is true and it's not a root section", () => {
-      courseSectionFrontMatter = yaml.safeLoad(
-        markdownGenerators
-          .generateCourseSectionFrontMatter(
-            "Syllabus",
-            null,
-            "course_section",
-            "Syllabus",
-            "syllabus",
-            null,
-            true,
-            false,
-            10,
-            false,
-            singleCourseJsonData["short_url"]
-          )
-          .replace(/---\n/g, "")
-      )
-      assert.equal(10, courseSectionFrontMatter["menu"]["leftnav"]["weight"])
-    })
-
     it("handles missing short_page_title correctly", async () => {
       const yaml = markdownGenerators.generateCourseSectionFrontMatter(
         "Syllabus",
         null,
         "course_section",
-        "Syllabus",
         "syllabus",
-        null,
-        true,
-        false,
-        10,
         false,
         singleCourseJsonData["short_url"]
       )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/309

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/364, we added support for generating navigation menus in `ocw-studio`.  This PR adjusts the way `ocw-to-hugo` generates menu items to be more in line with the way we expect `ocw-studio` to generate them.  Menu items have been removed from markdown content front matter and have been moved into a single `menus.yaml` file for all menu entries, including internal and external links.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before
 - Generate markdown for any course (you can find some examples in `example_courses.json` on the `master` branch
 - Generate markdown for the same course on the `cg/nav-to-config-file` branch and output to a different folder
 - Compare the menu items in the `master` branch output's markdown files to the ones in the branch output's `menus.yaml` file and ensure that all the same menu items are being generated
