### PR TITLE
Add dashes to exported uuids

### DIFF
--- a/src/config_generators_test.js
+++ b/src/config_generators_test.js
@@ -30,13 +30,13 @@ describe("generateMenuItems", () => {
     const expectedValue = yaml.safeDump({
       leftnav: [
         {
-          identifier: "b6c8c090d7079126837f7dda4af627c7",
+          identifier: "b6c8c090-d707-9126-837f-7dda4af627c7",
           name:       "Syllabus",
           url:        "/pages/onlinecourse",
           weight:     10
         },
         {
-          identifier: "2c792bd745905d336e5077b0ae1237e1",
+          identifier: "2c792bd7-4590-5d33-6e50-77b0ae1237e1",
           name:       "Calendar",
           url:        "/pages/calendar",
           weight:     20

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -85,7 +85,7 @@ const generateLegacyDataTemplate = (courseData, pathLookup) => {
         last_name:      instructor["last_name"],
         middle_initial: instructor["middle_initial"],
         salutation:     instructor["salutation"],
-        uid:            instructor["uid"]
+        uid:            helpers.addDashesToUid(instructor["uid"])
       }
     }
   )

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -323,7 +323,7 @@ describe("generateLegacyDataTemplate", () => {
         salutation:     "Prof.",
         instructor:     "Prof. Edward Crawley",
         url:            "/search/?q=%22Prof.%20Edward%20Crawley%22",
-        uid:            "e042c8f9995fcc110a2a5aafa674c5e6"
+        uid:            "e042c8f9-995f-cc11-0a2a-5aafa674c5e6"
       },
       {
         first_name:     "Olivier",
@@ -332,7 +332,7 @@ describe("generateLegacyDataTemplate", () => {
         salutation:     "Prof.",
         instructor:     "Prof. Olivier de Weck",
         url:            "/search/?q=%22Prof.%20Olivier%20de%20Weck%22",
-        uid:            "07d4f0555edfebf2c2477bbf2d19dd91"
+        uid:            "07d4f055-5edf-ebf2-c247-7bbf2d19dd91"
       }
     ])
   })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -98,13 +98,13 @@ const generatePageMenuItemsRecursive = (page, courseData, pathLookup) => {
   const listInLeftNav = page["list_in_left_nav"]
   if (inRootNav || listInLeftNav) {
     const menuItem = {
-      identifier: page["uid"],
+      identifier: addDashesToUid(page["uid"]),
       name:       shortTitle || "",
       url:        pathLookup.byUid[page["uid"]]["path"],
       weight:     menuIndex
     }
     if (parentId) {
-      menuItem["parent"] = parentId
+      menuItem["parent"] = addDashesToUid(parentId)
     }
     this["menuIndex"]++
     this["menuItems"].push(menuItem)
@@ -831,6 +831,9 @@ const parseDspaceUrl = url => {
 }
 
 const addDashesToUid = uid => {
+  if (!uid.match(/[a-f0-9]{32}/)) {
+    return uid
+  }
   return `${uid.substr(0, 8)}-${uid.substr(8, 4)}-${uid.substr(
     12,
     4

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -86,43 +86,43 @@ describe("helper functions", () => {
       )
       const expectedMenuItems = [
         {
-          identifier: "14896ec808d2b8ea4b434109ba3fb682",
+          identifier: "14896ec8-08d2-b8ea-4b43-4109ba3fb682",
           name:       "Syllabus",
           url:        "/pages/syllabus",
           weight:     10
         },
         {
-          identifier: "94beff3d30e5e7bc06fd9421fe63803d",
+          identifier: "94beff3d-30e5-e7bc-06fd-9421fe63803d",
           name:       "Calendar",
           url:        "/pages/calendar",
           weight:     20
         },
         {
-          identifier: "303c499be5d236b1cde0bb36d615f4e7",
+          identifier: "303c499b-e5d2-36b1-cde0-bb36d615f4e7",
           name:       "Study Materials",
           url:        "/pages/study-materials",
           weight:     30
         },
         {
-          identifier: "877f0e43412db8b16e5b2864cf8bf1cc",
+          identifier: "877f0e43-412d-b8b1-6e5b-2864cf8bf1cc",
           name:       "Labs",
           url:        "/pages/labs",
           weight:     40
         },
         {
-          identifier: "1016059a65d256e4e12de4f25591a1b8",
+          identifier: "1016059a-65d2-56e4-e12d-e4f25591a1b8",
           name:       "Assignments",
           url:        "/pages/assignments",
           weight:     50
         },
         {
-          identifier: "293500564c0073c5971dfc2bbf334afc",
+          identifier: "29350056-4c00-73c5-971d-fc2bbf334afc",
           name:       "Projects",
           url:        "/pages/projects",
           weight:     60
         },
         {
-          identifier: "9759c68f7ab55cc86388d95ca05794f4",
+          identifier: "9759c68f-7ab5-5cc8-6388-d95ca05794f4",
           name:       "Related Resources",
           url:        "/pages/related-resources",
           weight:     70

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -156,12 +156,12 @@ const generateCourseSectionFrontMatter = (
     Generate the front matter metadata for a course section
     */
   const courseSectionFrontMatter = {
-    uid:   pageId,
+    uid:   helpers.addDashesToUid(pageId),
     title: title
   }
 
   if (parentUid) {
-    courseSectionFrontMatter["parent_uid"] = parentUid
+    courseSectionFrontMatter["parent_uid"] = helpers.addDashesToUid(parentUid)
   }
   if (parentTitle) {
     courseSectionFrontMatter["parent_title"] = parentTitle
@@ -227,7 +227,7 @@ const generateResourceMarkdownForFile = file => {
   const frontMatter = {
     title:         file["title"],
     description:   file["description"],
-    uid:           file["uid"],
+    uid:           helpers.addDashesToUid(file["uid"]),
     resourcetype:  getResourceType(file["file_type"]),
     file_type:     file["file_type"],
     file_location: helpers.stripS3(file["file_location"])
@@ -265,7 +265,7 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
   const frontMatter = {
     title:          media["title"],
     description:    "",
-    uid:            media["uid"],
+    uid:            helpers.addDashesToUid(media["uid"]),
     resourceType:   RESOURCE_TYPE_VIDEO,
     video_metadata: {
       youtube_id: youtubeId
@@ -349,9 +349,9 @@ const generateImageGalleryMarkdown = (page, courseData) => {
           .map(key => `${key}="${args[key]}"`)
           .join(" ")} >}}`
     )
-    courseFeaturesMarkdown = `${courseFeaturesMarkdown}\n{{< image-gallery id="${
+    courseFeaturesMarkdown = `${courseFeaturesMarkdown}\n{{< image-gallery id="${helpers.addDashesToUid(
       page["uid"]
-    }_nanogallery2" baseUrl="${helpers.stripS3(
+    )}_nanogallery2" baseUrl="${helpers.stripS3(
       baseUrl
     )}" >}}\n${imageShortcodes.join("\n")}\n{{</ image-gallery >}}`
   }

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -260,7 +260,7 @@ describe("markdown generators", () => {
         file_type:    "image/svg+xml",
         resourcetype: "Image",
         title:        "jsinput_freebodydraw_massive_rope_between_trees_setup.svg",
-        uid:          "838633c70a5b59cce23f0909eaeb96d7"
+        uid:          "838633c7-0a5b-59cc-e23f-0909eaeb96d7"
       })
     })
 
@@ -276,7 +276,7 @@ describe("markdown generators", () => {
       assert.deepEqual(frontmatter, {
         title:          "0.1 Vectors vs. Scalars",
         description:    "",
-        uid:            "5b89e3d0ea345f02540bac14b4acac9b",
+        uid:            "5b89e3d0-ea34-5f02-540b-ac14b4acac9b",
         resourceType:   "Video",
         video_metadata: { youtube_id: "5ucfHd8FWKw" },
         video_files:    {
@@ -372,7 +372,7 @@ describe("markdown generators", () => {
         description:
           "This resource contains acknowledgements to the persons who helped build this course.",
         resourcetype:  "Document",
-        uid:           "d7d1fabcb57a6d4a9cc96f04348dedfd",
+        uid:           "d7d1fabc-b57a-6d4a-9cc9-6f04348dedfd",
         file_type:     "application/pdf",
         file_location:
           "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/d7d1fabcb57a6d4a9cc96f04348dedfd_acknowledgements.pdf"
@@ -390,7 +390,7 @@ describe("markdown generators", () => {
         title:       "summary_w12d2.pdf",
         description:
           "This file talks about how electricity and magnetism interact with each other and also considers finalizing Maxwell?s Equations, their result ? electromagnetic (EM) radiation and how energy flows in electric and magnetic fields.",
-        uid:           "a1bfc34ccf08ddf8474627b9a13d6ca8",
+        uid:           "a1bfc34c-cf08-ddf8-4746-27b9a13d6ca8",
         file_type:     "application/pdf",
         resourcetype:  "Document",
         file_location:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #361 
Rebased on #337 

#### What's this PR do?
Adds dashes to all exported uuids to be consistent with how we store and use them in ocw-studio

#### How should this be manually tested?
Run ocw-to-hugo on all courses, then run `grep -P "[^/][a-f0-9]{32}\b" . -R` or a similar command. You should see only a relatively small number of results, around 100-200 or so, and all uuids should be unrelated, used in other URLs for example. If you run the same command on master you will get ~150k results