### PR TITLE
Add image metadata

### DIFF
--- a/src/data_template_generators.js
+++ b/src/data_template_generators.js
@@ -1,8 +1,9 @@
 const moment = require("moment")
 
-const { generateCourseDescription } = require("./markdown_generators")
+const { fixLinks, generateCourseDescription } = require("./markdown_generators")
 const { INPUT_COURSE_DATE_FORMAT } = require("./constants")
 const helpers = require("./helpers")
+const { html2markdown } = require("./turndown")
 
 const generateDataTemplate = (courseData, pathLookup) => ({
   course_title:       courseData["title"],
@@ -62,9 +63,15 @@ const generateLegacyDataTemplate = (courseData, pathLookup) => {
   ]
     ? courseData["image_alternate_text"]
     : ""
-  dataTemplate["course_image_caption_text"] = courseData["image_caption_text"]
-    ? courseData["image_caption_text"]
-    : ""
+  dataTemplate["course_image_caption_text"] = html2markdown(
+    fixLinks(
+      courseData["image_caption_text"] ? courseData["image_caption_text"] : "",
+      courseData,
+      pathLookup,
+      false,
+      true
+    )
+  )
   dataTemplate["publishdate"] = courseData["first_published_to_production"]
     ? moment(
       courseData["first_published_to_production"],

--- a/src/data_template_generators_test.js
+++ b/src/data_template_generators_test.js
@@ -335,7 +335,7 @@ describe("generateLegacyDataTemplate", () => {
     )
     assert.equal(
       courseDataTemplate["course_image_caption_text"],
-      '<p>Astronauts setting up a lunar telescope array. (Image courtesy of <a href="http://www.nasa.gov/mission_pages/exploration/multimedia/jfa18844_prt.htm">NASA</a>.)</p>'
+      "Astronauts setting up a lunar telescope array. (Image courtesy of [NASA](http://www.nasa.gov/mission_pages/exploration/multimedia/jfa18844_prt.htm).)"
     )
   })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -70,7 +70,7 @@ const generateResourceMarkdown = (courseData, pathLookup) => {
 
       return {
         name: `${resourcePath}.md`,
-        data: generateResourceMarkdownForFile(file, courseData)
+        data: generateResourceMarkdownForFile(file, courseData, pathLookup)
       }
     } catch (err) {
       loggers.fileLogger.error(err)
@@ -227,7 +227,7 @@ const getResourceType = mimeType => {
   }
 }
 
-const generateResourceMarkdownForFile = (file, courseData) => {
+const generateResourceMarkdownForFile = (file, courseData, pathLookup) => {
   /**
   Generate the front matter metadata for a PDF file
   */
@@ -257,8 +257,10 @@ const generateResourceMarkdownForFile = (file, courseData) => {
 
     frontMatter["image_metadata"] = {
       ["image-alt"]: alt || "",
-      caption:       caption || "",
-      credit:        file["credit"] || ""
+      caption:       html2markdown(
+        fixLinks(caption || "", courseData, pathLookup, false, true)
+      ),
+      credit: file["credit"] || ""
     }
   }
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -260,7 +260,9 @@ const generateResourceMarkdownForFile = (file, courseData, pathLookup) => {
       caption:       html2markdown(
         fixLinks(caption || "", courseData, pathLookup, false, true)
       ),
-      credit: file["credit"] || ""
+      credit: html2markdown(
+        fixLinks(file["credit"] || "", courseData, pathLookup, false, true)
+      )
     }
   }
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -310,7 +310,7 @@ describe("markdown generators", () => {
       const imageFrontmatter = files.find(file => file.uid === courseImageUid)
       assert.deepEqual(imageFrontmatter["image_metadata"], {
         caption:
-          "<p>Issac Newton is honored on the facade of Killian Court at MIT. Newton developed most of the concepts studied in classical mechanics. (Photo courtesy of Dr. Michelle Tomasik.)</p>",
+          "Issac Newton is honored on the facade of Killian Court at MIT. Newton developed most of the concepts studied in classical mechanics. (Photo courtesy of Dr. Michelle Tomasik.)",
         credit:      "Photo courtesy of Dr. Michelle Tomasik.",
         "image-alt":
           'A photo of a building with the word "Newton" engraved on the side.'
@@ -321,7 +321,7 @@ describe("markdown generators", () => {
       )
       assert.deepEqual(thumbnailFrontmatter["image_metadata"], {
         caption:
-          "<p>Issac Newton is honored on the facade of Killian Court at MIT. Newton developed most of the concepts studied in classical mechanics. (Photo courtesy of Dr. Michelle Tomasik.)</p>",
+          "Issac Newton is honored on the facade of Killian Court at MIT. Newton developed most of the concepts studied in classical mechanics. (Photo courtesy of Dr. Michelle Tomasik.)",
         credit:      "Photo courtesy of Dr. Michelle Tomasik.",
         "image-alt":
           'A photo of a building with the word "Newton" engraved on the side.'

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -3,6 +3,8 @@ const { assert, expect } = require("chai").use(require("sinon-chai"))
 const yaml = require("js-yaml")
 
 const markdownGenerators = require("./markdown_generators")
+const dataTemplateGenerators = require("./data_template_generators")
+
 const helpers = require("./helpers")
 const fileOperations = require("./file_operations")
 const {
@@ -14,6 +16,7 @@ const {
   physics802Id,
   subtitlesCourseId,
   classicalMechanicsId,
+  embeddedYoutubeVideoCourseId,
   allCourseIds
 } = require("./test_utils")
 
@@ -24,6 +27,7 @@ describe("markdown generators", () => {
     physicsCourseJsonData,
     subtitlesCourseJsonData,
     classicalMechanicsJsonData,
+    embeddedYoutubeVideoJsonData,
     coursePagesWithText,
     imageGalleryPages,
     imageGalleryImages,
@@ -39,6 +43,7 @@ describe("markdown generators", () => {
     physicsCourseJsonData = readCourseJson(physics802Id)
     subtitlesCourseJsonData = readCourseJson(subtitlesCourseId)
     classicalMechanicsJsonData = readCourseJson(classicalMechanicsId)
+    embeddedYoutubeVideoJsonData = readCourseJson(embeddedYoutubeVideoCourseId)
 
     coursePagesWithText = singleCourseJsonData["course_pages"].filter(
       page => page["text"]
@@ -248,19 +253,78 @@ describe("markdown generators", () => {
         pathLookup
       )
       const file = markdownData.find(
-        file =>
-          file.name ===
-          "/resources/jsinput_freebodydraw_massive_rope_between_trees_setup.md"
+        file => file.name === "/resources/dvwkch0ocu8.md"
       )
       const frontmatter = yaml.safeLoad(file.data.split("---\n")[1])
       assert.deepEqual(frontmatter, {
         description: "",
         file:
-          "https://open-learning-course-data-production.s3.amazonaws.com/8-01sc-classical-mechanics-fall-2016/838633c70a5b59cce23f0909eaeb96d7_jsinput_freebodydraw_massive_rope_between_trees_setup.svg",
-        file_type:    "image/svg+xml",
-        resourcetype: "Image",
-        title:        "jsinput_freebodydraw_massive_rope_between_trees_setup.svg",
-        uid:          "838633c7-0a5b-59cc-e23f-0909eaeb96d7"
+          "https://open-learning-course-data-production.s3.amazonaws.com/8-01sc-classical-mechanics-fall-2016/96dd8de9796837cfb0e487cae01c2710_dvWKCH0ocu8.srt",
+        file_type:    "application/x-subrip",
+        resourcetype: "Other",
+        title:        "3play caption file",
+        uid:          "96dd8de9-7968-37cf-b0e4-87cae01c2710"
+      })
+    })
+
+    it("generates a resource page for an image", () => {
+      const markdownData = markdownGenerators.generateMarkdownFromJson(
+        embeddedYoutubeVideoJsonData,
+        pathLookup
+      )
+      const file = markdownData.find(
+        file => file.name === "/resources/shapes.md"
+      )
+      const frontmatter = yaml.safeLoad(file.data.split("---\n")[1])
+      assert.deepEqual(frontmatter, {
+        description: "Image: ",
+        file:
+          "https://open-learning-course-data-production.s3.amazonaws.com/15-071-the-analytics-edge-spring-2017/6a88ce72b6c9709cc7bd95550e3cd349_Shapes.jpg",
+        file_type:      "image/jpeg",
+        resourcetype:   "Image",
+        title:          "Shapes.jpg",
+        uid:            "6a88ce72-b6c9-709c-c7bd-95550e3cd349",
+        image_metadata: {
+          caption:     "",
+          credit:      "",
+          "image-alt":
+            "Variety of colors and shapes available in R using ggplot."
+        }
+      })
+    })
+
+    it("uses course home page image metadata for a course image or thumbnail", () => {
+      const courseJson = dataTemplateGenerators.generateLegacyDataTemplate(
+        classicalMechanicsJsonData,
+        pathLookup
+      )
+      const courseImageUid = courseJson["course_image"]["content"]
+      const courseThumbnailUid = courseJson["course_image_thumbnail"]["content"]
+      const markdownData = markdownGenerators.generateMarkdownFromJson(
+        classicalMechanicsJsonData,
+        pathLookup
+      )
+      const files = markdownData.map(file =>
+        yaml.safeLoad(file.data.split("---\n")[1])
+      )
+      const imageFrontmatter = files.find(file => file.uid === courseImageUid)
+      assert.deepEqual(imageFrontmatter["image_metadata"], {
+        caption:
+          "<p>Issac Newton is honored on the facade of Killian Court at MIT. Newton developed most of the concepts studied in classical mechanics. (Photo courtesy of Dr. Michelle Tomasik.)</p>",
+        credit:      "Photo courtesy of Dr. Michelle Tomasik.",
+        "image-alt":
+          'A photo of a building with the word "Newton" engraved on the side.'
+      })
+
+      const thumbnailFrontmatter = files.find(
+        file => file.uid === courseThumbnailUid
+      )
+      assert.deepEqual(thumbnailFrontmatter["image_metadata"], {
+        caption:
+          "<p>Issac Newton is honored on the facade of Killian Court at MIT. Newton developed most of the concepts studied in classical mechanics. (Photo courtesy of Dr. Michelle Tomasik.)</p>",
+        credit:      "Photo courtesy of Dr. Michelle Tomasik.",
+        "image-alt":
+          'A photo of a building with the word "Newton" engraved on the side.'
       })
     })
 

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -20,7 +20,9 @@ const {
   allCourseIds
 } = require("./test_utils")
 
-describe("markdown generators", () => {
+describe("markdown generators", function() {
+  this.timeout(5000)
+
   let singleCourseJsonData,
     imageGalleryCourseJsonData,
     videoGalleryCourseJsonData,

--- a/src/test_utils.js
+++ b/src/test_utils.js
@@ -50,7 +50,8 @@ const allCourseIds = [
   covidCourseId,
   engineering1601Id,
   algorithmsCourseId,
-  entropyCourseId
+  entropyCourseId,
+  embeddedYoutubeVideoCourseId
 ]
 
 const getParsedJsonPath = courseId =>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/260

#### What's this PR do?
Adds `image_metadata` for image resources. For the course image or thumbnail it will use the same alt text that we use in the legacy JSON

#### How should this be manually tested?
Convert `1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012`. Look at the course image and thumbnail uids in the `course.json` file. The uids will match `1-00s12.md` and `1-00s12-th.md`. Look in both of those files. You should see a `image_metadata` section which says "One big and one small circuit board" for the alt text, and "This phidget kit features one of the many tools" in the caption