### PR TITLE
use resource instead of youtube shortcode

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,9 @@
 module.exports = {
-  REPLACETHISWITHAPIPE:                "REPLACETHISWITHAPIPE",
-  BASEURL_PLACEHOLDER:                 "BASEURL_PLACEHOLDER",
-  BASEURL_PLACEHOLDER_REGEX:           new RegExp("BASEURL_PLACEHOLDER", "g"),
-  BASEURL_SHORTCODE:                   "{{< baseurl >}}",
-  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS: "youtube-placeholder",
+  REPLACETHISWITHAPIPE:                          "REPLACETHISWITHAPIPE",
+  BASEURL_PLACEHOLDER:                           "BASEURL_PLACEHOLDER",
+  BASEURL_PLACEHOLDER_REGEX:                     new RegExp("BASEURL_PLACEHOLDER", "g"),
+  BASEURL_SHORTCODE:                             "{{< baseurl >}}",
+  EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS: "embedded_resource",
   MISSING_JSON_ERROR_MESSAGE:
     "To download courses from AWS, you must specify the -c argument.  For more information, see README.md",
   MISSING_COURSE_ERROR_MESSAGE:

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,7 +13,7 @@ const {
   BASEURL_PLACEHOLDER,
   FILE_TYPE,
   INPUT_COURSE_DATE_FORMAT,
-  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
+  EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
   EMBEDDED_MEDIA_PAGE_TYPE,
   COURSE_TYPE
 } = require("./constants")
@@ -222,36 +222,9 @@ const getConsolidatedTopics = courseCollections =>
 
 /* eslint-disable camelcase */
 const getYoutubeEmbedCode = (media, pathLookup) => {
-  const youTubeMedia = media["embedded_media"].filter(embeddedMedia => {
-    return embeddedMedia["id"] === "Video-YouTube-Stream"
-  })
-
-  const captionsFile = media["embedded_media"].find(
-    embeddedMedia =>
-      embeddedMedia["id"].endsWith(".vtt") &&
-      embeddedMedia["title"] === "3play caption file"
-  )
-
-  const captionsFileLocation = captionsFile
-    ? stripS3(pathLookup.byUid[captionsFile.uid].fileLocation)
-    : ""
-
-  const transcriptFile = media["embedded_media"].find(
-    embeddedMedia =>
-      embeddedMedia["id"].endsWith(".pdf") &&
-      embeddedMedia["title"] === "3play pdf file"
-  )
-
-  const transcriptFileLocation = transcriptFile
-    ? stripS3(pathLookup.byUid[transcriptFile.uid].fileLocation)
-    : ""
-
-  return youTubeMedia
-    .map(
-      embeddedMedia =>
-        `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${embeddedMedia["media_location"]};${captionsFileLocation};${transcriptFileLocation}</div>`
-    )
-    .join("")
+  return `<div class="${EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS}">${addDashesToUid(
+    media["uid"]
+  )}</div>`
 }
 
 const makeResourceSlug = (originalFilename, resourceNameSet) => {

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -718,7 +718,7 @@ describe("helper functions", () => {
       assert.deepEqual(results, [
         {
           replacement:
-            '<div class="youtube-placeholder">ag7TLcT7VPQ;https://open-learning-course-data-production.s3.amazonaws.com/15-071-the-analytics-edge-spring-2017/c25deb20f0cc5a1ea110e6ca0f4529dc_ag7TLcT7VPQ.vtt;https://open-learning-course-data-production.s3.amazonaws.com/15-071-the-analytics-edge-spring-2017/37db4d00ba4615a77f502732a8d6165d_ag7TLcT7VPQ.pdf</div>',
+            '<div class="embedded_resource">d1eb865e-ba7f-9989-0be1-348ba7cad5bd</div>',
           match
         }
       ])

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -6,7 +6,7 @@ const {
   REPLACETHISWITHAPIPE,
   AWS_REGEX,
   SUPPORTED_IFRAME_EMBEDS,
-  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
+  EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
   IRREGULAR_WHITESPACE_REGEX,
   BASEURL_PLACEHOLDER_REGEX
 } = require("./constants")
@@ -375,21 +375,17 @@ turndownService.addRule("h4", {
   }
 })
 
-turndownService.addRule("youtube_shortcodes", {
+turndownService.addRule("resource_shortcodes", {
   filter: (node, options) => {
     const nodeClass = node.getAttribute("class")
     return (
       node.nodeName === "DIV" &&
-      nodeClass === YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS
+      nodeClass === EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS
     )
   },
   replacement: (content, node, options) => {
-    const [
-      mediaLocation,
-      captionLocation,
-      transcriptLocation
-    ] = node.textContent.split(";")
-    return `{{< youtube "${mediaLocation}" "${captionLocation}" "${transcriptLocation}">}}`
+    const mediaUid = node.textContent
+    return `{{< resource ${mediaUid} >}}`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -1,7 +1,7 @@
 const { assert } = require("chai").use(require("sinon-chai"))
 const { html2markdown } = require("./turndown")
 const {
-  YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS,
+  EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
   IRREGULAR_WHITESPACE_REGEX
 } = require("./constants")
 
@@ -254,15 +254,11 @@ describe("turndown", () => {
   })
 
   it("should properly create youtube shortcodes from placeholder divs", async () => {
-    const testId = "F3N5EkMX_ks"
-    const captionLocation = "https://example.com"
-    const transcriptLocation = "https://example2.com"
-    const inputHTML = `<div class="${YOUTUBE_SHORTCODE_PLACEHOLDER_CLASS}">${testId};${captionLocation};${transcriptLocation}</div>`
+    const uid = "d1eb865e-ba7f-9989-0be1-348ba7cad5bd"
+
+    const inputHTML = `<div class="${EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS}">${uid}</div>`
     const markdown = await html2markdown(inputHTML)
-    assert.equal(
-      markdown,
-      `{{< youtube "${testId}" "${captionLocation}" "${transcriptLocation}">}}`
-    )
+    assert.equal(markdown, `{{< resource ${uid} >}}`)
   })
 
   it(`replaces "approximate students" images with a shortcode`, async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
 https://github.com/mitodl/ocw-hugo-themes/issues/229

#### What's this PR do?
This pr replaces the youtube shortcode with a resource tag to match ocw-studio output

#### How should this be manually tested?
This pr should be tested with https://github.com/mitodl/ocw-hugo-themes/pull/230

Run
node . -i private/input -o private/output -c course_json_examples/example_courses.json --download

Go to

Go to /private/output/15-071-the-analytics-edge-spring-2017/content/pages/an-introduction-to-analytics/working-with-data-an-introduction-to-r/video-1-why-r.md

Verify that you see

```{{< resource 5bdfa329-4d68-f5b0-5fe2-356a47334e4d >}}```
instead of a youtube shortcode where the video is embedded in the page


