### PR TITLE
course description document relative urls

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,9 @@
 module.exports = {
   REPLACETHISWITHAPIPE:                "REPLACETHISWITHAPIPE",
-  BASEURL_SHORTCODE:                   "BASEURL_SHORTCODE",
+  BASEURL_PLACEHOLDER:                 "BASEURL_PLACEHOLDER",
+  BASEURL_PLACEHOLDER_REGEX:           new RegExp("BASEURL_PLACEHOLDER", "g"),
+  BASEURL_SHORTCODE:                   "{{< baseurl >}}",
+  ROOT_RELATIVE_REGEX:                 /<a href="\//g,
   YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS: "youtube-placeholder",
   MISSING_JSON_ERROR_MESSAGE:
     "To download courses from AWS, you must specify the -c argument.  For more information, see README.md",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,10 +10,12 @@ const DEPARTMENTS_JSON = require("./departments.json")
 const EXTERNAL_LINKS_JSON = require("./external_links.json")
 const {
   AWS_REGEX,
-  BASEURL_SHORTCODE,
+  BASEURL_PLACEHOLDER,
+  BASEURL_PLACEHOLDER_REGEX,
   FILE_TYPE,
   INPUT_COURSE_DATE_FORMAT,
-  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS
+  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
+  ROOT_RELATIVE_REGEX
 } = require("./constants")
 const loggers = require("./loggers")
 const runOptions = {}
@@ -29,7 +31,7 @@ const makeCourseUrlPrefixOrShortcode = (courseId, otherCourseId) => {
   }
 
   if (courseId === otherCourseId) {
-    return BASEURL_SHORTCODE
+    return BASEURL_PLACEHOLDER
   } else {
     return makeCourseUrlPrefix(courseId)
   }
@@ -187,7 +189,7 @@ const getCourseFeatureObject = (courseFeature, courseData, pathLookup) => {
       url,
       courseData,
       pathLookup
-    ).replace(BASEURL_SHORTCODE, "")
+    ).replace(BASEURL_PLACEHOLDER_REGEX, "")
   }
   return featureObject
 }
@@ -196,7 +198,7 @@ const FAKE_BASE_URL = "https://sentinel.example.com"
 const getPathFragments = url =>
   new URL(url, FAKE_BASE_URL).pathname.split("/").filter(Boolean)
 const updatePath = (url, pathPieces) => {
-  const hasBaseUrl = pathPieces[0] && pathPieces[0] === BASEURL_SHORTCODE
+  const hasBaseUrl = pathPieces[0] && pathPieces[0] === BASEURL_PLACEHOLDER
   if (hasBaseUrl) {
     // cut out the shortcode here and add it back in the end
     // so we don't mangle it in the URL object
@@ -210,7 +212,7 @@ const updatePath = (url, pathPieces) => {
     newUrl = newUrl.slice(FAKE_BASE_URL.length)
   }
   if (hasBaseUrl) {
-    newUrl = path.join(BASEURL_SHORTCODE, newUrl)
+    newUrl = path.join(BASEURL_PLACEHOLDER, newUrl)
   }
   return newUrl
 }
@@ -312,7 +314,7 @@ const getYoutubeEmbedCode = media => {
 
 const getVideoPageLink = (media, pathLookup) => {
   return `<a href = "${path.join(
-    BASEURL_SHORTCODE,
+    BASEURL_PLACEHOLDER,
     pathLookup.byUid[media["uid"]].path
   )}">${media["title"]}</a>`
 }
@@ -737,6 +739,12 @@ const parseDspaceUrl = url => {
   return null
 }
 
+const rootRelativeToDocumentRelative = text => {
+  return text
+    .replace(BASEURL_PLACEHOLDER_REGEX, "")
+    .replace(ROOT_RELATIVE_REGEX, '<a href="')
+}
+
 module.exports = {
   distinct,
   directoryExists,
@@ -775,5 +783,6 @@ module.exports = {
   getPathFragments,
   updatePath,
   makeCourseInfoUrl,
-  parseDspaceUrl
+  parseDspaceUrl,
+  rootRelativeToDocumentRelative
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -8,6 +8,7 @@ tmp.setGracefulCleanup()
 const helpers = require("./helpers")
 const loggers = require("./loggers")
 const fileOperations = require("./file_operations")
+const { BASEURL_SHORTCODE, BASEURL_PLACEHOLDER } = require("./constants")
 
 const testDataPath = "test_data/courses"
 const testCourse =
@@ -272,15 +273,15 @@ describe("resolveUidMatches", () => {
       [
         {
           match:       [`./resolveuid/${uid1}`],
-          replacement: "BASEURL_SHORTCODE/path/1/"
+          replacement: "BASEURL_PLACEHOLDER/path/1/"
         },
         {
           match:       [`./resolveuid/${uid2}`],
-          replacement: "BASEURL_SHORTCODE/path/2/"
+          replacement: "BASEURL_PLACEHOLDER/path/2/"
         },
         {
           match:       [`./resolveuid/${uid3}`],
-          replacement: "BASEURL_SHORTCODE/path/3/"
+          replacement: "BASEURL_PLACEHOLDER/path/3/"
         }
       ]
     )
@@ -314,7 +315,7 @@ describe("resolveUidMatches", () => {
     const pageResult = result.find(item => item.match[0] === link)
     assert.deepEqual(pageResult, {
       replacement:
-        "BASEURL_SHORTCODE/sections/instructor-insights/planning-a-good-field-trip",
+        "BASEURL_PLACEHOLDER/sections/instructor-insights/planning-a-good-field-trip",
       match: [link]
     })
   })
@@ -335,7 +336,7 @@ describe("resolveUidMatches", () => {
     )
     const fileResult = result.find(item => item.match[0] === link)
     assert.deepEqual(fileResult, {
-      replacement: `BASEURL_SHORTCODE/sections/field-trip/mit12_001f14_field_trip`,
+      replacement: `BASEURL_PLACEHOLDER/sections/field-trip/mit12_001f14_field_trip`,
       match:       [link]
     })
   })
@@ -401,7 +402,7 @@ describe("resolveUidMatches", () => {
           }
           : {
             match:       [`./resolveuid/${uid}`],
-            replacement: `BASEURL_SHORTCODE/`
+            replacement: `BASEURL_PLACEHOLDER/`
           }
       ])
     })
@@ -466,7 +467,7 @@ describe("resolveRelativeLinkMatches", () => {
     assert.equal(result[0].match.index, 121)
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_SHORTCODE/sections/projects"'
+      'href="BASEURL_PLACEHOLDER/sections/projects"'
     )
   })
 
@@ -480,7 +481,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_SHORTCODE/sections/study-materials/mit2_00ajs09_lec02"'
+      'href="BASEURL_PLACEHOLDER/sections/study-materials/mit2_00ajs09_lec02"'
     )
   })
 
@@ -532,7 +533,7 @@ describe("resolveRelativeLinkMatches", () => {
     assert.equal(result[0].match.index, 121)
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_SHORTCODE/sections/projects"'
+      'href="BASEURL_PLACEHOLDER/sections/projects"'
     )
     const link =
       "/courses/mathematics/18-01-single-variable-calculus-fall-2006/exams/prfinalsol.pdf"
@@ -573,7 +574,7 @@ describe("resolveRelativeLinkMatches", () => {
         result[0].replacement,
         external
           ? `href="/courses/${otherCourseId}/sections/syllabus#Table_organization"`
-          : 'href="BASEURL_SHORTCODE/sections/syllabus#Table_organization"'
+          : 'href="BASEURL_PLACEHOLDER/sections/syllabus#Table_organization"'
       )
     })
   })
@@ -589,7 +590,7 @@ describe("resolveRelativeLinkMatches", () => {
       )
       assert.equal(
         result[0].replacement,
-        'href="BASEURL_SHORTCODE/#Table_organization"'
+        'href="BASEURL_PLACEHOLDER/#Table_organization"'
       )
     })
   })
@@ -603,7 +604,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_SHORTCODE/sections/a/b/c/d/e#Table_organization"'
+      'href="BASEURL_PLACEHOLDER/sections/a/b/c/d/e#Table_organization"'
     )
   })
 
@@ -651,7 +652,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_SHORTCODE/sections/comps-programming/m19"'
+      'href="BASEURL_PLACEHOLDER/sections/comps-programming/m19"'
     )
   })
 
@@ -674,7 +675,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_SHORTCODE/sections/signals-systems/objectives"'
+      'href="BASEURL_PLACEHOLDER/sections/signals-systems/objectives"'
     )
   })
 
@@ -756,7 +757,7 @@ describe("resolveYouTubeEmbedMatches", () => {
     assert.deepEqual(results, [
       {
         replacement:
-          '<a href = "BASEURL_SHORTCODE/sections/instructor-insights/instructor-interview-course-iteration">Instructor Interview: Incorporating Authentic Text Going Forward</a>',
+          '<a href = "BASEURL_PLACEHOLDER/sections/instructor-insights/instructor-interview-course-iteration">Instructor Interview: Incorporating Authentic Text Going Forward</a>',
         match
       }
     ])
@@ -906,8 +907,8 @@ describe("misc functions", () => {
 
   it("updates the path of a url", () => {
     assert.deepEqual(
-      helpers.updatePath("/a/b/c/", ["BASEURL_SHORTCODE", "d", "e", "f"]),
-      "BASEURL_SHORTCODE/d/e/f"
+      helpers.updatePath("/a/b/c/", ["BASEURL_PLACEHOLDER", "d", "e", "f"]),
+      "BASEURL_PLACEHOLDER/d/e/f"
     )
     assert.deepEqual(helpers.updatePath("/a/b/c/", ["d", "e", "f"]), "/d/e/f")
     assert.deepEqual(
@@ -934,5 +935,12 @@ describe("misc functions", () => {
     it(`parses a dspace URL like ${url}`, () => {
       assert.equal(helpers.parseDspaceUrl(url), expected)
     })
+  })
+
+  it("turns root relative urls into document relative urls", () => {
+    const input = `<a href="${BASEURL_PLACEHOLDER}/projects/tools">Tools</a>`
+    const output = helpers.rootRelativeToDocumentRelative(input)
+    const expected = `<a href="projects/tools">Tools</a>`
+    assert.equal(output, expected)
   })
 })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -2,6 +2,7 @@ const path = require("path")
 const yaml = require("js-yaml")
 const stripHtml = require("string-strip-html")
 
+const { BASEURL_PLACEHOLDER_REGEX } = require("./constants")
 const helpers = require("./helpers")
 const loggers = require("./loggers")
 const { html2markdown } = require("./turndown")
@@ -386,21 +387,25 @@ const generateCourseDescription = (courseData, pathLookup) => {
   )
   const courseDescription = courseData["description"]
     ? html2markdown(
-      fixLinks(
-        courseData["description"],
-        courseHomePage,
-        courseData,
-        pathLookup
+      helpers.rootRelativeToDocumentRelative(
+        fixLinks(
+          courseData["description"],
+          courseHomePage,
+          courseData,
+          pathLookup
+        )
       )
     )
     : ""
   const otherInformationText = courseData["other_information_text"]
     ? html2markdown(
-      fixLinks(
-        courseData["other_information_text"],
-        courseHomePage,
-        courseData,
-        pathLookup
+      helpers.rootRelativeToDocumentRelative(
+        fixLinks(
+          courseData["other_information_text"],
+          courseHomePage,
+          courseData,
+          pathLookup
+        )
       )
     )
     : ""

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -5,6 +5,7 @@ const { gfm, tables } = turndownPluginGfm
 const {
   REPLACETHISWITHAPIPE,
   AWS_REGEX,
+  BASEURL_PLACEHOLDER,
   BASEURL_SHORTCODE,
   SUPPORTED_IFRAME_EMBEDS,
   YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
@@ -242,7 +243,7 @@ turndownService.addRule("quoteshortcode", {
 turndownService.addRule("baseurlshortcode", {
   filter: (node, options) => {
     if (node.nodeName === "A" && node.getAttribute("href")) {
-      if (node.getAttribute("href").includes(BASEURL_SHORTCODE)) {
+      if (node.getAttribute("href").includes(BASEURL_PLACEHOLDER)) {
         return true
       }
     }
@@ -251,7 +252,7 @@ turndownService.addRule("baseurlshortcode", {
   replacement: (content, node, options) => {
     return `[${content}](${node
       .getAttribute("href")
-      .replace(BASEURL_SHORTCODE, "{{< baseurl >}}")})`
+      .replace(BASEURL_PLACEHOLDER, BASEURL_SHORTCODE)})`
   }
 })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/325

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/323, we moved the course description from the markdown body of the course home page into the course data template, `course.json`.  Some course descriptions contain relative or `resolveuid` links to other sections. Because of the issue described in [this](https://github.com/gohugoio/hugo/issues/6703) thread, there is no way to have Hugo render shortcodes from markdown other than the markdown in the body of a `.md` ffile processed by Hugo during the build.  This PR transforms all links in the course description from a root relative link prefixed with the `baseurl` shortcode to a document relative link.  This is safe as long as `course_description` is only ever rendered on the course home page.  If `course_description` were to be rendered on another page, then the links would be generated relative to that page.  This has been discussed as a safe assumption for legacy courses.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before, and make sure you are configured to download courses from S3
 - Put the following in your `courses.json` folder:
```
{
  "courses": [
    "12-000-solving-complex-problems-fall-2003",
    "8-01sc-classical-mechanics-fall-2016"
  ]
}
```
 - Run `node . -i private/input -o private/output -c private/courses.json --download`
 - inspect the `course_description` property of the `data/course.json` files in the output folder for each course.  Any URL's in `href` properties should not contain the `baseurl` shortcode prefix nor a leading slash.  They should be document relative.
