### PR TITLE
more ocw studio updates

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -20,12 +20,6 @@ const generateDataTemplate = (courseData, pathLookup) => {
     course_image_caption_text: courseData["image_caption_text"]
       ? courseData["image_caption_text"]
       : "",
-    publishdate: courseData["first_published_to_production"]
-      ? moment(
-        courseData["first_published_to_production"],
-        INPUT_COURSE_DATE_FORMAT
-      ).format()
-      : "",
     instructors: {
       content: (courseData["instructors"] || []).map(instructor =>
         helpers.addDashesToUid(instructor["uid"])
@@ -60,6 +54,12 @@ const generateDataTemplate = (courseData, pathLookup) => {
 
 const generateLegacyDataTemplate = (courseData, pathLookup) => {
   const dataTemplate = generateDataTemplate(courseData, pathLookup)
+  dataTemplate["publishdate"] = courseData["first_published_to_production"]
+    ? moment(
+      courseData["first_published_to_production"],
+      INPUT_COURSE_DATE_FORMAT
+    ).format()
+    : ""
   delete dataTemplate["department_numbers"]
   dataTemplate["departments"] = helpers.getDepartments(courseData)
   dataTemplate["level"] = {

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -27,11 +27,9 @@ const generateDataTemplate = (courseData, pathLookup) => {
       website: "ocw-www"
     },
     department_numbers: helpers.getDepartmentNumbers(courseData),
-    course_features:    courseData["course_feature_tags"]
-      ? courseData["course_feature_tags"].map(
-        courseFeature => courseFeature["course_feature_tag"]
-      )
-      : [],
+    course_features:    (courseData["course_feature_tags"] || []).map(
+      courseFeature => courseFeature["course_feature_tag"]
+    ),
     topics:                helpers.getConsolidatedTopics(courseData["course_collections"]),
     primary_course_number: helpers.getPrimaryCourseNumber(courseData),
     extra_course_numbers:  helpers.getExtraCourseNumbers(courseData).join(", "),
@@ -66,11 +64,11 @@ const generateLegacyDataTemplate = (courseData, pathLookup) => {
     level: courseData["course_level"],
     url:   helpers.makeCourseInfoUrl(courseData["course_level"], "level")
   }
-  dataTemplate["course_features"] = courseData["course_feature_tags"]
-    ? courseData["course_feature_tags"].map(courseFeature =>
-      helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
-    )
-    : []
+  dataTemplate["course_features"] = (
+    courseData["course_feature_tags"] || []
+  ).map(courseFeature =>
+    helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
+  )
   dataTemplate["extra_course_numbers"] = helpers.getExtraCourseNumbers(
     courseData
   )

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -32,21 +32,18 @@ const generateDataTemplate = (courseData, pathLookup) => {
       ),
       website: "ocw-www"
     },
-    departments:     helpers.getDepartments(courseData),
-    course_features: courseData["course_feature_tags"]
-      ? courseData["course_feature_tags"].map(courseFeature =>
-        helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
+    department_numbers: helpers.getDepartmentNumbers(courseData),
+    course_features:    courseData["course_feature_tags"]
+      ? courseData["course_feature_tags"].map(
+        courseFeature => courseFeature["course_feature_tag"]
       )
       : [],
     topics:                helpers.getConsolidatedTopics(courseData["course_collections"]),
     primary_course_number: helpers.getPrimaryCourseNumber(courseData),
-    extra_course_numbers:  helpers.getExtraCourseNumbers(courseData),
+    extra_course_numbers:  helpers.getExtraCourseNumbers(courseData).join(", "),
     term:                  `${courseData["from_semester"]} ${courseData["from_year"]}`,
-    level:                 {
-      level: courseData["course_level"],
-      url:   helpers.makeCourseInfoUrl(courseData["course_level"], "level")
-    },
-    other_versions: helpers.getOtherVersions(
+    level:                 courseData["course_level"],
+    other_versions:        helpers.getOtherVersions(
       courseData["other_version_parent_uids"],
       courseData["short_url"],
       pathLookup
@@ -63,6 +60,20 @@ const generateDataTemplate = (courseData, pathLookup) => {
 
 const generateLegacyDataTemplate = (courseData, pathLookup) => {
   const dataTemplate = generateDataTemplate(courseData, pathLookup)
+  delete dataTemplate["department_numbers"]
+  dataTemplate["departments"] = helpers.getDepartments(courseData)
+  dataTemplate["level"] = {
+    level: courseData["course_level"],
+    url:   helpers.makeCourseInfoUrl(courseData["course_level"], "level")
+  }
+  dataTemplate["course_features"] = courseData["course_feature_tags"]
+    ? courseData["course_feature_tags"].map(courseFeature =>
+      helpers.getCourseFeatureObject(courseFeature, courseData, pathLookup)
+    )
+    : []
+  dataTemplate["extra_course_numbers"] = helpers.getExtraCourseNumbers(
+    courseData
+  )
   dataTemplate["instructors"] = (courseData["instructors"] || []).map(
     instructor => {
       const name = instructor["salutation"]

--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -26,8 +26,8 @@ const generateDataTemplate = (courseData, pathLookup) => {
       ),
       website: "ocw-www"
     },
-    department_numbers: helpers.getDepartmentNumbers(courseData),
-    course_features:    (courseData["course_feature_tags"] || []).map(
+    department_numbers:      helpers.getDepartmentNumbers(courseData),
+    learning_resource_types: (courseData["course_feature_tags"] || []).map(
       courseFeature => courseFeature["course_feature_tag"]
     ),
     topics:                helpers.getConsolidatedTopics(courseData["course_collections"]),

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -170,16 +170,6 @@ describe("generateDataTemplate", () => {
     )
   })
 
-  it("sets the publishdate property to the first_published_to_production property of the course json data", () => {
-    const courseDataTemplate = generateDataTemplate(
-      singleCourseJsonData,
-      pathLookup
-    )
-    assert.isTrue(
-      courseDataTemplate["publishdate"].startsWith("2008-07-17T16:06:15")
-    )
-  })
-
   it("sets an array of instructor uids under the instructors -> content property", () => {
     const courseDataTemplate = generateDataTemplate(
       singleCourseJsonData,
@@ -194,28 +184,12 @@ describe("generateDataTemplate", () => {
     })
   })
 
-  it("sets the department property to the department found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
+  it("sets the department_numbers property to the department numbers found on the url property of the course json data", () => {
     const courseDataTemplate = generateDataTemplate(
       singleCourseJsonData,
       pathLookup
     )
-    assert.deepEqual(
-      [
-        {
-          department: "Aeronautics and Astronautics",
-          url:        `/search/?d=${encodeURIComponent(
-            "Aeronautics and Astronautics"
-          )}`
-        },
-        {
-          department: "Institute for Data, Systems, and Society",
-          url:        `/search/?d=${encodeURIComponent(
-            "Institute for Data, Systems, and Society"
-          )}`
-        }
-      ],
-      courseDataTemplate["departments"]
-    )
+    assert.deepEqual(["16", "IDS"], courseDataTemplate["department_numbers"])
   })
 
   it("sets the course_features property to the instructors found in the instuctors node of the course json data", () => {
@@ -224,57 +198,11 @@ describe("generateDataTemplate", () => {
       pathLookup
     )
     assert.deepEqual(courseDataTemplate["course_features"], [
-      {
-        feature: "Projects with Examples",
-        url:     "pages/projects"
-      },
-      {
-        feature: "Design Assignments",
-        url:     "pages/assignments"
-      },
-      {
-        feature: "Presentation Assignments with Examples",
-        url:     "pages/projects"
-      },
-      {
-        feature: "Written Assignments with Examples",
-        url:     "pages/assignments"
-      }
+      "Projects with Examples",
+      "Design Assignments",
+      "Presentation Assignments with Examples",
+      "Written Assignments with Examples"
     ])
-  })
-
-  //
-  ;[
-    [true, "./resolveuid/244945a815a4b2a3af2a20384f403eab", "pages/projects"],
-    [
-      false,
-      "./resolveuid/63e325a780c79e352fb5bddb9b8b2c6a",
-      "/courses/8-01sc-classical-mechanics-fall-2016/pages/week-1-kinematics"
-    ]
-  ].forEach(([sameCourse, url, expected]) => {
-    it(`handles links in the course_features property properly when the link is for ${
-      sameCourse ? "the same" : "a different"
-    } course`, () => {
-      singleCourseJsonData["course_feature_tags"] = [
-        {
-          ocw_feature:       "Projects",
-          ocw_subfeature:    "Examples",
-          ocw_feature_url:   url,
-          ocw_speciality:    "",
-          ocw_feature_notes:
-            "Projects section; projects files; file count: 16; file format: .pdf"
-        }
-      ]
-      const courseDataTemplate = generateDataTemplate(
-        singleCourseJsonData,
-        pathLookup
-      )
-      assert.deepEqual(courseDataTemplate["course_features"], [
-        {
-          url: expected
-        }
-      ])
-    })
   })
 
   it("sets the topics property on the course data template to a consolidated list of topics from the course_collections property of the course json data", () => {
@@ -334,19 +262,12 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets the level property on the course data template to course_level in the course json data", () => {
-    const level = singleCourseJsonData["course_level"]
     const courseDataTemplate = generateDataTemplate(
       singleCourseJsonData,
       pathLookup
     )
     const foundValue = courseDataTemplate["level"]
-    assert.deepEqual(
-      {
-        level: level,
-        url:   "/search/?l=Graduate"
-      },
-      foundValue
-    )
+    assert.equal(foundValue, "Graduate")
   })
 
   it("sets the expected text in other_versions", () => {
@@ -417,7 +338,7 @@ describe("generateDataTemplate", () => {
 
 describe("generateLegacyDataTemplate", () => {
   const sandbox = sinon.createSandbox()
-  let consoleLog, courseDataTemplate, pathLookup, singleCourseJsonData
+  let consoleLog, pathLookup, singleCourseJsonData
 
   beforeEach(async () => {
     consoleLog = sandbox.stub(console, "log")
@@ -425,11 +346,7 @@ describe("generateLegacyDataTemplate", () => {
     singleCourseJsonData = JSON.parse(singleCourseRawData)
     pathLookup = await fileOperations.buildPathsForAllCourses(
       "test_data/courses",
-      [singleCourseId]
-    )
-    courseDataTemplate = generateLegacyDataTemplate(
-      singleCourseJsonData,
-      pathLookup
+      [singleCourseId, mechanicsCourseId]
     )
   })
 
@@ -438,6 +355,10 @@ describe("generateLegacyDataTemplate", () => {
   })
 
   it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {
+    const courseDataTemplate = generateLegacyDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
     assert.deepEqual(courseDataTemplate["instructors"], [
       {
         first_name:     "Edward",
@@ -458,5 +379,114 @@ describe("generateLegacyDataTemplate", () => {
         uid:            "07d4f0555edfebf2c2477bbf2d19dd91"
       }
     ])
+  })
+
+  it("sets the publishdate property to the first_published_to_production property of the course json data", () => {
+    const courseDataTemplate = generateLegacyDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.isTrue(
+      courseDataTemplate["publishdate"].startsWith("2008-07-17T16:06:15")
+    )
+  })
+
+  it("sets the level property on the course data template to course_level in the course json data", () => {
+    const courseDataTemplate = generateLegacyDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    const level = singleCourseJsonData["course_level"]
+    const foundValue = courseDataTemplate["level"]
+    assert.deepEqual(
+      {
+        level: level,
+        url:   "/search/?l=Graduate"
+      },
+      foundValue
+    )
+  })
+
+  //
+  ;[
+    [true, "./resolveuid/244945a815a4b2a3af2a20384f403eab", "pages/projects"],
+    [
+      false,
+      "./resolveuid/63e325a780c79e352fb5bddb9b8b2c6a",
+      "/courses/8-01sc-classical-mechanics-fall-2016/pages/week-1-kinematics"
+    ]
+  ].forEach(([sameCourse, url, expected]) => {
+    it(`handles links in the course_features property properly when the link is for ${
+      sameCourse ? "the same" : "a different"
+    } course`, () => {
+      singleCourseJsonData["course_feature_tags"] = [
+        {
+          ocw_feature:       "Projects",
+          ocw_subfeature:    "Examples",
+          ocw_feature_url:   url,
+          ocw_speciality:    "",
+          ocw_feature_notes:
+            "Projects section; projects files; file count: 16; file format: .pdf"
+        }
+      ]
+      const courseDataTemplate = generateLegacyDataTemplate(
+        singleCourseJsonData,
+        pathLookup
+      )
+      assert.deepEqual(courseDataTemplate["course_features"], [
+        {
+          url: expected
+        }
+      ])
+    })
+  })
+
+  it("sets the course_features property to the instructors found in the instuctors node of the course json data", () => {
+    const courseDataTemplate = generateLegacyDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.deepEqual(courseDataTemplate["course_features"], [
+      {
+        feature: "Projects with Examples",
+        url:     "pages/projects"
+      },
+      {
+        feature: "Design Assignments",
+        url:     "pages/assignments"
+      },
+      {
+        feature: "Presentation Assignments with Examples",
+        url:     "pages/projects"
+      },
+      {
+        feature: "Written Assignments with Examples",
+        url:     "pages/assignments"
+      }
+    ])
+  })
+
+  it("sets the department property to the department found on the url property of the course json data, title cased with hyphens replaced with spaces", () => {
+    const courseDataTemplate = generateLegacyDataTemplate(
+      singleCourseJsonData,
+      pathLookup
+    )
+    assert.deepEqual(
+      [
+        {
+          department: "Aeronautics and Astronautics",
+          url:        `/search/?d=${encodeURIComponent(
+            "Aeronautics and Astronautics"
+          )}`
+        },
+        {
+          department: "Institute for Data, Systems, and Society",
+          url:        `/search/?d=${encodeURIComponent(
+            "Institute for Data, Systems, and Society"
+          )}`
+        }
+      ],
+      courseDataTemplate["departments"]
+    )
   })
 })

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -192,12 +192,12 @@ describe("generateDataTemplate", () => {
     assert.deepEqual(["16", "IDS"], courseDataTemplate["department_numbers"])
   })
 
-  it("sets the course_features property to the instructors found in the instuctors node of the course json data", () => {
+  it("sets the learning_resource_types property to the processed list of course_feature_tags from the course json data", () => {
     const courseDataTemplate = generateDataTemplate(
       singleCourseJsonData,
       pathLookup
     )
-    assert.deepEqual(courseDataTemplate["course_features"], [
+    assert.deepEqual(courseDataTemplate["learning_resource_types"], [
       "Projects with Examples",
       "Design Assignments",
       "Presentation Assignments with Examples",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -56,19 +56,22 @@ const DEPARTMENTS_LOOKUP = new Map(
 const findDepartmentByNumber = departmentNumber =>
   DEPARTMENTS_LOOKUP.get(departmentNumber.toString())
 
-const getDepartments = courseData => {
-  let departmentNumbers = [
+const getDepartmentNumbers = courseData => {
+  const departmentNumbers = [
     getPrimaryCourseNumber(courseData),
     ...getExtraCourseNumbers(courseData)
   ].map(number => number.split(".")[0])
   // deduplicate and remove numbers that don't match with our list
-  departmentNumbers = [...new Set(departmentNumbers)].filter(
-    findDepartmentByNumber
-  )
-  return departmentNumbers.map(findDepartmentByNumber).map(department => ({
-    department: department.title,
-    url:        makeCourseInfoUrl(department.title, "department_name")
-  }))
+  return [...new Set(departmentNumbers)].filter(findDepartmentByNumber)
+}
+
+const getDepartments = courseData => {
+  return getDepartmentNumbers(courseData)
+    .map(findDepartmentByNumber)
+    .map(department => ({
+      department: department.title,
+      url:        makeCourseInfoUrl(department.title, "department_name")
+    }))
 }
 
 const getRootSections = courseData => {
@@ -845,6 +848,7 @@ module.exports = {
   createOrOverwriteFile,
   fileExists,
   findDepartmentByNumber,
+  getDepartmentNumbers,
   getDepartments,
   getRootSections,
   getInternalMenuItems,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/issues/568
Closes https://github.com/mitodl/ocw-to-hugo/issues/351
Closes https://github.com/mitodl/ocw-to-hugo/issues/363
Closes https://github.com/mitodl/ocw-to-hugo/issues/364
Closes https://github.com/mitodl/ocw-to-hugo/issues/365

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/issues/568, we've defined a number of adjustments that need to be made to the course data template to conform with the way `ocw-studio` takes in the data and publishes it.  This PR adjusts the following properties:

 - `publishdate` has been removed
 - `departments` has been removed and replaced with `department_numbers` which is a simple list of the department numbers
 - `extra_course_numbers` is now a single string with a comma separated list of the extra course numbers
 - the search URL has been removed from `course_features` objects and it is now a simple list of strings and the key has been renamed to `learning_resource_types`
 - the search URL has been removed from `level` and it is now just a simple string representing the course level

The old way of generating these various properties has been preserved in `course_legacy.json` for importing purposes.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before and make sure you are set up with S3 access
 - Run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download`
 - Compare some of the `course.json` files to the `course_legacy.json` files in the `data` folder of each course and ensure that the changes described above have been applied appropriately
