### PR TITLE
adjust output to more closely match exported courses from ocw-studio

### DIFF
--- a/src/config_generators_test.js
+++ b/src/config_generators_test.js
@@ -40,13 +40,13 @@ describe("generateMenuItems", () => {
         {
           identifier: "b6c8c090d7079126837f7dda4af627c7",
           name:       "Syllabus",
-          url:        "/sections/onlinecourse",
+          url:        "/pages/onlinecourse",
           weight:     10
         },
         {
           identifier: "2c792bd745905d336e5077b0ae1237e1",
           name:       "Calendar",
-          url:        "/sections/calendar",
+          url:        "/pages/calendar",
           weight:     20
         },
         {

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -6,7 +6,6 @@ const helpers = require("./helpers")
 
 const generateDataTemplate = (courseData, pathLookup) => {
   return {
-    course_id:          courseData["short_url"],
     course_title:       courseData["title"],
     course_description: generateCourseDescription(courseData, pathLookup),
     course_image_url:   helpers.stripS3(

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -59,12 +59,6 @@ describe("generateDataTemplate", () => {
     sandbox.restore()
   })
 
-  it("sets the course_id property to the short_url property of the course json data", () => {
-    const expectedValue = singleCourseJsonData["short_url"]
-    const foundValue = courseDataTemplate["course_id"]
-    assert.equal(expectedValue, foundValue)
-  })
-
   it("sets the course_title property to the title property of the course json data", () => {
     const expectedValue = singleCourseJsonData["title"]
     const foundValue = courseDataTemplate["course_title"]

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -281,24 +281,24 @@ describe("file operations", () => {
       rimraf.sync(path.join(outputPath, "*"))
     })
 
-    it("calls mkDir to create sections folder", () => {
+    it("calls mkDir to create pages folder", () => {
       expect(mkDirStub).to.be.calledWith(
-        path.join(outputPath, singleCourseId, "sections")
+        path.join(outputPath, singleCourseId, "pages")
       )
     })
 
-    it("calls mkDir to create subfolders for sections with children", () => {
+    it("calls mkDir to create subfolders for pages with children", () => {
       singleCourseMarkdownData
         .filter(file => file["name"] !== "_index.md")
         .forEach(file => {
           if (file["children"].length > 0) {
             const child = singleCourseJsonData["course_pages"].filter(
               page =>
-                path.join("sections", page["short_url"], "_index.md") ===
+                path.join("pages", page["short_url"], "_index.md") ===
                 file["name"]
             )[0]
             expect(mkDirStub).to.be.calledWith(
-              path.join(outputPath, singleCourseId, "sections")
+              path.join(outputPath, singleCourseId, "pages")
             )
           }
         })
@@ -330,7 +330,7 @@ describe("file operations", () => {
       const uids = pathLookup.byUid
       assert.deepEqual(uids["93e58d46191f9fc3c54ec80752ad3b80"], {
         course:       "12-001-introduction-to-geology-fall-2013",
-        path:         "/sections/lecture-notes-and-slides/MIT12_001F13_Lec5Notes.pdf",
+        path:         "/pages/lecture-notes-and-slides/MIT12_001F13_Lec5Notes.pdf",
         fileType:     "application/pdf",
         id:           "MIT12_001F13_Lec5Notes.pdf",
         parentUid:    "7a74d241d2fe5d877f747158998d8ed3",
@@ -342,7 +342,7 @@ describe("file operations", () => {
       assert.deepEqual(uids["877f0e43412db8b16e5b2864cf8bf1cc"], {
         course:
           "2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009",
-        path:      "/sections/labs",
+        path:      "/pages/labs",
         type:      PAGE_TYPE,
         parentUid: "e395587c58555f1fe564e8afd75899e6",
         uid:       "877f0e43412db8b16e5b2864cf8bf1cc"
@@ -362,7 +362,7 @@ describe("file operations", () => {
       })
       assert.deepEqual(uids["b03952e4bdfcea4962271aeae1dedb3f"], {
         course:    "ec-711-d-lab-energy-spring-2011",
-        path:      "/sections/intro-energy-basics-human-power/lab-1-human-power",
+        path:      "/pages/intro-energy-basics-human-power/lab-1-human-power",
         type:      EMBEDDED_MEDIA_PAGE_TYPE,
         parentUid: "32a22e0de0add67342ce41445297fce7",
         uid:       "b03952e4bdfcea4962271aeae1dedb3f"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -326,9 +326,9 @@ const buildPathRecursive = (item, itemsLookup, courseUid, pathLookup) => {
   const parentItem = itemsLookup[parentUid]
 
   if (courseUid === parentUid) {
-    // course is the parent, so link should be off of /sections
+    // course is the parent, so link should be off of /pages
     const filename = page[filenameKey]
-    pathLookup[uid] = path.join("/sections", filename)
+    pathLookup[uid] = path.join("/pages", filename)
     return
   }
 
@@ -552,7 +552,7 @@ const resolveRelativeLink = (url, courseData, pathLookup, useDirectLink) => {
 
         return updatePath(url, [
           makeCourseUrlPrefixOrShortcode(courseId, thisCourseId),
-          ...(paths.length ? ["sections", ...paths] : [])
+          ...(paths.length ? ["pages", ...paths] : [])
         ])
       }
     }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -101,43 +101,43 @@ describe("getInternalMenuItems", () => {
       {
         identifier: "14896ec808d2b8ea4b434109ba3fb682",
         name:       "Syllabus",
-        url:        "/sections/syllabus",
+        url:        "/pages/syllabus",
         weight:     10
       },
       {
         identifier: "94beff3d30e5e7bc06fd9421fe63803d",
         name:       "Calendar",
-        url:        "/sections/calendar",
+        url:        "/pages/calendar",
         weight:     20
       },
       {
         identifier: "303c499be5d236b1cde0bb36d615f4e7",
         name:       "Study Materials",
-        url:        "/sections/study-materials",
+        url:        "/pages/study-materials",
         weight:     30
       },
       {
         identifier: "877f0e43412db8b16e5b2864cf8bf1cc",
         name:       "Labs",
-        url:        "/sections/labs",
+        url:        "/pages/labs",
         weight:     40
       },
       {
         identifier: "1016059a65d256e4e12de4f25591a1b8",
         name:       "Assignments",
-        url:        "/sections/assignments",
+        url:        "/pages/assignments",
         weight:     50
       },
       {
         identifier: "293500564c0073c5971dfc2bbf334afc",
         name:       "Projects",
-        url:        "/sections/projects",
+        url:        "/pages/projects",
         weight:     60
       },
       {
         identifier: "9759c68f7ab55cc86388d95ca05794f4",
         name:       "Related Resources",
-        url:        "/sections/related-resources",
+        url:        "/pages/related-resources",
         weight:     70
       }
     ]
@@ -303,7 +303,7 @@ describe("resolveUidMatches", () => {
         byUid: {
           ef6931d2c8e6bc0b8e9a5572a78fe125: {
             course: courseId,
-            path:   "/sections/instructor-insights/planning-a-good-field-trip"
+            path:   "/pages/instructor-insights/planning-a-good-field-trip"
           },
           de36fe69cf33ddf238bc3896d0ce9eff: {
             course: courseId,
@@ -315,7 +315,7 @@ describe("resolveUidMatches", () => {
     const pageResult = result.find(item => item.match[0] === link)
     assert.deepEqual(pageResult, {
       replacement:
-        "BASEURL_PLACEHOLDER/sections/instructor-insights/planning-a-good-field-trip",
+        "BASEURL_PLACEHOLDER/pages/instructor-insights/planning-a-good-field-trip",
       match: [link]
     })
   })
@@ -336,7 +336,7 @@ describe("resolveUidMatches", () => {
     )
     const fileResult = result.find(item => item.match[0] === link)
     assert.deepEqual(fileResult, {
-      replacement: `BASEURL_PLACEHOLDER/sections/field-trip/mit12_001f14_field_trip`,
+      replacement: `BASEURL_PLACEHOLDER/pages/field-trip/mit12_001f14_field_trip`,
       match:       [link]
     })
   })
@@ -467,7 +467,7 @@ describe("resolveRelativeLinkMatches", () => {
     assert.equal(result[0].match.index, 121)
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_PLACEHOLDER/sections/projects"'
+      'href="BASEURL_PLACEHOLDER/pages/projects"'
     )
   })
 
@@ -481,7 +481,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_PLACEHOLDER/sections/study-materials/mit2_00ajs09_lec02"'
+      'href="BASEURL_PLACEHOLDER/pages/study-materials/mit2_00ajs09_lec02"'
     )
   })
 
@@ -496,7 +496,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="/courses/12-001-introduction-to-geology-fall-2013/sections/field-trip/mit12_001f14_field_trip"'
+      'href="/courses/12-001-introduction-to-geology-fall-2013/pages/field-trip/mit12_001f14_field_trip"'
     )
   })
 
@@ -533,7 +533,7 @@ describe("resolveRelativeLinkMatches", () => {
     assert.equal(result[0].match.index, 121)
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_PLACEHOLDER/sections/projects"'
+      'href="BASEURL_PLACEHOLDER/pages/projects"'
     )
     const link =
       "/courses/mathematics/18-01-single-variable-calculus-fall-2006/exams/prfinalsol.pdf"
@@ -552,7 +552,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/sections/syllabus#Table_organization"'
+      'href="/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus#Table_organization"'
     )
   })
 
@@ -573,8 +573,8 @@ describe("resolveRelativeLinkMatches", () => {
       assert.equal(
         result[0].replacement,
         external
-          ? `href="/courses/${otherCourseId}/sections/syllabus#Table_organization"`
-          : 'href="BASEURL_PLACEHOLDER/sections/syllabus#Table_organization"'
+          ? `href="/courses/${otherCourseId}/pages/syllabus#Table_organization"`
+          : 'href="BASEURL_PLACEHOLDER/pages/syllabus#Table_organization"'
       )
     })
   })
@@ -604,7 +604,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_PLACEHOLDER/sections/a/b/c/d/e#Table_organization"'
+      'href="BASEURL_PLACEHOLDER/pages/a/b/c/d/e#Table_organization"'
     )
   })
 
@@ -652,7 +652,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_PLACEHOLDER/sections/comps-programming/m19"'
+      'href="BASEURL_PLACEHOLDER/pages/comps-programming/m19"'
     )
   })
 
@@ -675,7 +675,7 @@ describe("resolveRelativeLinkMatches", () => {
     )
     assert.equal(
       result[0].replacement,
-      'href="BASEURL_PLACEHOLDER/sections/signals-systems/objectives"'
+      'href="BASEURL_PLACEHOLDER/pages/signals-systems/objectives"'
     )
   })
 
@@ -690,7 +690,7 @@ describe("resolveRelativeLinkMatches", () => {
       )
       assert.equal(
         result[0].replacement,
-        'href="/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/sections/syllabus#Table_organization"'
+        'href="/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus#Table_organization"'
       )
     })
   })
@@ -757,7 +757,7 @@ describe("resolveYouTubeEmbedMatches", () => {
     assert.deepEqual(results, [
       {
         replacement:
-          '<a href = "BASEURL_PLACEHOLDER/sections/instructor-insights/instructor-interview-course-iteration">Instructor Interview: Incorporating Authentic Text Going Forward</a>',
+          '<a href = "BASEURL_PLACEHOLDER/pages/instructor-insights/instructor-interview-course-iteration">Instructor Interview: Incorporating Authentic Text Going Forward</a>',
         match
       }
     ])
@@ -842,19 +842,16 @@ describe("buildPathsForCourse", () => {
     const paths = helpers.buildPathsForCourse(singleCourseJsonData)
     assert.equal(
       paths["303c499be5d236b1cde0bb36d615f4e7"],
-      "/sections/study-materials"
+      "/pages/study-materials"
     )
-    assert.equal(
-      paths["42664d52bd9a5b1632bac20876dc344d"],
-      "/sections/index.htm"
-    )
+    assert.equal(paths["42664d52bd9a5b1632bac20876dc344d"], "/pages/index.htm")
     assert.equal(
       paths["b6a31a6a85998d664ea826a766d9032b"],
-      "/sections/2-00ajs09.jpg"
+      "/pages/2-00ajs09.jpg"
     )
     assert.equal(
       paths["6f5063fc562d919e4005ac2c983eefb7"],
-      "/sections/study-materials/MIT2_00AJs09_res01B.pdf"
+      "/pages/study-materials/MIT2_00AJs09_res01B.pdf"
     )
     assert.lengthOf(Object.values(paths), 67)
   })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -82,8 +82,6 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
 
       return {
         ...courseEmbeddedMedia,
-        course_id:      courseData["short_url"],
-        type:           "course",
         layout:         "video",
         embedded_media: embeddedMediaItems
       }
@@ -101,9 +99,7 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
     page["short_url"] === "instructor-insights" ||
     (hasParent && parent["type"] === "ThisCourseAtMITSection") ||
     (hasParent && parent["short_url"] === "instructor-insights")
-  const layout = isInstructorInsightsSection
-    ? "instructor_insights"
-    : "course_section"
+  const layout = isInstructorInsightsSection ? "instructor_insights" : null
   let courseSectionMarkdown = generateCourseSectionFrontMatter(
     page["title"],
     hasParent ? parent["uid"] : null,
@@ -178,11 +174,8 @@ const generateCourseHomeMarkdown = (courseData, pathLookup) => {
 
   const pageId = courseHomePage ? courseHomePage["uid"] : ""
   const frontMatter = {
-    uid:       pageId,
-    title:     "",
-    type:      "course",
-    layout:    "course_home",
-    course_id: courseData["short_url"]
+    uid:   pageId,
+    title: ""
   }
   try {
     return `---\n${yaml.safeDump(frontMatter)}---\n`
@@ -225,11 +218,8 @@ const generateCourseSectionFrontMatter = (
     Generate the front matter metadata for a course section
     */
   const courseSectionFrontMatter = {
-    uid:       pageId,
-    title:     title,
-    course_id: courseId,
-    type:      "course",
-    layout:    layout
+    uid:   pageId,
+    title: title
   }
 
   if (parentUid) {
@@ -241,6 +231,10 @@ const generateCourseSectionFrontMatter = (
 
   if (isMediaGallery) {
     courseSectionFrontMatter["is_media_gallery"] = true
+  }
+
+  if (layout) {
+    courseSectionFrontMatter["layout"] = layout
   }
   return `---\n${yaml.safeDump(courseSectionFrontMatter)}---\n`
 }
@@ -283,13 +277,11 @@ const generatePdfMarkdown = (file, courseData) => {
   const pdfFrontMatter = {
     title:         file["title"],
     description:   file["description"],
-    type:          "course",
     layout:        "pdf",
     uid:           file["uid"],
     parent_uid:    file["parent_uid"],
     file_type:     file["file_type"],
-    file_location: helpers.stripS3(file["file_location"]),
-    course_id:     courseData["short_url"]
+    file_location: helpers.stripS3(file["file_location"])
   }
   return `---\n${yaml.safeDump(pdfFrontMatter)}---\n`
 }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -172,7 +172,7 @@ describe("markdown generators", () => {
         )
         .map(page => page["short_url"])
       expectedSections.forEach(expectedSection => {
-        let filename = `sections/${expectedSection}`
+        let filename = `pages/${expectedSection}`
         const sectionMarkdownData = singleCourseMarkdownData.filter(
           section =>
             section["name"] === `${filename}.md` ||
@@ -210,7 +210,7 @@ describe("markdown generators", () => {
           ).filter(embeddedMedia => embeddedMedia["parent_uid"] === sectionUid)
           expectedChildren.forEach(expectedChild => {
             const childFilename = path.join(
-              "sections/",
+              "pages/",
               expectedChild["url"].split("/")[4],
               "river-testing-photos.md"
             )
@@ -222,7 +222,7 @@ describe("markdown generators", () => {
             )[0]
             const fragmentUrlPieces = fragment.url.split("/")
             const fileFilename = path.join(
-              "sections",
+              "pages",
               fragmentUrlPieces[fragmentUrlPieces.length - 1],
               `${expectedFile["id"].replace(".pdf", "")}.md`
             )
@@ -236,12 +236,6 @@ describe("markdown generators", () => {
             assert.include(mediaMarkdownFileNames, mediaFilename)
           })
         }
-      })
-    })
-
-    it("puts the course_id in every course page's markdown", () => {
-      singleCourseMarkdownData.forEach(sectionMarkdownData => {
-        assertCourseIdRecursive(sectionMarkdownData, singleCourseId)
       })
     })
 
@@ -462,14 +456,12 @@ describe("markdown generators", () => {
         title:       "acknowledgements.pdf",
         description:
           "This resource contains acknowledgements to the persons who helped build this course.",
-        type:          "course",
         layout:        "pdf",
         uid:           "d7d1fabcb57a6d4a9cc96f04348dedfd",
         parent_uid:    "8d3bdda7363b3a4b18d9d5b7c4083899",
         file_type:     "application/pdf",
         file_location:
-          "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/d7d1fabcb57a6d4a9cc96f04348dedfd_acknowledgements.pdf",
-        course_id: "8-02-physics-ii-electricity-and-magnetism-spring-2007"
+          "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/d7d1fabcb57a6d4a9cc96f04348dedfd_acknowledgements.pdf"
       })
     })
 
@@ -482,19 +474,17 @@ describe("markdown generators", () => {
       const markdown = yaml.safeLoad(
         pdfMarkdownFile["data"].replace(/---\n/g, "")
       )
-      assert.equal(fileName, "/sections/readings/summary_w12d2.md")
+      assert.equal(fileName, "/pages/readings/summary_w12d2.md")
       assert.deepEqual(markdown, {
         title:       "summary_w12d2.pdf",
         description:
           "This file talks about how electricity and magnetism interact with each other and also considers finalizing Maxwell?s Equations, their result ? electromagnetic (EM) radiation and how energy flows in electric and magnetic fields.",
-        type:          "course",
         layout:        "pdf",
         uid:           "a1bfc34ccf08ddf8474627b9a13d6ca8",
         parent_uid:    "0daf498714598983aa855689f242c83b",
         file_type:     "application/pdf",
         file_location:
-          "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/a1bfc34ccf08ddf8474627b9a13d6ca8_summary_w12d2.pdf",
-        course_id: "8-02-physics-ii-electricity-and-magnetism-spring-2007"
+          "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/a1bfc34ccf08ddf8474627b9a13d6ca8_summary_w12d2.pdf"
       })
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/330
Closes https://github.com/mitodl/ocw-to-hugo/issues/329

#### What's this PR do?
As we move toward publishing courses with `ocw-studio`, a number of adjustments to `ocw-hugo-themes` have been necessary to support the way `ocw-studio` outputs courses as well as generally improve our usage of Hugo.  This PR does a number of things, including:

 - Renames the `sections` folder to `pages` to match the type defined in the `ocw-course` starter that `ocw-studio` uses
 - Removes the `course_home` and `course_section` layout definitions from various pages and instead relies on these layouts being more aligned with the Hugo defaults, `layouts/home.html` for the course home page and `layouts/pages/single.html` for course sections
 - Removes the `type: course` declaration from various pages
 - Removes the `course_id` definition from the data template as well as any pages generated by `ocw-to-hugo`

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before and make sure you are set up to download course data from S3
 - Run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download`
 - Inspect the courses output to `private/output`.  Each course should:
   - have its pages output to `content/pages`
   - pages under `content/pages` should not have `type: course` in the front matter
   - pages under `content/pages` should not have `layout: course_section` in the front matter
   - pages under `content/pages` that represent special types of pages like PDF's, Instructor Insights, etc. should still have a layout definition in the front matter
   - no pages nor the course data template (`data/course.json`) should contain `course_id`
   - URLs in `config/_default/menus.yaml` should point to `/pages/<section>`
