### PR TITLE
Fix typo for resourcetype for video pages

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -266,7 +266,7 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
     title:          media["title"],
     description:    "",
     uid:            helpers.addDashesToUid(media["uid"]),
-    resourceType:   RESOURCE_TYPE_VIDEO,
+    resourcetype:   RESOURCE_TYPE_VIDEO,
     video_metadata: {
       youtube_id: youtubeId
     },

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -277,7 +277,7 @@ describe("markdown generators", () => {
         title:          "0.1 Vectors vs. Scalars",
         description:    "",
         uid:            "5b89e3d0-ea34-5f02-540b-ac14b4acac9b",
-        resourceType:   "Video",
+        resourcetype:   "Video",
         video_metadata: { youtube_id: "5ucfHd8FWKw" },
         video_files:    {
           video_captions_file:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #374 

#### What's this PR do?
Fixes a typo. The field should be `resourcetype` without any capital letters so that it matches the schema

#### How should this be manually tested?
Convert `18-06-linear-algebra-spring-2010` and check `content/resources/lecture-10-the-four-fundamental-subspaces.md` in the output. It should say `resourcetype` in the markdown