### PR TITLE
apply baseurl to images

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -245,13 +245,24 @@ turndownService.addRule("baseurlshortcode", {
       if (node.getAttribute("href").match(BASEURL_PLACEHOLDER_REGEX)) {
         return true
       }
+    } else if (node.nodeName === "IMG" && node.getAttribute("src")) {
+      if (node.getAttribute("src").match(BASEURL_PLACEHOLDER_REGEX)) {
+        return true
+      }
     }
     return false
   },
   replacement: (content, node, options) => {
-    return `[${content}](${node
-      .getAttribute("href")
-      .replace(BASEURL_PLACEHOLDER_REGEX, "{{< baseurl >}}")})`
+    if (node.nodeName === "A") {
+      return `[${content}](${node
+        .getAttribute("href")
+        .replace(BASEURL_PLACEHOLDER_REGEX, "{{< baseurl >}}")})`
+    } else if (node.nodeName === "IMG") {
+      const altText = node.getAttribute("alt") ? node.getAttribute("alt") : ""
+      return `![${altText}](${node
+        .getAttribute("src")
+        .replace(BASEURL_PLACEHOLDER_REGEX, "{{< baseurl >}}")})`
+    }
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -137,6 +137,18 @@ describe("turndown", () => {
     )
   })
 
+  it("should return a baseurl shortcode in a link if the placeholder is there", async () => {
+    const inputHTML = `<a href="BASEURL_PLACEHOLDER/test-section/page">link text</a>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, "[link text]({{< baseurl >}}/test-section/page)")
+  })
+
+  it("should return a baseurl shortcode in an img src if the placeholder is there", async () => {
+    const inputHTML = `<img src="BASEURL_PLACEHOLDER/resources/image" alt="test image" />`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, "![test image]({{< baseurl >}}/resources/image)")
+  })
+
   it("should return a quote shortcode for instructor insights quotes", async () => {
     const inputHTML = `<div class="pullquote right">
       <p class="quote">I think stories are an important element of education, and if you strip them out, you don't have


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/377

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/175, we added a turndown rule to apply the `{{< baseurl >}}` shortcode before relative links in markdown, so that links in content would respect the `--baseUrl` build time argument when running Hugo.  The rule was set up to apply to links, but not images which can also have a relative URL.  This PR sets up the turndown rule to apply to images as well.

#### How should this be manually tested?
 - Clone `ocw-to-hugo` locally on this branch and ensure you are set up to download courses from S3
 - Run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download --rm`
 - Open `private/output/18-06sc-linear-algebra-fall-2011/content/pages/positive-definite-matrices-and-applications/similar-matrices-and-jordan-form.md` and verify that you don't see `BASEURL_PLACEHOLDER` anywhere in the markdown
