### PR TITLE
move course description to the course data template

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -1,13 +1,15 @@
 const moment = require("moment")
 
+const { generateCourseDescription } = require("./markdown_generators")
 const { INPUT_COURSE_DATE_FORMAT } = require("./constants")
 const helpers = require("./helpers")
 
 const generateDataTemplate = (courseData, pathLookup) => {
   return {
-    course_id:        courseData["short_url"],
-    course_title:     courseData["title"],
-    course_image_url: helpers.stripS3(
+    course_id:          courseData["short_url"],
+    course_title:       courseData["title"],
+    course_description: generateCourseDescription(courseData, pathLookup),
+    course_image_url:   helpers.stripS3(
       courseData["image_src"] ? courseData["image_src"] : ""
     ),
     course_thumbnail_image_url: helpers.stripS3(

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -7,6 +7,7 @@ const tmp = require("tmp")
 
 const { INPUT_COURSE_DATE_FORMAT } = require("./constants")
 const fileOperations = require("./file_operations")
+const markdownGenerators = require("./markdown_generators")
 const { generateDataTemplate } = require("./data_template_generators")
 const helpers = require("./helpers")
 
@@ -67,6 +68,15 @@ describe("generateDataTemplate", () => {
   it("sets the course_title property to the title property of the course json data", () => {
     const expectedValue = singleCourseJsonData["title"]
     const foundValue = courseDataTemplate["course_title"]
+    assert.equal(expectedValue, foundValue)
+  })
+
+  it("sets the course_description property to the markdown converted course description and other information text", () => {
+    const expectedValue = markdownGenerators.generateCourseDescription(
+      singleCourseJsonData,
+      pathLookup
+    )
+    const foundValue = courseDataTemplate["course_description"]
     assert.equal(expectedValue, foundValue)
   })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -174,26 +174,6 @@ const generateCourseHomeMarkdown = (courseData, pathLookup) => {
       coursePage["type"] === "CourseHomeSection" ||
       coursePage["type"] === "SRHomePage"
   )
-  const courseDescription = courseData["description"]
-    ? html2markdown(
-      fixLinks(
-        courseData["description"],
-        courseHomePage,
-        courseData,
-        pathLookup
-      )
-    )
-    : ""
-  const otherInformationText = courseData["other_information_text"]
-    ? html2markdown(
-      fixLinks(
-        courseData["other_information_text"],
-        courseHomePage,
-        courseData,
-        pathLookup
-      )
-    )
-    : ""
 
   const pageId = courseHomePage ? courseHomePage["uid"] : ""
   const frontMatter = {
@@ -204,9 +184,7 @@ const generateCourseHomeMarkdown = (courseData, pathLookup) => {
     course_id: courseData["short_url"]
   }
   try {
-    return `---\n${yaml.safeDump(
-      frontMatter
-    )}---\n${courseDescription}\n${otherInformationText}`
+    return `---\n${yaml.safeDump(frontMatter)}---\n`
   } catch (err) {
     loggers.fileLogger.error(err)
     return null
@@ -400,6 +378,40 @@ const generateCourseFeaturesMarkdown = (page, courseData, pathLookup) => {
   return ""
 }
 
+const generateCourseDescription = (courseData, pathLookup) => {
+  const courseHomePage = courseData["course_pages"].find(
+    coursePage =>
+      coursePage["type"] === "CourseHomeSection" ||
+      coursePage["type"] === "SRHomePage"
+  )
+  const courseDescription = courseData["description"]
+    ? html2markdown(
+      fixLinks(
+        courseData["description"],
+        courseHomePage,
+        courseData,
+        pathLookup
+      )
+    )
+    : ""
+  const otherInformationText = courseData["other_information_text"]
+    ? html2markdown(
+      fixLinks(
+        courseData["other_information_text"],
+        courseHomePage,
+        courseData,
+        pathLookup
+      )
+    )
+    : ""
+  try {
+    return `${courseDescription}\n${otherInformationText}`
+  } catch (err) {
+    loggers.fileLogger.error(err)
+    return null
+  }
+}
+
 module.exports = {
   generateMarkdownFromJson,
   generateCourseHomeMarkdown,
@@ -407,5 +419,6 @@ module.exports = {
   generateCourseSectionFrontMatter,
   generateCourseSectionMarkdown,
   generateCourseFeaturesMarkdown,
+  generateCourseDescription,
   fixLinks
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/322

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/42, we added a `course_description` markdown field to the course metadata.  Since we will be storing the course description here moving forward, legacy data should be adjusted to reflect this change.  This PR moves rendering of the course description from the markdown body of the course home page to a new `course_description` property in the course data template.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before
 - Convert any number of courses
 - Inspect the output.  The course home page in each course (`_index.md` at the root of the course) should have an empty markdown body now and the data template (`data/course.json`) should contain a new `course_description` property with a markdown string
