### PR TITLE
Change term to be only the semester without year

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -28,7 +28,7 @@ const generateDataTemplate = (courseData, pathLookup) => ({
   topics:                helpers.getConsolidatedTopics(courseData["course_collections"]),
   primary_course_number: helpers.getPrimaryCourseNumber(courseData),
   extra_course_numbers:  helpers.getExtraCourseNumbers(courseData).join(", "),
-  term:                  `${courseData["from_semester"]} ${courseData["from_year"]}`,
+  term:                  courseData["from_semester"],
   year:                  courseData["from_year"],
   level:                 !courseData["course_level"]
     ? []

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -189,7 +189,7 @@ describe("generateDataTemplate", () => {
   })
 
   it("sets the term property on the course data template to from_semester and from_year in the course json data", () => {
-    const expectedValue = `${spaceSystemsJsonData["from_semester"]} ${spaceSystemsJsonData["from_year"]}`
+    const expectedValue = spaceSystemsJsonData["from_semester"]
     const courseDataTemplate = generateDataTemplate(
       spaceSystemsJsonData,
       pathLookup


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to #399 

#### What's this PR do?
Updates term to be only the "Fall", "Summer", "Spring", or "January IAP" part of the string. The year is not included anymore since it is now in its own field.

#### How should this be manually tested?
Convert a course and verify that only the term has changed, not including the year part