### PR TITLE
Add other pieces of instructor data to course json

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -36,7 +36,8 @@ const generateDataTemplate = (courseData, pathLookup) => {
         first_name:     instructor["first_name"],
         last_name:      instructor["last_name"],
         middle_initial: instructor["middle_initial"],
-        salutation:     instructor["salutation"]
+        salutation:     instructor["salutation"],
+        uid:            instructor["uid"]
       }
     }),
     departments:     helpers.getDepartments(courseData),

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -31,8 +31,12 @@ const generateDataTemplate = (courseData, pathLookup) => {
         : `${instructor["first_name"]} ${instructor["last_name"]}`
 
       return {
-        instructor: name,
-        url:        helpers.makeCourseInfoUrl(name, "q")
+        instructor:     name,
+        url:            helpers.makeCourseInfoUrl(name, "q"),
+        first_name:     instructor["first_name"],
+        last_name:      instructor["last_name"],
+        middle_initial: instructor["middle_initial"],
+        salutation:     instructor["salutation"]
       }
     }),
     departments:     helpers.getDepartments(courseData),

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -105,7 +105,8 @@ describe("generateDataTemplate", () => {
         middle_initial: "",
         salutation:     "Prof.",
         instructor:     "Prof. Edward Crawley",
-        url:            "/search/?q=%22Prof.%20Edward%20Crawley%22"
+        url:            "/search/?q=%22Prof.%20Edward%20Crawley%22",
+        uid:            "e042c8f9995fcc110a2a5aafa674c5e6"
       },
       {
         first_name:     "Olivier",
@@ -113,7 +114,8 @@ describe("generateDataTemplate", () => {
         middle_initial: "",
         salutation:     "Prof.",
         instructor:     "Prof. Olivier de Weck",
-        url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22"
+        url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22",
+        uid:            "07d4f0555edfebf2c2477bbf2d19dd91"
       }
     ])
   })

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -98,18 +98,24 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {
-    singleCourseJsonData["instructors"].forEach((instructor, index) => {
-      const expectedName = instructor["salutation"]
-        ? `${instructor["salutation"]} ${instructor["first_name"]} ${instructor["last_name"]}`
-        : `${instructor["first_name"]} ${instructor["last_name"]}`
-
-      const expectedValue = {
-        instructor: expectedName,
-        url:        `/search/?q=${encodeURIComponent(`"${expectedName}"`)}`
+    assert.deepEqual(courseDataTemplate["instructors"], [
+      {
+        first_name:     "Edward",
+        last_name:      "Crawley",
+        middle_initial: "",
+        salutation:     "Prof.",
+        instructor:     "Prof. Edward Crawley",
+        url:            "/search/?q=%22Prof.%20Edward%20Crawley%22"
+      },
+      {
+        first_name:     "Olivier",
+        last_name:      "de Weck",
+        middle_initial: "",
+        salutation:     "Prof.",
+        instructor:     "Prof. Olivier de Weck",
+        url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22"
       }
-      const foundValue = courseDataTemplate["instructors"][index]
-      assert.deepEqual(expectedValue, foundValue)
-    })
+    ])
   })
 
   it("sets the department property to the department found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Required for https://github.com/mitodl/ocw-studio/issues/382

#### What's this PR do?
Adds some other pieces of instructor data to `course.json`

#### How should this be manually tested?
Convert a course and look at the output in `data/course.json`. You should see an `instructors` list with fields like `url` and `instructor` which were there before, but also `first_name`, `last_name`, `middle_initial`, and `saluation`
