### PR TITLE
add parent_uid to the front matter on sections that have a parent

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -307,6 +307,7 @@ const generatePdfMarkdown = (file, courseData) => {
     type:          "course",
     layout:        "pdf",
     uid:           file["uid"],
+    parent_uid:    file["parent_uid"],
     file_type:     file["file_type"],
     file_location: helpers.stripS3(file["file_location"]),
     course_id:     courseData["short_url"]

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -105,6 +105,7 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
     : "course_section"
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
+    hasParent ? parent["uid"] : null,
     hasParent ? parent["title"] : null,
     layout,
     page["uid"],
@@ -234,6 +235,7 @@ const generatePagePdfMarkdown = (courseData, pathLookup) => {
 
 const generateCourseSectionFrontMatter = (
   title,
+  parentUid,
   parentTitle,
   layout,
   pageId,
@@ -251,6 +253,9 @@ const generateCourseSectionFrontMatter = (
     layout:    layout
   }
 
+  if (parentUid) {
+    courseSectionFrontMatter["parent_uid"] = parentUid
+  }
   if (parentTitle) {
     courseSectionFrontMatter["parent_title"] = parentTitle
   }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -465,6 +465,7 @@ describe("markdown generators", () => {
         type:          "course",
         layout:        "pdf",
         uid:           "d7d1fabcb57a6d4a9cc96f04348dedfd",
+        parent_uid:    "8d3bdda7363b3a4b18d9d5b7c4083899",
         file_type:     "application/pdf",
         file_location:
           "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/d7d1fabcb57a6d4a9cc96f04348dedfd_acknowledgements.pdf",
@@ -489,6 +490,7 @@ describe("markdown generators", () => {
         type:          "course",
         layout:        "pdf",
         uid:           "a1bfc34ccf08ddf8474627b9a13d6ca8",
+        parent_uid:    "0daf498714598983aa855689f242c83b",
         file_type:     "application/pdf",
         file_location:
           "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/a1bfc34ccf08ddf8474627b9a13d6ca8_summary_w12d2.pdf",

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -266,7 +266,7 @@ describe("markdown generators", () => {
       })
     })
 
-    it("sets a parent_title property on second tier pages", () => {
+    it("sets a parent_uid and parent_title property on second tier pages", () => {
       const markdownData = markdownGenerators.generateMarkdownFromJson(
         imageGalleryCourseJsonData,
         pathLookup
@@ -275,8 +275,23 @@ describe("markdown generators", () => {
         const frontMatter = yaml.safeLoad(
           sectionMarkdownData["data"].split("---\n")[1]
         )
-        if (frontMatter["uid"] === "eb66e88131e84c5dae78ba67407a1fc6") {
-          assert.equal(frontMatter["parent_title"], "Instructor Insights")
+        if (
+          frontMatter["uid"] === "1c2cb2ad1c70fd66f19e20103dc94595" &&
+          sectionMarkdownData["children"].length > 0
+        ) {
+          sectionMarkdownData["children"].forEach(childSection => {
+            const childFrontMatter = yaml.safeLoad(
+              childSection["data"].split("---\n")[1]
+            )
+            assert.equal(
+              childFrontMatter["parent_uid"],
+              "1c2cb2ad1c70fd66f19e20103dc94595"
+            )
+            assert.equal(
+              childFrontMatter["parent_title"],
+              "Instructor Insights"
+            )
+          })
         }
       })
     })
@@ -493,13 +508,9 @@ describe("markdown generators", () => {
           .generateCourseSectionFrontMatter(
             "Syllabus",
             null,
-            "course_section",
-            "Syllabus",
-            "syllabus",
             null,
-            true,
-            false,
-            10,
+            "course_section",
+            "syllabus",
             false,
             singleCourseJsonData["short_url"]
           )
@@ -525,13 +536,9 @@ describe("markdown generators", () => {
           .generateCourseSectionFrontMatter(
             "Syllabus",
             null,
-            "course_section",
-            "Syllabus",
-            "syllabus",
             null,
-            false,
-            false,
-            10,
+            "course_section",
+            "syllabus",
             false,
             singleCourseJsonData["short_url"]
           )
@@ -543,6 +550,7 @@ describe("markdown generators", () => {
     it("handles missing short_page_title correctly", async () => {
       const yaml = markdownGenerators.generateCourseSectionFrontMatter(
         "Syllabus",
+        null,
         null,
         "course_section",
         "syllabus",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/issues/430

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/311, we moved nav menu configuration into a single `menus.yaml` file.  `ocw-studio`'s import functionality that consumes the output of `ocw-to-hugo` is currently configured to use the old front matter based menu entries to determine the parent / child relationships of imported pages.  This PR adds the `parent_uid` property to sections that have a parent so `ocw-studio` can determine this relationship without depending on the menu entries.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before
 - Set up `ocw-to-hugo` to download content from S3
 - Convert a course that has a section with children, like `12-001-introduction-to-geology-fall-2013`
 - Inspect the output and make sure pages in the Instructor Insights section have `parent_uid` properties and the UID matches the UID of the Instructor Insights page itself