### PR TITLE
add course_legacy.json

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -61,6 +61,29 @@ const generateDataTemplate = (courseData, pathLookup) => {
   }
 }
 
+const generateLegacyDataTemplate = (courseData, pathLookup) => {
+  const dataTemplate = generateDataTemplate(courseData, pathLookup)
+  dataTemplate["instructors"] = (courseData["instructors"] || []).map(
+    instructor => {
+      const name = instructor["salutation"]
+        ? `${instructor["salutation"]} ${instructor["first_name"]} ${instructor["last_name"]}`
+        : `${instructor["first_name"]} ${instructor["last_name"]}`
+
+      return {
+        instructor:     name,
+        url:            helpers.makeCourseInfoUrl(name, "q"),
+        first_name:     instructor["first_name"],
+        last_name:      instructor["last_name"],
+        middle_initial: instructor["middle_initial"],
+        salutation:     instructor["salutation"],
+        uid:            instructor["uid"]
+      }
+    }
+  )
+  return dataTemplate
+}
+
 module.exports = {
-  generateDataTemplate
+  generateDataTemplate,
+  generateLegacyDataTemplate
 }

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -417,10 +417,12 @@ describe("generateDataTemplate", () => {
 
 describe("generateLegacyDataTemplate", () => {
   const sandbox = sinon.createSandbox()
-  let consoleLog, courseDataTemplate, pathLookup, physicsCourseDataTemplate
+  let consoleLog, courseDataTemplate, pathLookup, singleCourseJsonData
 
   beforeEach(async () => {
     consoleLog = sandbox.stub(console, "log")
+    const singleCourseRawData = fs.readFileSync(singleCourseParsedJsonPath)
+    singleCourseJsonData = JSON.parse(singleCourseRawData)
     pathLookup = await fileOperations.buildPathsForAllCourses(
       "test_data/courses",
       [singleCourseId]

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -8,7 +8,10 @@ const tmp = require("tmp")
 const { INPUT_COURSE_DATE_FORMAT } = require("./constants")
 const fileOperations = require("./file_operations")
 const markdownGenerators = require("./markdown_generators")
-const { generateDataTemplate } = require("./data_template_generators")
+const {
+  generateDataTemplate,
+  generateLegacyDataTemplate
+} = require("./data_template_generators")
 const helpers = require("./helpers")
 
 const testDataPath = "test_data/courses"
@@ -409,5 +412,49 @@ describe("generateDataTemplate", () => {
     )
     const foundValue = courseDataTemplate["open_learning_library_versions"]
     assert.deepEqual(expectedValue, foundValue)
+  })
+})
+
+describe("generateLegacyDataTemplate", () => {
+  const sandbox = sinon.createSandbox()
+  let consoleLog, courseDataTemplate, pathLookup, physicsCourseDataTemplate
+
+  beforeEach(async () => {
+    consoleLog = sandbox.stub(console, "log")
+    pathLookup = await fileOperations.buildPathsForAllCourses(
+      "test_data/courses",
+      [singleCourseId]
+    )
+    courseDataTemplate = generateLegacyDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {
+    assert.deepEqual(courseDataTemplate["instructors"], [
+      {
+        first_name:     "Edward",
+        last_name:      "Crawley",
+        middle_initial: "",
+        salutation:     "Prof.",
+        instructor:     "Prof. Edward Crawley",
+        url:            "/search/?q=%22Prof.%20Edward%20Crawley%22",
+        uid:            "e042c8f9995fcc110a2a5aafa674c5e6"
+      },
+      {
+        first_name:     "Olivier",
+        last_name:      "de Weck",
+        middle_initial: "",
+        salutation:     "Prof.",
+        instructor:     "Prof. Olivier de Weck",
+        url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22",
+        uid:            "07d4f0555edfebf2c2477bbf2d19dd91"
+      }
+    ])
   })
 })

--- a/src/file_operations.js
+++ b/src/file_operations.js
@@ -317,13 +317,23 @@ const scanCourse = async (inputPath, outputPath, course, pathLookup) => {
         courseData,
         pathLookup
       )
+      const legacyDataTemplate = dataTemplateGenerators.generateLegacyDataTemplate(
+        courseData,
+        pathLookup
+      )
       await writeMarkdownFilesRecursive(
         path.join(outputPath, courseData["short_url"], "content"),
         markdownData
       )
       await writeDataTemplate(
         path.join(outputPath, courseData["short_url"], "data"),
+        "course.json",
         dataTemplate
+      )
+      await writeDataTemplate(
+        path.join(outputPath, courseData["short_url"], "data"),
+        "course_legacy.json",
+        legacyDataTemplate
       )
       const configDir = path.join(
         outputPath,
@@ -375,9 +385,9 @@ const writeMarkdownFilesRecursive = async (outputPath, markdownData) => {
   }
 }
 
-const writeDataTemplate = async (outputPath, dataTemplate) => {
+const writeDataTemplate = async (outputPath, fileName, dataTemplate) => {
   await helpers.createOrOverwriteFile(
-    path.join(outputPath, "course.json"),
+    path.join(outputPath, fileName),
     JSON.stringify(dataTemplate, null, 2)
   )
 }

--- a/src/file_operations_test.js
+++ b/src/file_operations_test.js
@@ -167,7 +167,8 @@ describe("file operations", () => {
     let readFileStub,
       generateMarkdownFromJson,
       generateMenuItems,
-      generateDataTemplate
+      generateDataTemplate,
+      generateLegacyDataTemplate
     const sandbox = sinon.createSandbox()
     const outputPath = tmp.dirSync({ prefix: "output" }).name
 
@@ -183,6 +184,10 @@ describe("file operations", () => {
       generateDataTemplate = sandbox.spy(
         dataTemplateGenerators,
         "generateDataTemplate"
+      )
+      generateLegacyDataTemplate = sandbox.spy(
+        dataTemplateGenerators,
+        "generateLegacyDataTemplate"
       )
     })
 
@@ -226,7 +231,7 @@ describe("file operations", () => {
       )
     }).timeout(10000)
 
-    it("calls generateDataTemplate on the course data", async () => {
+    it("calls generateDataTemplate and generateLegacyDataTemplate on the course data", async () => {
       await fileOperations.scanCourse(
         testDataPath,
         outputPath,
@@ -234,6 +239,10 @@ describe("file operations", () => {
         pathLookup
       )
       expect(generateDataTemplate).to.be.calledOnceWithExactly(
+        singleCourseJsonData,
+        pathLookup
+      )
+      expect(generateLegacyDataTemplate).to.be.calledWithExactly(
         singleCourseJsonData,
         pathLookup
       )


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/347

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/341, we moved to only putting the UUID of an instructor in the `course.json` data template to match the way `ocw-studio` links instructors using a relation widget.  This PR adds the generation of a second data template, called `course_legacy.json` that contains the unmodified course data from before we started modifying it to match `ocw-studio`.  This will allow `ocw-studio`'s import functionality to continue to function while developing changes to `course.json` without the need to update the import code to match for the most part.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before and make sure you are set up to download courses from S3
 - Generate markdown for the example courses using `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download`
 - Inspect the output and make sure courses have a `course_legacy.json` alongside `course.json` in the `data` folder.  The only difference at the moment should be that the legacy `course.json` contains all the piecemeal instructor information, whereas the new `course.json` contains only the UUID.