### PR TITLE
separate primary course number and extra course numbers

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -46,10 +46,11 @@ const generateDataTemplate = (courseData, pathLookup) => {
         helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
       )
       : [],
-    topics:         helpers.getConsolidatedTopics(courseData["course_collections"]),
-    course_numbers: helpers.getCourseNumbers(courseData),
-    term:           `${courseData["from_semester"]} ${courseData["from_year"]}`,
-    level:          {
+    topics:                helpers.getConsolidatedTopics(courseData["course_collections"]),
+    primary_course_number: helpers.getPrimaryCourseNumber(courseData),
+    extra_course_numbers:  helpers.getExtraCourseNumbers(courseData),
+    term:                  `${courseData["from_semester"]} ${courseData["from_year"]}`,
+    level:                 {
       level: courseData["course_level"],
       url:   helpers.makeCourseInfoUrl(courseData["course_level"], "level")
     },

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -162,10 +162,10 @@ describe("generateDataTemplate", () => {
     sinon.assert.match(expectedValue, foundValue)
   })
 
-  it("sets the course_number property on the course data template to data parsed from sort_as and extra_course_number properties in the course json data", () => {
-    const expectedValues = helpers.getCourseNumbers(singleCourseJsonData)
-    const foundValues = courseDataTemplate["course_numbers"]
-    assert.deepEqual(expectedValues, foundValues)
+  it("sets the primary_course_number property on the course data template to data parsed from department_number and master_course_number in the course json data", () => {
+    const expectedValue = helpers.getPrimaryCourseNumber(singleCourseJsonData)
+    const foundValues = courseDataTemplate["primary_course_number"]
+    assert.equal(expectedValue, foundValues)
   })
 
   it("sets the term property on the course data template to from_semester and from_year in the course json data", () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -70,9 +70,10 @@ const findDepartmentByNumber = departmentNumber =>
   DEPARTMENTS_LOOKUP.get(departmentNumber.toString())
 
 const getDepartments = courseData => {
-  let departmentNumbers = getCourseNumbers(courseData).map(
-    number => number.split(".")[0]
-  )
+  let departmentNumbers = [
+    getPrimaryCourseNumber(courseData),
+    ...getExtraCourseNumbers(courseData)
+  ].map(number => number.split(".")[0])
   // deduplicate and remove numbers that don't match with our list
   departmentNumbers = [...new Set(departmentNumbers)].filter(
     findDepartmentByNumber
@@ -143,12 +144,11 @@ const getExternalMenuItems = courseData => {
   )
 }
 
-const getCourseNumbers = courseData => {
-  const primaryCourseNumber = getUpdatedCourseNumber(
+const getPrimaryCourseNumber = courseData => {
+  return getUpdatedCourseNumber(
     `${courseData["department_number"]}.${courseData["master_course_number"]}`,
     courseData
   )
-  return [primaryCourseNumber, ...getExtraCourseNumbers(courseData)]
 }
 
 const getExtraCourseNumbers = courseData => {
@@ -747,7 +747,8 @@ module.exports = {
   getRootSections,
   getInternalMenuItems,
   getExternalMenuItems,
-  getCourseNumbers,
+  getPrimaryCourseNumber,
+  getExtraCourseNumbers,
   getCourseFeatureObject,
   getCourseSectionFromFeatureUrl,
   getConsolidatedTopics,

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -161,10 +161,18 @@ describe("getExternalMenuItems", () => {
   })
 })
 
-describe("getCourseNumbers", () => {
-  it("returns the expected course numbers for a given course json input", () => {
-    assert.equal(helpers.getCourseNumbers(singleCourseJsonData)[0], "2.00AJ")
-    assert.equal(helpers.getCourseNumbers(singleCourseJsonData)[1], "16.00AJ")
+describe("getPrimaryCourseNumber", () => {
+  it("returns the expected primary course number for a given course json input", () => {
+    assert.equal(helpers.getPrimaryCourseNumber(singleCourseJsonData), "2.00AJ")
+  })
+})
+
+describe("getExtraCourseNumbers", () => {
+  it("returns the expected extra course numbers for a given course json input", () => {
+    assert.equal(
+      helpers.getExtraCourseNumbers(singleCourseJsonData)[0],
+      "16.00AJ"
+    )
   })
 })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -316,13 +316,11 @@ describe("markdown generators", () => {
   describe("generateCourseHomeMarkdown", () => {
     let courseHomeMarkdown,
       courseHomeFrontMatter,
-      getCourseNumbers,
       getConsolidatedTopics,
       safeDump
     const sandbox = sinon.createSandbox()
 
     beforeEach(async () => {
-      getCourseNumbers = sandbox.spy(helpers, "getCourseNumbers")
       getConsolidatedTopics = sandbox.spy(helpers, "getConsolidatedTopics")
       safeDump = sandbox.spy(yaml, "safeDump")
       const pathLookup = await fileOperations.buildPathsForAllCourses(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/317
Related to https://github.com/mitodl/ocw-hugo-projects/issues/25

#### What's this PR do?
In the process of moving to generating content in `ocw-studio`, some of the course metadata formatting is being adjusted.  This PR breaks out the `course_numbers` array into `primary_course_number` and `extra_course_numbers`.  

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before
 - Put the following in `private/courses.json`:
 ```
{
  "courses": [
    "21a-360j-the-anthropology-of-sound-spring-2008"
  ]
}
 ```
- Make sure `ocw-to-hugo` is configured to download courses from S3
 - Run `node . -i private/input -o private/output -c private/courses.json --download`
 - Check the course's data template in the output folder and ensure that `primary_course_number` contains the primary course number and extra course numbers are stored in `extra_course_numbers`
