### PR TITLE
course images should be a 1:1 relationship

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -9,11 +9,11 @@ const generateDataTemplate = (courseData, pathLookup) => {
     course_title:       courseData["title"],
     course_description: generateCourseDescription(courseData, pathLookup),
     course_image:       {
-      content: [helpers.getUidFromFilePath(courseData["image_src"])],
+      content: helpers.getUidFromFilePath(courseData["image_src"]),
       website: courseData["short_url"]
     },
     course_image_thumbnail: {
-      content: [helpers.getUidFromFilePath(courseData["thumbnail_image_src"])],
+      content: helpers.getUidFromFilePath(courseData["thumbnail_image_src"]),
       website: courseData["short_url"]
     },
     instructors: {

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -122,11 +122,11 @@ describe("generateDataTemplate", () => {
       pathLookup
     )
     assert.deepEqual(courseDataTemplate["course_image"], {
-      content: ["2a01cea0-4000-d318-a1d6-3c46d451a0d4"],
+      content: "2a01cea0-4000-d318-a1d6-3c46d451a0d4",
       website: "16-89j-space-systems-engineering-spring-2007"
     })
     assert.deepEqual(courseDataTemplate["course_image_thumbnail"], {
-      content: ["9136249e-26df-7962-1171-ddd1b58405a3"],
+      content: "9136249e-26df-7962-1171-ddd1b58405a3",
       website: "16-89j-space-systems-engineering-spring-2007"
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/385

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/378, we altered `ocw-to-hugo` to produce references to the course images in the course data template `data/course.json` in the way `ocw-studio` does this.  Unfortunately, this was not done properly.  The course images are being written in a list as if it was a one to many relationship, when really it's a one to one relationship.  This PR updates the course images to be a single string 1:1 reference.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before, making sure you're set up with S3 access
 - Run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download`
 - Inspect the output and look at the data templates for the various courses.  The `course_image` and `course_image_thumbnail` properties should have a `content` key that has a simple string based UUID for its value.
