### PR TITLE
instructors by uid

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -26,21 +26,11 @@ const generateDataTemplate = (courseData, pathLookup) => {
         INPUT_COURSE_DATE_FORMAT
       ).format()
       : "",
-    instructors: (courseData["instructors"] || []).map(instructor => {
-      const name = instructor["salutation"]
-        ? `${instructor["salutation"]} ${instructor["first_name"]} ${instructor["last_name"]}`
-        : `${instructor["first_name"]} ${instructor["last_name"]}`
-
-      return {
-        instructor:     name,
-        url:            helpers.makeCourseInfoUrl(name, "q"),
-        first_name:     instructor["first_name"],
-        last_name:      instructor["last_name"],
-        middle_initial: instructor["middle_initial"],
-        salutation:     instructor["salutation"],
-        uid:            instructor["uid"]
-      }
-    }),
+    instructors: {
+      content: (courseData["instructors"] || []).map(instructor =>
+        helpers.addDashesToUid(instructor["uid"])
+      )
+    },
     departments:     helpers.getDepartments(courseData),
     course_features: courseData["course_feature_tags"]
       ? courseData["course_feature_tags"].map(courseFeature =>

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -29,7 +29,8 @@ const generateDataTemplate = (courseData, pathLookup) => {
     instructors: {
       content: (courseData["instructors"] || []).map(instructor =>
         helpers.addDashesToUid(instructor["uid"])
-      )
+      ),
+      website: "ocw-www"
     },
     departments:     helpers.getDepartments(courseData),
     course_features: courseData["course_feature_tags"]

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -102,10 +102,13 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets an array of instructor uids under the instructors -> content property", () => {
-    assert.deepEqual(courseDataTemplate["instructors"]["content"], [
-      "e042c8f9-995f-cc11-0a2a-5aafa674c5e6",
-      "07d4f055-5edf-ebf2-c247-7bbf2d19dd91"
-    ])
+    assert.deepEqual(courseDataTemplate["instructors"], {
+      content: [
+        "e042c8f9-995f-cc11-0a2a-5aafa674c5e6",
+        "07d4f055-5edf-ebf2-c247-7bbf2d19dd91"
+      ],
+      website: "ocw-www"
+    })
   })
 
   it("sets the department property to the department found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -101,26 +101,10 @@ describe("generateDataTemplate", () => {
     assert.equal(expectedValue, foundValue)
   })
 
-  it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {
-    assert.deepEqual(courseDataTemplate["instructors"], [
-      {
-        first_name:     "Edward",
-        last_name:      "Crawley",
-        middle_initial: "",
-        salutation:     "Prof.",
-        instructor:     "Prof. Edward Crawley",
-        url:            "/search/?q=%22Prof.%20Edward%20Crawley%22",
-        uid:            "e042c8f9995fcc110a2a5aafa674c5e6"
-      },
-      {
-        first_name:     "Olivier",
-        last_name:      "de Weck",
-        middle_initial: "",
-        salutation:     "Prof.",
-        instructor:     "Prof. Olivier de Weck",
-        url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22",
-        uid:            "07d4f0555edfebf2c2477bbf2d19dd91"
-      }
+  it("sets an array of instructor uids under the instructors -> content property", () => {
+    assert.deepEqual(courseDataTemplate["instructors"]["content"], [
+      "e042c8f9-995f-cc11-0a2a-5aafa674c5e6",
+      "07d4f055-5edf-ebf2-c247-7bbf2d19dd91"
     ])
   })
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -745,6 +745,13 @@ const rootRelativeToDocumentRelative = text => {
     .replace(ROOT_RELATIVE_REGEX, '<a href="')
 }
 
+const addDashesToUid = uid => {
+  return `${uid.substr(0, 8)}-${uid.substr(8, 4)}-${uid.substr(
+    12,
+    4
+  )}-${uid.substr(16, 4)}-${uid.substr(20)}`
+}
+
 module.exports = {
   distinct,
   directoryExists,
@@ -784,5 +791,6 @@ module.exports = {
   updatePath,
   makeCourseInfoUrl,
   parseDspaceUrl,
-  rootRelativeToDocumentRelative
+  rootRelativeToDocumentRelative,
+  addDashesToUid
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -940,4 +940,11 @@ describe("misc functions", () => {
     const expected = `<a href="projects/tools">Tools</a>`
     assert.equal(output, expected)
   })
+
+  it("adds dashes to a uid imported from Plone in the proper spots", () => {
+    const input = "e042c8f9995fcc110a2a5aafa674c5e6"
+    const output = helpers.addDashesToUid(input)
+    const expected = "e042c8f9-995f-cc11-0a2a-5aafa674c5e6"
+    assert.equal(output, expected)
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/340

#### What's this PR do?
In https://github.com/mitodl/ocw-www/pull/127 and https://github.com/mitodl/ocw-hugo-themes/pull/167, we added a static JSON API of instructors that can be referenced in the same way `ocw-studio` links instructors to a course using a relation widget on the course data template.  This PR mimics that structure by adding a `content` key under `instructors` in the course data template and iterating a list of the instructor UUID's there.  In a subsequent `ocw-hugo-themes` PR, the `course` theme will be updated to source instructor data this way using the new instructors static JSON API.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before and make sure you have S3 access set up
 - Run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download --rm`
 - Inspect the output of the course data template.  The `instructors` key should be as described above