### PR TITLE
course images by reference

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -8,18 +8,14 @@ const generateDataTemplate = (courseData, pathLookup) => {
   return {
     course_title:       courseData["title"],
     course_description: generateCourseDescription(courseData, pathLookup),
-    course_image_url:   helpers.stripS3(
-      courseData["image_src"] ? courseData["image_src"] : ""
-    ),
-    course_thumbnail_image_url: helpers.stripS3(
-      courseData["thumbnail_image_src"] ? courseData["thumbnail_image_src"] : ""
-    ),
-    course_image_alternate_text: courseData["image_alternate_text"]
-      ? courseData["image_alternate_text"]
-      : "",
-    course_image_caption_text: courseData["image_caption_text"]
-      ? courseData["image_caption_text"]
-      : "",
+    course_image:       {
+      content: [helpers.getUidFromFilePath(courseData["image_src"])],
+      website: courseData["short_url"]
+    },
+    course_image_thumbnail: {
+      content: [helpers.getUidFromFilePath(courseData["thumbnail_image_src"])],
+      website: courseData["short_url"]
+    },
     instructors: {
       content: (courseData["instructors"] || []).map(instructor =>
         helpers.addDashesToUid(instructor["uid"])
@@ -52,6 +48,20 @@ const generateDataTemplate = (courseData, pathLookup) => {
 
 const generateLegacyDataTemplate = (courseData, pathLookup) => {
   const dataTemplate = generateDataTemplate(courseData, pathLookup)
+  dataTemplate["course_image_url"] = helpers.stripS3(
+    courseData["image_src"] ? courseData["image_src"] : ""
+  )
+  dataTemplate["course_thumbnail_image_url"] = helpers.stripS3(
+    courseData["thumbnail_image_src"] ? courseData["thumbnail_image_src"] : ""
+  )
+  dataTemplate["course_image_alternate_text"] = courseData[
+    "image_alternate_text"
+  ]
+    ? courseData["image_alternate_text"]
+    : ""
+  dataTemplate["course_image_caption_text"] = courseData["image_caption_text"]
+    ? courseData["image_caption_text"]
+    : ""
   dataTemplate["publishdate"] = courseData["first_published_to_production"]
     ? moment(
       courseData["first_published_to_production"],

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -121,22 +121,14 @@ describe("generateDataTemplate", () => {
       spaceSystemsJsonData,
       pathLookup
     )
-    assert.equal(
-      courseDataTemplate["course_image_url"],
-      "https://open-learning-course-data-production.s3.amazonaws.com/16-89j-space-systems-engineering-spring-2007/2a01cea04000d318a1d63c46d451a0d4_16-89js07.jpg"
-    )
-    assert.equal(
-      courseDataTemplate["course_thumbnail_image_url"],
-      "https://open-learning-course-data-production.s3.amazonaws.com/16-89j-space-systems-engineering-spring-2007/9136249e26df79621171ddd1b58405a3_16-89js07-th.jpg"
-    )
-    assert.equal(
-      courseDataTemplate["course_image_alternate_text"],
-      "Artist's conception of astronauts setting up a lunar telescope array."
-    )
-    assert.equal(
-      courseDataTemplate["course_image_caption_text"],
-      '<p>Astronauts setting up a lunar telescope array. (Image courtesy of <a href="http://www.nasa.gov/mission_pages/exploration/multimedia/jfa18844_prt.htm">NASA</a>.)</p>'
-    )
+    assert.deepEqual(courseDataTemplate["course_image"], {
+      content: ["2a01cea0-4000-d318-a1d6-3c46d451a0d4"],
+      website: "16-89j-space-systems-engineering-spring-2007"
+    })
+    assert.deepEqual(courseDataTemplate["course_image_thumbnail"], {
+      content: ["9136249e-26df-7962-1171-ddd1b58405a3"],
+      website: "16-89j-space-systems-engineering-spring-2007"
+    })
   })
 
   it("sets an array of instructor uids under the instructors -> content property", () => {
@@ -284,6 +276,29 @@ describe("generateLegacyDataTemplate", () => {
 
   afterEach(() => {
     sandbox.restore()
+  })
+
+  it("sets various image properties correctly", () => {
+    const courseDataTemplate = generateLegacyDataTemplate(
+      spaceSystemsJsonData,
+      pathLookup
+    )
+    assert.equal(
+      courseDataTemplate["course_image_url"],
+      "https://open-learning-course-data-production.s3.amazonaws.com/16-89j-space-systems-engineering-spring-2007/2a01cea04000d318a1d63c46d451a0d4_16-89js07.jpg"
+    )
+    assert.equal(
+      courseDataTemplate["course_thumbnail_image_url"],
+      "https://open-learning-course-data-production.s3.amazonaws.com/16-89j-space-systems-engineering-spring-2007/9136249e26df79621171ddd1b58405a3_16-89js07-th.jpg"
+    )
+    assert.equal(
+      courseDataTemplate["course_image_alternate_text"],
+      "Artist's conception of astronauts setting up a lunar telescope array."
+    )
+    assert.equal(
+      courseDataTemplate["course_image_caption_text"],
+      '<p>Astronauts setting up a lunar telescope array. (Image courtesy of <a href="http://www.nasa.gov/mission_pages/exploration/multimedia/jfa18844_prt.htm">NASA</a>.)</p>'
+    )
   })
 
   it("sets the instructors property to the instructors found in the instuctors node of the course json data", () => {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -801,6 +801,10 @@ const addDashesToUid = uid => {
   )}-${uid.substr(16, 4)}-${uid.substr(20)}`
 }
 
+const getUidFromFilePath = filePath => {
+  return addDashesToUid(path.basename(filePath).split("_")[0])
+}
+
 module.exports = {
   directoryExists,
   createOrOverwriteFile,
@@ -838,5 +842,6 @@ module.exports = {
   makeCourseInfoUrl,
   parseDspaceUrl,
   addDashesToUid,
-  replaceSubstring
+  replaceSubstring,
+  getUidFromFilePath
 }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -149,8 +149,7 @@ const generateCourseSectionFrontMatter = (
   parentTitle,
   layout,
   pageId,
-  isMediaGallery,
-  courseId
+  isMediaGallery
 ) => {
   /**
     Generate the front matter metadata for a course section
@@ -371,11 +370,6 @@ const generateCourseFeaturesMarkdown = (page, courseData, pathLookup) => {
 }
 
 const generateCourseDescription = (courseData, pathLookup) => {
-  const courseHomePage = courseData["course_pages"].find(
-    coursePage =>
-      coursePage["type"] === "CourseHomeSection" ||
-      coursePage["type"] === "SRHomePage"
-  )
   const courseDescription = courseData["description"]
     ? html2markdown(
       fixLinks(courseData["description"], courseData, pathLookup, false, true)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/338

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/32, we set the course image and thumbnail to be referenced from the `ocw-www` website in `ocw-studio` using a relation widget.  In https://github.com/mitodl/ocw-to-hugo/pull/337, we changed `ocw-to-hugo` so that markdown files are created for resources in the source `course_files` array and placed in the `content/resources` directory to represent the resources attached to a course.  Since the course image and thumbnail are included in `course_files`, resource markdown is already being created for them.  This PR adjusts the rendering of the course metadata (`course.json`) to produce `ocw-studio` like references to the `resource` content referencing the course image and the course image thumbnail.

#### How should this be manually tested?
 - Make sure you have read the readme and are set up to download courses from S3
 - Run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download`
 - Inspect the output for the various courses and look at their data templates at `data/course.json`, verifying that `course_image` and `course_image_thumbnail` are rendered like an `ocw-studio` relation widget.  Each should have a `content` and `website` key, containing an array with a single UUID (that matches the respective content in `content/resources`) and the course id, respectively.
