### PR TITLE
Fix issue with a pipe being treated as a string

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -251,7 +251,7 @@ const getYoutubeEmbedCode = media => {
   return youTubeMedia
     .map(
       embeddedMedia =>
-        `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${embeddedMedia["media_location"]}|${location}</div>`
+        `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${embeddedMedia["media_location"]};${location}</div>`
     )
     .join("")
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -615,7 +615,7 @@ describe("resolveYouTubeEmbedMatches", () => {
     match.index = 10
     assert.deepEqual(results, [
       {
-        replacement: '<div class="youtube-placeholder">LnSvSfXUmVs|</div>',
+        replacement: '<div class="youtube-placeholder">LnSvSfXUmVs;</div>',
         match
       }
     ])

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -384,8 +384,8 @@ turndownService.addRule("youtube_shortcodes", {
     )
   },
   replacement: (content, node, options) => {
-    const [mediaLocation, captionLocation] = node.textContent.split("|")
-    return `{{< youtube ${mediaLocation} ${captionLocation} >}}`
+    const [mediaLocation, captionLocation] = node.textContent.split(";")
+    return `{{< youtube "${mediaLocation}" "${captionLocation}" >}}`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -256,9 +256,9 @@ describe("turndown", () => {
   it("should properly create youtube shortcodes from placeholder divs", async () => {
     const testId = "F3N5EkMX_ks"
     const location = "https://example.com"
-    const inputHTML = `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${testId}|${location}</div>`
+    const inputHTML = `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${testId};${location}</div>`
     const markdown = await html2markdown(inputHTML)
-    assert.equal(markdown, `{{< youtube ${testId} ${location} >}}`)
+    assert.equal(markdown, `{{< youtube "${testId}" "${location}" >}}`)
   })
 
   it(`replaces "approximate students" images with a shortcode`, async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fix issue with a pipe being treated as a string

#### What's this PR do?
Pipes are transformed into a url encoded string because markdown tables are built with pipes. This PR changes a pipe to a semicolon.
Also wrapped the parameters into quotes, since the new parameter is a full URL and contains slashes and a colon which breaks it on the Hugo side.

#### How should this be manually tested?
Run `node . -i private/input -o private/output --courses private/courses.json --download --rm` , there should be no errors.
