### PR TITLE
Refactor path handling

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,6 @@ module.exports = {
   BASEURL_PLACEHOLDER:                 "BASEURL_PLACEHOLDER",
   BASEURL_PLACEHOLDER_REGEX:           new RegExp("BASEURL_PLACEHOLDER", "g"),
   BASEURL_SHORTCODE:                   "{{< baseurl >}}",
-  ROOT_RELATIVE_REGEX:                 /<a href="\//g,
   YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS: "youtube-placeholder",
   MISSING_JSON_ERROR_MESSAGE:
     "To download courses from AWS, you must specify the -c argument.  For more information, see README.md",

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -191,33 +191,6 @@ describe("generateDataTemplate", () => {
     })
   })
 
-  it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {
-    const courseDataTemplate = generateDataTemplate(
-      singleCourseJsonData,
-      pathLookup
-    )
-    assert.deepEqual(courseDataTemplate["instructors"], [
-      {
-        first_name:     "Edward",
-        last_name:      "Crawley",
-        middle_initial: "",
-        salutation:     "Prof.",
-        instructor:     "Prof. Edward Crawley",
-        url:            "/search/?q=%22Prof.%20Edward%20Crawley%22",
-        uid:            "e042c8f9995fcc110a2a5aafa674c5e6"
-      },
-      {
-        first_name:     "Olivier",
-        last_name:      "de Weck",
-        middle_initial: "",
-        salutation:     "Prof.",
-        instructor:     "Prof. Olivier de Weck",
-        url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22",
-        uid:            "07d4f0555edfebf2c2477bbf2d19dd91"
-      }
-    ])
-  })
-
   it("sets the department property to the department found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
     const courseDataTemplate = generateDataTemplate(
       singleCourseJsonData,

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -18,21 +18,28 @@ const singleCourseParsedJsonPath = path.join(
   singleCourseId,
   `${singleCourseId}_parsed.json`
 )
-const singleCourseRawData = fs.readFileSync(singleCourseParsedJsonPath)
-const singleCourseJsonData = JSON.parse(singleCourseRawData)
 
-const physicsCourseId = "8-01sc-classical-mechanics-fall-2016"
-const physicsCourseParsedJsonPath = path.join(
+const mechanicsCourseId = "8-01sc-classical-mechanics-fall-2016"
+const mechanicsCourseJsonPath = path.join(
+  testDataPath,
+  mechanicsCourseId,
+  `${mechanicsCourseId}_parsed.json`
+)
+
+const physicsCourseId = "8-02-physics-ii-electricity-and-magnetism-spring-2007"
+const physicsCourseJsonPath = path.join(
   testDataPath,
   physicsCourseId,
   `${physicsCourseId}_parsed.json`
 )
-const physicsCourseRawData = fs.readFileSync(physicsCourseParsedJsonPath)
-const physicsCourseJsonData = JSON.parse(physicsCourseRawData)
 
 describe("generateDataTemplate", () => {
   const sandbox = sinon.createSandbox()
-  let consoleLog, courseDataTemplate, pathLookup, physicsCourseDataTemplate
+  let consoleLog,
+    pathLookup,
+    singleCourseJsonData,
+    mechanicsCourseJsonData,
+    physicsCourseJsonData
 
   beforeEach(async () => {
     consoleLog = sandbox.stub(console, "log")
@@ -40,6 +47,7 @@ describe("generateDataTemplate", () => {
       "test_data/courses",
       [
         singleCourseId,
+        mechanicsCourseId,
         physicsCourseId,
         "8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002",
         "17-40-american-foreign-policy-past-present-and-future-fall-2017",
@@ -48,11 +56,15 @@ describe("generateDataTemplate", () => {
         "17-40-american-foreign-policy-past-present-and-future-fall-2002"
       ]
     )
-    courseDataTemplate = generateDataTemplate(singleCourseJsonData, pathLookup)
-    physicsCourseDataTemplate = generateDataTemplate(
-      physicsCourseJsonData,
-      pathLookup
-    )
+
+    const singleCourseRawData = fs.readFileSync(singleCourseParsedJsonPath)
+    singleCourseJsonData = JSON.parse(singleCourseRawData)
+
+    const mechanicsCourseRawData = fs.readFileSync(mechanicsCourseJsonPath)
+    mechanicsCourseJsonData = JSON.parse(mechanicsCourseRawData)
+
+    const physicsCourseRawData = fs.readFileSync(physicsCourseJsonPath)
+    physicsCourseJsonData = JSON.parse(physicsCourseRawData)
   })
 
   afterEach(() => {
@@ -60,48 +72,116 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets the course_title property to the title property of the course json data", () => {
-    const expectedValue = singleCourseJsonData["title"]
-    const foundValue = courseDataTemplate["course_title"]
-    assert.equal(expectedValue, foundValue)
-  })
-
-  it("sets the course_description property to the markdown converted course description and other information text", () => {
-    const expectedValue = markdownGenerators.generateCourseDescription(
+    const courseDataTemplate = generateDataTemplate(
       singleCourseJsonData,
       pathLookup
     )
-    const foundValue = courseDataTemplate["course_description"]
-    assert.equal(expectedValue, foundValue)
+    assert.equal(
+      courseDataTemplate["course_title"],
+      "Space Systems Engineering"
+    )
   })
 
-  it("sets the course_image_url property to the image_src property of the course json data", () => {
-    const expectedValue = singleCourseJsonData["image_src"]
-    const foundValue = courseDataTemplate["course_image_url"]
-    assert.equal(expectedValue, foundValue)
+  it("sets the course_description property to the markdown converted course description and other information text", () => {
+    singleCourseJsonData["description"] = "course description"
+    singleCourseJsonData["other_information_text"] = "some other info"
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.equal(
+      courseDataTemplate["course_description"],
+      "course description\nsome other info"
+    )
   })
 
-  it("sets the course_thumbnail_image_url property to the thumbnail_image_src property of the course json data", () => {
-    const expectedValue = singleCourseJsonData["thumbnail_image_src"]
-    const foundValue = courseDataTemplate["course_thumbnail_image_url"]
-    assert.equal(expectedValue, foundValue)
+  //
+  ;["description", "other_information_text"].forEach(key => {
+    [
+      [
+        true,
+        `/courses/physics/${physicsCourseId}/acknowledgements.pdf`,
+        "pages/acknowledgements.pdf"
+      ],
+      [
+        false,
+        "./resolveuid/63e325a780c79e352fb5bddb9b8b2c6a",
+        "/courses/8-01sc-classical-mechanics-fall-2016/pages/week-1-kinematics"
+      ]
+    ].forEach(([sameCourse, url, expected]) => {
+      it(`handles links properly in the course description, when the link is to ${
+        sameCourse ? "the same" : "a different"
+      } course`, () => {
+        physicsCourseJsonData = {
+          ...physicsCourseJsonData,
+          description:            "",
+          other_information_text: "",
+          [key]:                  `<p>(<a href="${url}">PDF</a>)</p>`
+        }
+        const courseDataTemplate = generateDataTemplate(
+          physicsCourseJsonData,
+          pathLookup
+        )
+        assert.include(
+          courseDataTemplate["course_description"],
+          `[PDF](${expected})`
+        )
+      })
+    })
   })
 
-  it("sets the course_image_caption_text property to the image_caption_text property of the course json data", () => {
-    const expectedValue = singleCourseJsonData["image_caption_text"]
-    const foundValue = courseDataTemplate["course_image_caption_text"]
-    assert.equal(expectedValue, foundValue)
+  it("handles relative links properly in course descriptions", () => {
+    singleCourseJsonData[
+      "description"
+    ] = `<a href="/courses/mechanical-engineering/${singleCourseId}/syllabus">syllabus</a>`
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.equal(
+      courseDataTemplate["course_description"],
+      "[syllabus](pages/syllabus)\n"
+    )
+  })
+
+  it("sets various image properties correctly", () => {
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.equal(
+      courseDataTemplate["course_image_url"],
+      "https://open-learning-course-data-production.s3.amazonaws.com/16-89j-space-systems-engineering-spring-2007/2a01cea04000d318a1d63c46d451a0d4_16-89js07.jpg"
+    )
+    assert.equal(
+      courseDataTemplate["course_thumbnail_image_url"],
+      "https://open-learning-course-data-production.s3.amazonaws.com/16-89j-space-systems-engineering-spring-2007/9136249e26df79621171ddd1b58405a3_16-89js07-th.jpg"
+    )
+    assert.equal(
+      courseDataTemplate["course_image_alternate_text"],
+      "Artist's conception of astronauts setting up a lunar telescope array."
+    )
+    assert.equal(
+      courseDataTemplate["course_image_caption_text"],
+      '<p>Astronauts setting up a lunar telescope array. (Image courtesy of <a href="http://www.nasa.gov/mission_pages/exploration/multimedia/jfa18844_prt.htm">NASA</a>.)</p>'
+    )
   })
 
   it("sets the publishdate property to the first_published_to_production property of the course json data", () => {
-    const expectedValue = moment(
-      singleCourseJsonData["first_published_to_production"],
-      INPUT_COURSE_DATE_FORMAT
-    ).format()
-    const foundValue = courseDataTemplate["publishdate"]
-    assert.equal(expectedValue, foundValue)
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.isTrue(
+      courseDataTemplate["publishdate"].startsWith("2008-07-17T16:06:15")
+    )
   })
 
   it("sets an array of instructor uids under the instructors -> content property", () => {
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
     assert.deepEqual(courseDataTemplate["instructors"], {
       content: [
         "e042c8f9-995f-cc11-0a2a-5aafa674c5e6",
@@ -111,7 +191,38 @@ describe("generateDataTemplate", () => {
     })
   })
 
+  it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.deepEqual(courseDataTemplate["instructors"], [
+      {
+        first_name:     "Edward",
+        last_name:      "Crawley",
+        middle_initial: "",
+        salutation:     "Prof.",
+        instructor:     "Prof. Edward Crawley",
+        url:            "/search/?q=%22Prof.%20Edward%20Crawley%22",
+        uid:            "e042c8f9995fcc110a2a5aafa674c5e6"
+      },
+      {
+        first_name:     "Olivier",
+        last_name:      "de Weck",
+        middle_initial: "",
+        salutation:     "Prof.",
+        instructor:     "Prof. Olivier de Weck",
+        url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22",
+        uid:            "07d4f0555edfebf2c2477bbf2d19dd91"
+      }
+    ])
+  })
+
   it("sets the department property to the department found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
     assert.deepEqual(
       [
         {
@@ -132,41 +243,126 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets the course_features property to the instructors found in the instuctors node of the course json data", () => {
-    singleCourseJsonData["course_feature_tags"].forEach(
-      (courseFeature, index) => {
-        const expectedValue = helpers.getCourseFeatureObject(
-          courseFeature,
-          singleCourseJsonData,
-          pathLookup
-        )
-        const foundValue = courseDataTemplate["course_features"][index]
-        sinon.assert.match(expectedValue, foundValue)
-      }
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
     )
+    assert.deepEqual(courseDataTemplate["course_features"], [
+      {
+        feature: "Projects with Examples",
+        url:     "pages/projects"
+      },
+      {
+        feature: "Design Assignments",
+        url:     "pages/assignments"
+      },
+      {
+        feature: "Presentation Assignments with Examples",
+        url:     "pages/projects"
+      },
+      {
+        feature: "Written Assignments with Examples",
+        url:     "pages/assignments"
+      }
+    ])
+  })
+
+  //
+  ;[
+    [true, "./resolveuid/244945a815a4b2a3af2a20384f403eab", "pages/projects"],
+    [
+      false,
+      "./resolveuid/63e325a780c79e352fb5bddb9b8b2c6a",
+      "/courses/8-01sc-classical-mechanics-fall-2016/pages/week-1-kinematics"
+    ]
+  ].forEach(([sameCourse, url, expected]) => {
+    it(`handles links in the course_features property properly when the link is for ${
+      sameCourse ? "the same" : "a different"
+    } course`, () => {
+      singleCourseJsonData["course_feature_tags"] = [
+        {
+          ocw_feature:       "Projects",
+          ocw_subfeature:    "Examples",
+          ocw_feature_url:   url,
+          ocw_speciality:    "",
+          ocw_feature_notes:
+            "Projects section; projects files; file count: 16; file format: .pdf"
+        }
+      ]
+      const courseDataTemplate = generateDataTemplate(
+        singleCourseJsonData,
+        pathLookup
+      )
+      assert.deepEqual(courseDataTemplate["course_features"], [
+        {
+          url: expected
+        }
+      ])
+    })
   })
 
   it("sets the topics property on the course data template to a consolidated list of topics from the course_collections property of the course json data", () => {
-    const expectedValue = helpers.getConsolidatedTopics(
-      singleCourseJsonData["course_collections"]
-    )[0]
-    const foundValue = courseDataTemplate["topics"][0]
-    sinon.assert.match(expectedValue, foundValue)
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.deepEqual(courseDataTemplate["topics"], [
+      {
+        subtopics: [
+          {
+            specialities: [],
+            subtopic:     "Aerospace Engineering",
+            url:          "/search/?t=Aerospace%20Engineering"
+          },
+          {
+            specialities: [],
+            subtopic:     "Systems Engineering",
+            url:          "/search/?t=Systems%20Engineering"
+          }
+        ],
+        topic: "Engineering",
+        url:   "/search/?t=Engineering"
+      },
+      {
+        subtopics: [
+          {
+            specialities: [],
+            subtopic:     "Operations Management",
+            url:          "/search/?t=Operations%20Management"
+          }
+        ],
+        topic: "Business",
+        url:   "/search/?t=Business"
+      }
+    ])
   })
 
   it("sets the primary_course_number property on the course data template to data parsed from department_number and master_course_number in the course json data", () => {
     const expectedValue = helpers.getPrimaryCourseNumber(singleCourseJsonData)
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
     const foundValues = courseDataTemplate["primary_course_number"]
     assert.equal(expectedValue, foundValues)
   })
 
   it("sets the term property on the course data template to from_semester and from_year in the course json data", () => {
     const expectedValue = `${singleCourseJsonData["from_semester"]} ${singleCourseJsonData["from_year"]}`
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
     const foundValue = courseDataTemplate["term"]
     assert.equal(expectedValue, foundValue)
   })
 
   it("sets the level property on the course data template to course_level in the course json data", () => {
     const level = singleCourseJsonData["course_level"]
+    const courseDataTemplate = generateDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
     const foundValue = courseDataTemplate["level"]
     assert.deepEqual(
       {
@@ -181,7 +377,11 @@ describe("generateDataTemplate", () => {
     const expectedValue = [
       "[8.01X PHYSICS I: CLASSICAL MECHANICS WITH AN EXPERIMENTAL FOCUS](/courses/8-01x-physics-i-classical-mechanics-with-an-experimental-focus-fall-2002) |  FALL 2002"
     ]
-    const foundValue = physicsCourseDataTemplate["other_versions"]
+    const courseDataTemplate = generateDataTemplate(
+      mechanicsCourseJsonData,
+      pathLookup
+    )
+    const foundValue = courseDataTemplate["other_versions"]
     assert.deepEqual(expectedValue, foundValue)
   })
 
@@ -230,8 +430,11 @@ describe("generateDataTemplate", () => {
       "[8.01.3x Mechanics-Rotational Dynamics](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.01.3x+1T2019/about) | OPEN LEARNING LIBRARY",
       "[8.01.4x Mechanics-Simple Harmonic Motion](https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.01.4x+1T2019/about) | OPEN LEARNING LIBRARY"
     ]
-    const foundValue =
-      physicsCourseDataTemplate["open_learning_library_versions"]
+    const courseDataTemplate = generateDataTemplate(
+      mechanicsCourseJsonData,
+      pathLookup
+    )
+    const foundValue = courseDataTemplate["open_learning_library_versions"]
     assert.deepEqual(expectedValue, foundValue)
   })
 })

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -96,10 +96,15 @@ const buildCoursePathLookup = async (inputPath, courseList) => {
 
     // add paths for uids found within course and include extra data which is useful for lookup purposes
     const uidInfoLookup = makeUidInfoLookup(courseData)
-    const coursePathLookup = helpers.buildPathsForCourse(courseData)
-    for (const [uid, path] of Object.entries(coursePathLookup)) {
+    const coursePathLookup = helpers.buildPathsForCourse(
+      courseData,
+      uidInfoLookup
+    )
+    for (const [uid, { path, unalteredPath }] of Object.entries(
+      coursePathLookup
+    )) {
       const info = uidInfoLookup[uid] || {}
-      const pathObj = { course, path, uid, ...info }
+      const pathObj = { course, path, unalteredPath, uid, ...info }
       pathLookup[uid] = pathObj
       courseLookupList.push(pathObj)
     }
@@ -109,9 +114,10 @@ const buildCoursePathLookup = async (inputPath, courseList) => {
     const courseInfo = uidInfoLookup[courseUid] || {}
     const pathObj = {
       course,
-      path:      "/",
-      uid:       courseUid,
-      published: helpers.isCoursePublished(courseData),
+      path:          "/",
+      unalteredPath: "/",
+      uid:           courseUid,
+      published:     helpers.isCoursePublished(courseData),
       ...courseInfo
     }
     pathLookup[courseUid] = pathObj
@@ -397,5 +403,6 @@ module.exports = {
   scanCourse,
   getMasterJsonFileName,
   writeMarkdownFilesRecursive,
-  buildPathsForAllCourses
+  buildPathsForAllCourses,
+  makeUidInfoLookup
 }

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -329,8 +329,10 @@ describe("file operations", () => {
       )
       const uids = pathLookup.byUid
       assert.deepEqual(uids["93e58d46191f9fc3c54ec80752ad3b80"], {
-        course:       "12-001-introduction-to-geology-fall-2013",
-        path:         "/pages/lecture-notes-and-slides/MIT12_001F13_Lec5Notes.pdf",
+        course:        "12-001-introduction-to-geology-fall-2013",
+        unalteredPath:
+          "/pages/lecture-notes-and-slides/MIT12_001F13_Lec5Notes.pdf",
+        path:         "/pages/lecture-notes-and-slides/mit12_001f13_lec5notes",
         fileType:     "application/pdf",
         id:           "MIT12_001F13_Lec5Notes.pdf",
         parentUid:    "7a74d241d2fe5d877f747158998d8ed3",
@@ -342,14 +344,16 @@ describe("file operations", () => {
       assert.deepEqual(uids["877f0e43412db8b16e5b2864cf8bf1cc"], {
         course:
           "2-00aj-exploring-sea-space-earth-fundamentals-of-engineering-design-spring-2009",
-        path:      "/pages/labs",
-        type:      PAGE_TYPE,
-        parentUid: "e395587c58555f1fe564e8afd75899e6",
-        uid:       "877f0e43412db8b16e5b2864cf8bf1cc"
+        path:          "/pages/labs",
+        unalteredPath: "/pages/labs",
+        type:          PAGE_TYPE,
+        parentUid:     "e395587c58555f1fe564e8afd75899e6",
+        uid:           "877f0e43412db8b16e5b2864cf8bf1cc"
       })
       assert.deepEqual(uids["d9aad1541f1a9d3c0f7b0dcf9531a9a1"], {
         course:               "12-001-introduction-to-geology-fall-2013",
         path:                 "/",
+        unalteredPath:        "/",
         type:                 COURSE_TYPE,
         uid:                  "d9aad1541f1a9d3c0f7b0dcf9531a9a1",
         department_number:    "12",
@@ -361,8 +365,10 @@ describe("file operations", () => {
         published:            true
       })
       assert.deepEqual(uids["b03952e4bdfcea4962271aeae1dedb3f"], {
-        course:    "ec-711-d-lab-energy-spring-2011",
-        path:      "/pages/intro-energy-basics-human-power/lab-1-human-power",
+        course:        "ec-711-d-lab-energy-spring-2011",
+        path:          "/pages/intro-energy-basics-human-power/lab-1-human-power",
+        unalteredPath:
+          "/pages/intro-energy-basics-human-power/lab-1-human-power",
         type:      EMBEDDED_MEDIA_PAGE_TYPE,
         parentUid: "32a22e0de0add67342ce41445297fce7",
         uid:       "b03952e4bdfcea4962271aeae1dedb3f"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -832,12 +832,6 @@ const parseDspaceUrl = url => {
   return null
 }
 
-const rootRelativeToDocumentRelative = text => {
-  return text
-    .replace(BASEURL_PLACEHOLDER_REGEX, "")
-    .replace(ROOT_RELATIVE_REGEX, '<a href="')
-}
-
 const addDashesToUid = uid => {
   return `${uid.substr(0, 8)}-${uid.substr(8, 4)}-${uid.substr(
     12,
@@ -882,6 +876,5 @@ module.exports = {
   updatePath,
   makeCourseInfoUrl,
   parseDspaceUrl,
-  rootRelativeToDocumentRelative,
   addDashesToUid
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,34 +11,16 @@ const EXTERNAL_LINKS_JSON = require("./external_links.json")
 const {
   AWS_REGEX,
   BASEURL_PLACEHOLDER,
-  BASEURL_PLACEHOLDER_REGEX,
   FILE_TYPE,
   INPUT_COURSE_DATE_FORMAT,
   YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
-  ROOT_RELATIVE_REGEX,
   EMBEDDED_MEDIA_PAGE_TYPE,
-  RESOURCE_PLACEHOLDER,
   COURSE_TYPE
 } = require("./constants")
 const loggers = require("./loggers")
 const runOptions = {}
 
 const makeCourseUrlPrefix = courseId => `/courses/${courseId}`
-
-const makeCourseUrlPrefixOrShortcode = (courseId, otherCourseId) => {
-  if (!courseId) {
-    throw new Error(`Missing course id ${courseId}`)
-  }
-  if (!otherCourseId) {
-    throw new Error(`Missing other course id ${otherCourseId}`)
-  }
-
-  if (courseId === otherCourseId) {
-    return BASEURL_PLACEHOLDER
-  } else {
-    return makeCourseUrlPrefix(courseId)
-  }
-}
 
 const distinct = (value, index, self) => {
   return self.indexOf(value) === index

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -1019,13 +1019,6 @@ describe("misc functions", () => {
     })
   })
 
-  it("turns root relative urls into document relative urls", () => {
-    const input = `<a href="${BASEURL_PLACEHOLDER}/projects/tools">Tools</a>`
-    const output = helpers.rootRelativeToDocumentRelative(input)
-    const expected = `<a href="projects/tools">Tools</a>`
-    assert.equal(output, expected)
-  })
-
   it("adds dashes to a uid imported from Plone in the proper spots", () => {
     const input = "e042c8f9995fcc110a2a5aafa674c5e6"
     const output = helpers.addDashesToUid(input)

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -204,17 +204,6 @@ describe("getCourseFeatureObject", async () => {
   })
 })
 
-describe("getCourseSectionFromFeatureUrl", () => {
-  it("returns the expected course section from a course feature object", () => {
-    assert.equal(
-      helpers.getCourseSectionFromFeatureUrl(
-        singleCourseJsonData["course_features"][2]
-      ),
-      "./resolveuid/293500564c0073c5971dfc2bbf334afc"
-    )
-  })
-})
-
 describe("getYoutubeEmbedHtml", () => {
   it("returned html strings contain the youtube media url for each embedded media", () => {
     let html = ""
@@ -268,7 +257,9 @@ describe("resolveUidMatches", () => {
             [uid3]:      { course: courseId, path: "/path/3/" },
             [parentUid]: { course: courseId, path: "/path/parent" }
           }
-        }
+        },
+        true,
+        false
       ),
       [
         {
@@ -310,7 +301,9 @@ describe("resolveUidMatches", () => {
             path:   "/path/to/parent"
           }
         }
-      }
+      },
+      true,
+      false
     )
     const pageResult = result.find(item => item.match[0] === link)
     assert.deepEqual(pageResult, {
@@ -320,24 +313,44 @@ describe("resolveUidMatches", () => {
     })
   })
 
-  it("resolves a uid for a PDF file", async () => {
-    const link = "./resolveuid/f828208d0d04e1f39c1bb31d6fbe5f2d"
-    assert.include(
-      fieldTripPage["text"],
-      `<a href="${link}">Field Trip Guide (PDF - 4.2MB)</a>`
-    )
-    const result = helpers.resolveUidMatches(
-      fieldTripPage["text"],
-      fieldTripPage,
-      courseData,
-      await fileOperations.buildPathsForAllCourses("test_data/courses", [
-        course
-      ])
-    )
-    const fileResult = result.find(item => item.match[0] === link)
-    assert.deepEqual(fileResult, {
-      replacement: `BASEURL_PLACEHOLDER/pages/field-trip/mit12_001f14_field_trip`,
-      match:       [link]
+  //
+  ;[
+    [
+      false,
+      false,
+      "/courses/12-001-introduction-to-geology-fall-2013/pages/field-trip/mit12_001f14_field_trip"
+    ],
+    [false, true, "pages/field-trip/mit12_001f14_field_trip"],
+    [
+      true,
+      false,
+      "BASEURL_PLACEHOLDER/pages/field-trip/mit12_001f14_field_trip"
+    ],
+    [true, true, "BASEURL_PLACEHOLDER/pages/field-trip/mit12_001f14_field_trip"]
+  ].forEach(([useShortcodes, isRelativeToRoot, expected]) => {
+    it(`resolves a uid for a PDF file when useShortcodes=${String(
+      useShortcodes
+    )} and isRelativeToRoot=${String(isRelativeToRoot)}`, async () => {
+      const link = "./resolveuid/f828208d0d04e1f39c1bb31d6fbe5f2d"
+      assert.include(
+        fieldTripPage["text"],
+        `<a href="${link}">Field Trip Guide (PDF - 4.2MB)</a>`
+      )
+      const result = helpers.resolveUidMatches(
+        fieldTripPage["text"],
+        fieldTripPage,
+        courseData,
+        await fileOperations.buildPathsForAllCourses("test_data/courses", [
+          course
+        ]),
+        useShortcodes,
+        isRelativeToRoot
+      )
+      const fileResult = result.find(item => item.match[0] === link)
+      assert.deepEqual(fileResult, {
+        replacement: expected,
+        match:       [link]
+      })
     })
   })
 
@@ -350,7 +363,9 @@ describe("resolveUidMatches", () => {
       courseData,
       await fileOperations.buildPathsForAllCourses("test_data/courses", [
         course
-      ])
+      ]),
+      true,
+      false
     )
     const fileResult = result.find(item => item.match[0] === link)
     assert.deepEqual(fileResult, {
@@ -392,7 +407,9 @@ describe("resolveUidMatches", () => {
           byUid: {
             [uid]: { course: course, path: "/" }
           }
-        }
+        },
+        true,
+        false
       )
       assert.deepEqual(result, [
         external
@@ -428,7 +445,9 @@ describe("resolveUidMatches", () => {
       originalLink,
       syllabusPage,
       linkingCourseData,
-      {}
+      {},
+      true,
+      false
     )
     assert.deepEqual(result, [])
   })
@@ -457,7 +476,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       assignmentsPage["text"],
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.lengthOf(result, 1)
     assert.equal(
@@ -477,7 +498,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.equal(
       result[0].replacement,
@@ -492,7 +515,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.equal(
       result[0].replacement,
@@ -508,7 +533,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.lengthOf(result, 1)
     assert.deepEqual(result[0].match[0], `href="${link}"`)
@@ -523,7 +550,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.lengthOf(result, 2)
     assert.equal(
@@ -568,7 +597,9 @@ describe("resolveRelativeLinkMatches", () => {
       const result = helpers.resolveRelativeLinkMatches(
         text,
         singleCourseJsonData,
-        pathLookup
+        pathLookup,
+        true,
+        false
       )
       assert.equal(
         result[0].replacement,
@@ -586,7 +617,9 @@ describe("resolveRelativeLinkMatches", () => {
       const result = helpers.resolveRelativeLinkMatches(
         text,
         singleCourseJsonData,
-        pathLookup
+        pathLookup,
+        true,
+        false
       )
       assert.equal(
         result[0].replacement,
@@ -600,7 +633,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.equal(
       result[0].replacement,
@@ -614,7 +649,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.lengthOf(result, 1)
     assert.equal(result[0].replacement, `href="${link}"`)
@@ -625,7 +662,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       singleCourseJsonData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.equal(
       result[0].replacement,
@@ -648,7 +687,9 @@ describe("resolveRelativeLinkMatches", () => {
     const result = helpers.resolveRelativeLinkMatches(
       text,
       courseData,
-      pathLookup
+      pathLookup,
+      true,
+      false
     )
     assert.equal(
       result[0].replacement,
@@ -656,27 +697,40 @@ describe("resolveRelativeLinkMatches", () => {
     )
   })
 
-  it("picks the correct PDF when there are two items with the same filename but with different parents", () => {
-    const courseId =
-      "16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006"
-    const parsedPath = path.join(
-      "test_data",
-      "courses",
-      courseId,
-      `${courseId}_parsed.json`
-    )
-    const courseData = JSON.parse(fs.readFileSync(parsedPath))
+  //
+  ;[
+    [
+      false,
+      false,
+      "/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/signals-systems/objectives"
+    ],
+    [false, true, "pages/signals-systems/objectives"],
+    [true, false, "BASEURL_PLACEHOLDER/pages/signals-systems/objectives"],
+    [true, true, "BASEURL_PLACEHOLDER/pages/signals-systems/objectives"]
+  ].forEach(([useShortcodes, isRelativeToRoot, expected]) => {
+    it(`picks the correct PDF when there are two items with the same filename but with different parents, when useShortcodes=${String(
+      useShortcodes
+    )} and isRelativeToRoot=${String(isRelativeToRoot)}`, () => {
+      const courseId =
+        "16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006"
+      const parsedPath = path.join(
+        "test_data",
+        "courses",
+        courseId,
+        `${courseId}_parsed.json`
+      )
+      const courseData = JSON.parse(fs.readFileSync(parsedPath))
 
-    const text = `<a href="/courses/aeronautics-and-astronautics/${courseId}/signals-systems/objectives.pdf">PDF</a>`
-    const result = helpers.resolveRelativeLinkMatches(
-      text,
-      courseData,
-      pathLookup
-    )
-    assert.equal(
-      result[0].replacement,
-      'href="BASEURL_PLACEHOLDER/pages/signals-systems/objectives"'
-    )
+      const text = `<a href="/courses/aeronautics-and-astronautics/${courseId}/signals-systems/objectives.pdf">PDF</a>`
+      const result = helpers.resolveRelativeLinkMatches(
+        text,
+        courseData,
+        pathLookup,
+        useShortcodes,
+        isRelativeToRoot
+      )
+      assert.equal(result[0].replacement, `href="${expected}"`)
+    })
   })
 
   //
@@ -736,33 +790,60 @@ describe("resolveYouTubeEmbedMatches", () => {
     assert.lengthOf(Object.values(courseData["course_embedded_media"]), 21)
   })
 
-  it("resolves youtube popup links", async () => {
-    const youtubeKey = "16382356instructorinterview:courseiteration55791478"
-    const htmlStr = `some text ${youtubeKey} other text`
-    const courseId = "21g-107-chinese-i-streamlined-fall-2014"
-    const courseData = JSON.parse(
-      fs.readFileSync(`test_data/courses/${courseId}/${courseId}_parsed.json`)
-    )
-    const pathLookup = await fileOperations.buildPathsForAllCourses(
-      "test_data/courses",
-      [courseId]
-    )
-    const results = helpers.resolveYouTubeEmbedMatches(
-      htmlStr,
-      courseData,
-      pathLookup
-    )
-    const match = [youtubeKey]
-    match.index = 10
-    assert.deepEqual(results, [
-      {
-        replacement:
-          '<a href = "BASEURL_PLACEHOLDER/pages/instructor-insights/instructor-interview-course-iteration">Instructor Interview: Incorporating Authentic Text Going Forward</a>',
-        match
-      }
-    ])
-    // verify that if there is a key not present in the html, it is skipped
-    assert.lengthOf(Object.values(courseData["course_embedded_media"]), 11)
+  //
+  ;[
+    [
+      false,
+      false,
+      "/courses/21g-107-chinese-i-streamlined-fall-2014/pages/instructor-insights/instructor-interview-course-iteration"
+    ],
+    [
+      false,
+      true,
+      "pages/instructor-insights/instructor-interview-course-iteration"
+    ],
+    [
+      true,
+      false,
+      "BASEURL_PLACEHOLDER/pages/instructor-insights/instructor-interview-course-iteration"
+    ],
+    [
+      true,
+      true,
+      "BASEURL_PLACEHOLDER/pages/instructor-insights/instructor-interview-course-iteration"
+    ]
+  ].forEach(([useShortcodes, isRelativeToRoot, expected]) => {
+    it(`resolves youtube popup links when useShortcodes=${String(
+      useShortcodes
+    )} and isRelativeToRoot=${String(isRelativeToRoot)}`, async () => {
+      const youtubeKey = "16382356instructorinterview:courseiteration55791478"
+      const htmlStr = `some text ${youtubeKey} other text`
+      const courseId = "21g-107-chinese-i-streamlined-fall-2014"
+      const courseData = JSON.parse(
+        fs.readFileSync(`test_data/courses/${courseId}/${courseId}_parsed.json`)
+      )
+      const pathLookup = await fileOperations.buildPathsForAllCourses(
+        "test_data/courses",
+        [courseId]
+      )
+      const results = helpers.resolveYouTubeEmbedMatches(
+        htmlStr,
+        courseData,
+        pathLookup,
+        useShortcodes,
+        isRelativeToRoot
+      )
+      const match = [youtubeKey]
+      match.index = 10
+      assert.deepEqual(results, [
+        {
+          replacement: `<a href = "${expected}">Instructor Interview: Incorporating Authentic Text Going Forward</a>`,
+          match
+        }
+      ])
+      // verify that if there is a key not present in the html, it is skipped
+      assert.lengthOf(Object.values(courseData["course_embedded_media"]), 11)
+    })
   })
 })
 
@@ -839,20 +920,24 @@ describe("isCoursePublished", () => {
 
 describe("buildPathsForCourse", () => {
   it("builds some paths", () => {
-    const paths = helpers.buildPathsForCourse(singleCourseJsonData)
-    assert.equal(
-      paths["303c499be5d236b1cde0bb36d615f4e7"],
-      "/pages/study-materials"
-    )
-    assert.equal(paths["42664d52bd9a5b1632bac20876dc344d"], "/pages/index.htm")
-    assert.equal(
-      paths["b6a31a6a85998d664ea826a766d9032b"],
-      "/pages/2-00ajs09.jpg"
-    )
-    assert.equal(
-      paths["6f5063fc562d919e4005ac2c983eefb7"],
-      "/pages/study-materials/MIT2_00AJs09_res01B.pdf"
-    )
+    const uidLookup = fileOperations.makeUidInfoLookup(singleCourseJsonData)
+    const paths = helpers.buildPathsForCourse(singleCourseJsonData, uidLookup)
+    assert.deepEqual(paths["303c499be5d236b1cde0bb36d615f4e7"], {
+      path:          "/pages/study-materials",
+      unalteredPath: "/pages/study-materials"
+    })
+    assert.deepEqual(paths["42664d52bd9a5b1632bac20876dc344d"], {
+      path:          "/pages/index.htm",
+      unalteredPath: "/pages/index.htm"
+    })
+    assert.deepEqual(paths["b6a31a6a85998d664ea826a766d9032b"], {
+      path:          "/pages/2-00ajs09.jpg",
+      unalteredPath: "/pages/2-00ajs09.jpg"
+    })
+    assert.deepEqual(paths["6f5063fc562d919e4005ac2c983eefb7"], {
+      path:          "/pages/study-materials/mit2_00ajs09_res01b",
+      unalteredPath: "/pages/study-materials/MIT2_00AJs09_res01B.pdf"
+    })
     assert.lengthOf(Object.values(paths), 67)
   })
 })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -7,12 +7,38 @@ const helpers = require("./helpers")
 const loggers = require("./loggers")
 const { html2markdown } = require("./turndown")
 
-const fixLinks = (htmlStr, page, courseData, pathLookup) => {
+const fixLinks = (
+  htmlStr,
+  page,
+  courseData,
+  pathLookup,
+  useShortcodes,
+  isRelativeToRoot
+) => {
   if (htmlStr && page) {
     const matchAndReplacements = [
-      ...helpers.resolveUidMatches(htmlStr, page, courseData, pathLookup),
-      ...helpers.resolveRelativeLinkMatches(htmlStr, courseData, pathLookup),
-      ...helpers.resolveYouTubeEmbedMatches(htmlStr, courseData, pathLookup)
+      ...helpers.resolveUidMatches(
+        htmlStr,
+        page,
+        courseData,
+        pathLookup,
+        useShortcodes,
+        isRelativeToRoot
+      ),
+      ...helpers.resolveRelativeLinkMatches(
+        htmlStr,
+        courseData,
+        pathLookup,
+        useShortcodes,
+        isRelativeToRoot
+      ),
+      ...helpers.resolveYouTubeEmbedMatches(
+        htmlStr,
+        courseData,
+        pathLookup,
+        useShortcodes,
+        isRelativeToRoot
+      )
     ]
     htmlStr = helpers.applyReplacements(matchAndReplacements, htmlStr)
   }
@@ -55,7 +81,9 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
               technicalLocation,
               courseData,
               pathLookup,
-              true
+              true,
+              true,
+              false
             )
             if (replacement) {
               technicalLocation = replacement
@@ -213,7 +241,14 @@ const formatHTMLMarkDown = (page, courseData, section, pathLookup) => {
   return page[section]
     ? `\n${helpers.unescapeBackticks(
       html2markdown(
-        fixLinks(page[section] || "", page, courseData, pathLookup)
+        fixLinks(
+          page[section] || "",
+          page,
+          courseData,
+          pathLookup,
+          true,
+          false
+        )
       )
     )}`
     : ""
@@ -349,25 +384,25 @@ const generateCourseDescription = (courseData, pathLookup) => {
   )
   const courseDescription = courseData["description"]
     ? html2markdown(
-      helpers.rootRelativeToDocumentRelative(
-        fixLinks(
-          courseData["description"],
-          courseHomePage,
-          courseData,
-          pathLookup
-        )
+      fixLinks(
+        courseData["description"],
+        courseHomePage,
+        courseData,
+        pathLookup,
+        false,
+        true
       )
     )
     : ""
   const otherInformationText = courseData["other_information_text"]
     ? html2markdown(
-      helpers.rootRelativeToDocumentRelative(
-        fixLinks(
-          courseData["other_information_text"],
-          courseHomePage,
-          courseData,
-          pathLookup
-        )
+      fixLinks(
+        courseData["other_information_text"],
+        courseHomePage,
+        courseData,
+        pathLookup,
+        false,
+        true
       )
     )
     : ""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #337 

#### What's this PR do?
This was part of #337 but I broke it out to be an easier review since this is mostly just a refactor with a couple exceptions. This does a few things:
 - Course feature links don't start with a `/` anymore. For example `/pages/projects` is now `pages/projects`. I think this is more intuitive as a relative link, it simplifies the cases we need to consider for creating links, and it should require only a tiny change in the template to handle it
 - The `rootRelativeToDocumentRelative` string replace code is removed. Instead we are making links with or without the slash prefix in `constructInternalLink`
 - `constructInternalLink` is meant to centralize the logic on what links should be rendered when, if shortcodes are allowed to be used or if the link should be relative to the course home page. #337 will expand this and add a resource shortcode which will be included as appropriate
 - PDF links are now created in `pathLookup`, with a new property `unalteredPath` which is used in some cases to resolve relative links
 - The whole path of a resource is matched, and in some cases the pdfs we export have different `technical_location` urls. I tried a few links from different courses where they differed and they still pointed to identical files so I don't know if the end user will see any improvement here. However you might notice that the uid of the course file is included in the `technical_location` now so I think it is probably resolving more correctly than before.

#### How should this be manually tested?
Convert all courses on master, then convert all courses on this PR, and compare the two directories. You probably won't be able to check everything but pick a few files which are different and verify that the changes you see make sense.

You should see some differences:
 - course feature links now start with `pages` instead of `/pages`
 - `technical_location` urls will be different in some cases
 - links to other courses in course descriptions now start with `/courses/...` instead of `courses/...` which should fix those links
 - `/ans7870` links in course descriptions are fixed and now start with a slash

I noticed a couple differences where the old behavior is broken so I don't consider these regressions:
 - A pdf link was updated and doesn't work, but it was also broken before so I am not counting this as a regression https://github.com/mitodl/ocw-to-hugo/issues/343
 - Another link was changed but that link was also broken beforehand #344 
