### PR TITLE
Add link to 7.00 F21 and a little sorting

### DIFF
--- a/src/external_links.json
+++ b/src/external_links.json
@@ -55,6 +55,16 @@
     "title": "Online Publication"
   },
   {
+    "course_id": "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020",
+    "url": "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/",
+    "title": "Online Publication"
+  },
+  {
+    "course_id": "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2021",
+    "url": "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/",
+    "title": "Online Publication"
+  },
+  {
     "course_id": "8-370x-quantum-information-science-i-spring-2018",
     "url": "https://openlearninglibrary.mit.edu/courses/course-v1:MITx+8.370.1x+1T2018/about",
     "title": "Quantum Information Science I, Part 1"

--- a/src/external_links.json
+++ b/src/external_links.json
@@ -40,11 +40,6 @@
     "title": "III. Magnetic Materials and Devices"
   },
   {
-    "course_id": "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020",
-    "url": "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/",
-    "title": "Online Publication"
-  },
-  {
     "course_id": "6-036-introduction-to-machine-learning-fall-2020",
     "url": "https://openlearninglibrary.mit.edu/courses/course-v1:MITx+6.036+1T2019/about",
     "title": "Online Publication"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

fixup for #400 

#### What's this PR do?

adds an external link for the Fall 2021 version of 7.00. There have been two versions of this course so far. 

#### How should this be manually tested?

- make sure it doesn't break ocw-to-hugo
- run the one course and build it
- look for the link to biology.mit.edu

