### PR TITLE
generate resource_file shortcodes for images

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,8 @@ module.exports = {
   BASEURL_PLACEHOLDER:                           "BASEURL_PLACEHOLDER",
   BASEURL_PLACEHOLDER_REGEX:                     new RegExp("BASEURL_PLACEHOLDER", "g"),
   BASEURL_SHORTCODE:                             "{{< baseurl >}}",
+  RESOURCE_FILE_PLACEHOLDER:                     "RESOURCE_FILE_PLACEHOLDER",
+  RESOURCE_FILE_PLACEHOLDER_REGEX:               new RegExp("RESOURCE_FILE_PLACEHOLDER", "g"),
   EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS: "embedded_resource",
   MISSING_JSON_ERROR_MESSAGE:
     "To download courses from AWS, you must specify the -c argument.  For more information, see README.md",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,6 +11,7 @@ const EXTERNAL_LINKS_JSON = require("./external_links.json")
 const {
   AWS_REGEX,
   BASEURL_PLACEHOLDER,
+  RESOURCE_FILE_PLACEHOLDER,
   FILE_TYPE,
   INPUT_COURSE_DATE_FORMAT,
   EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
@@ -375,13 +376,16 @@ const constructInternalLink = (
       ? stripSlashPrefix(pathRelativeToCourseRoot)
       : pathRelativeToCourseRoot
 
-  // if this links to an image resource, return the resource_file shortcode
+  // if this links to an image resource, return the resource_file placeholder
   const matchingFile = courseData["course_files"].filter(
     file => file["uid"] === uid
   )
   if (matchingFile.length > 0) {
     if (getResourceType(matchingFile[0]["file_type"]) === RESOURCE_TYPE_IMAGE) {
-      return `{{< resource_file ${addDashesToUid(uid)} >}}`
+      return `${RESOURCE_FILE_PLACEHOLDER} ${uid} ${path.join(
+        "/",
+        strippedPath
+      )}`
     }
   }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -382,7 +382,7 @@ const constructInternalLink = (
   )
   if (matchingFile.length > 0) {
     if (getResourceType(matchingFile[0]["file_type"]) === RESOURCE_TYPE_IMAGE) {
-      return `${RESOURCE_FILE_PLACEHOLDER} ${uid} ${path.join(
+      return `${RESOURCE_FILE_PLACEHOLDER} ${addDashesToUid(uid)} ${path.join(
         "/",
         strippedPath
       )}`

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,7 @@ const {
   COURSE_TYPE,
   RESOURCE_TYPE_OTHER,
   RESOURCE_TYPE_DOCUMENT,
-  RESOURCE_TYPE_IMAGE,
+  RESOURCE_TYPE_IMAGE
 } = require("./constants")
 const loggers = require("./loggers")
 const runOptions = {}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -377,11 +377,11 @@ const constructInternalLink = (
       : pathRelativeToCourseRoot
 
   // if this links to an image resource, return the resource_file placeholder
-  const matchingFile = courseData["course_files"].filter(
+  const matchingFile = courseData["course_files"].find(
     file => file["uid"] === uid
   )
-  if (matchingFile.length > 0) {
-    if (getResourceType(matchingFile[0]["file_type"]) === RESOURCE_TYPE_IMAGE) {
+  if (matchingFile) {
+    if (getResourceType(matchingFile["file_type"]) === RESOURCE_TYPE_IMAGE) {
       return `${RESOURCE_FILE_PLACEHOLDER} ${addDashesToUid(uid)} ${path.join(
         "/",
         strippedPath

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,7 +15,10 @@ const {
   INPUT_COURSE_DATE_FORMAT,
   EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
   EMBEDDED_MEDIA_PAGE_TYPE,
-  COURSE_TYPE
+  COURSE_TYPE,
+  RESOURCE_TYPE_OTHER,
+  RESOURCE_TYPE_DOCUMENT,
+  RESOURCE_TYPE_IMAGE,
 } = require("./constants")
 const loggers = require("./loggers")
 const runOptions = {}
@@ -363,13 +366,24 @@ const constructInternalLink = (
   uid,
   pageCourse,
   useShortcodes,
-  isRelativeToRoot
+  isRelativeToRoot,
+  courseData
 ) => {
   const isSameCourse = linkCourse === pageCourse
   const strippedPath =
     pathRelativeToCourseRoot !== "/"
       ? stripSlashPrefix(pathRelativeToCourseRoot)
       : pathRelativeToCourseRoot
+
+  // if this links to an image resource, return the resource_file shortcode
+  const matchingFile = courseData["course_files"].filter(
+    file => file["uid"] === uid
+  )
+  if (matchingFile.length > 0) {
+    if (getResourceType(matchingFile[0]["file_type"]) === RESOURCE_TYPE_IMAGE) {
+      return `{{< resource_file ${addDashesToUid(uid)} >}}`
+    }
+  }
 
   if (!useShortcodes) {
     // course.json can't use shortcodes at the moment. However the course description is only shown on the course
@@ -409,7 +423,8 @@ const resolveUidForLink = (
       uid,
       courseId,
       useShortcodes,
-      isRelativeToRoot
+      isRelativeToRoot,
+      courseData
     )
   }
 
@@ -509,7 +524,8 @@ const resolveRelativeLink = (
           null,
           thisCourseId,
           useShortcodes,
-          isRelativeToRoot
+          isRelativeToRoot,
+          courseData
         )
         return updatePath(url, getPathFragments(internalLink), isRelativeToRoot)
       }
@@ -534,7 +550,8 @@ const resolveRelativeLink = (
                 uid,
                 thisCourseId,
                 useShortcodes,
-                isRelativeToRoot
+                isRelativeToRoot,
+                courseData
               )
             } else {
               return stripS3(pathObj.fileLocation)
@@ -557,7 +574,8 @@ const resolveRelativeLink = (
           null,
           thisCourseId,
           useShortcodes,
-          isRelativeToRoot
+          isRelativeToRoot,
+          courseData
         )
         return updatePath(url, getPathFragments(internalLink), isRelativeToRoot)
       }
@@ -644,7 +662,8 @@ const resolveYouTubeEmbedMatches = (
           uid,
           courseData["short_url"],
           useShortcodes,
-          isRelativeToRoot
+          isRelativeToRoot,
+          courseData
         )
 
         const replacement =
@@ -800,6 +819,21 @@ const getVideoUidsFromPage = (page, courseData) => {
   return videos.map(video => addDashesToUid(video["uid"]))
 }
 
+const getResourceType = mimeType => {
+  switch (mimeType) {
+  case "application/pdf":
+    return RESOURCE_TYPE_DOCUMENT
+  case "image/gif":
+  case "image/jpeg":
+  case "image/png":
+  case "image/svg+xml":
+  case "image/tiff":
+    return RESOURCE_TYPE_IMAGE
+  default:
+    return RESOURCE_TYPE_OTHER
+  }
+}
+
 module.exports = {
   directoryExists,
   createOrOverwriteFile,
@@ -839,5 +873,6 @@ module.exports = {
   addDashesToUid,
   replaceSubstring,
   getUidFromFilePath,
-  getVideoUidsFromPage
+  getVideoUidsFromPage,
+  getResourceType
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -345,8 +345,9 @@ describe("helper functions", () => {
       )
       const fileResult = result.find(item => item.match[0] === link)
       assert.deepEqual(fileResult, {
-        replacement: "{{< resource_file 915b6ae8-ee3c-e053-1360-df600464d389 >}}",
-        match:       [link]
+        replacement:
+          "{{< resource_file 915b6ae8-ee3c-e053-1360-df600464d389 >}}",
+        match: [link]
       })
     })
 

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -346,7 +346,7 @@ describe("helper functions", () => {
       const fileResult = result.find(item => item.match[0] === link)
       assert.deepEqual(fileResult, {
         replacement:
-          "RESOURCE_FILE_PLACEHOLDER 915b6ae8ee3ce0531360df600464d389 resources/img_20141011_092912",
+          "RESOURCE_FILE_PLACEHOLDER 915b6ae8ee3ce0531360df600464d389 /resources/img_20141011_092912",
         match: [link]
       })
     })
@@ -625,7 +625,7 @@ describe("helper functions", () => {
       )
       assert.equal(
         result[0].replacement,
-        'href="RESOURCE_FILE_PLACEHOLDER 365bce6e8357a07d939a271972558376 resources/12"'
+        'href="RESOURCE_FILE_PLACEHOLDER 365bce6e8357a07d939a271972558376 /resources/12"'
       )
     })
 

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -345,7 +345,7 @@ describe("helper functions", () => {
       )
       const fileResult = result.find(item => item.match[0] === link)
       assert.deepEqual(fileResult, {
-        replacement: "BASEURL_PLACEHOLDER/resources/img_20141011_092912",
+        replacement: "{{< resource_file 915b6ae8-ee3c-e053-1360-df600464d389 >}}",
         match:       [link]
       })
     })
@@ -614,7 +614,7 @@ describe("helper functions", () => {
     })
 
     it("handles relative links to static assets by adding an S3 link", () => {
-      const text = `<a href="/courses/aeronautics-and-astronautics/${singleCourseId}/labs/12.jpg">Table Organization</a></p> `
+      const text = `<p><a href="/courses/aeronautics-and-astronautics/${singleCourseId}/labs/12.jpg">Table Organization</a></p> `
       const result = helpers.resolveRelativeLinkMatches(
         text,
         singleCourseJsonData,
@@ -624,7 +624,7 @@ describe("helper functions", () => {
       )
       assert.equal(
         result[0].replacement,
-        'href="BASEURL_PLACEHOLDER/resources/12"'
+        'href="{{< resource_file 365bce6e-8357-a07d-939a-271972558376 >}}"'
       )
     })
 

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -346,7 +346,7 @@ describe("helper functions", () => {
       const fileResult = result.find(item => item.match[0] === link)
       assert.deepEqual(fileResult, {
         replacement:
-          "RESOURCE_FILE_PLACEHOLDER 915b6ae8ee3ce0531360df600464d389 /resources/img_20141011_092912",
+          "RESOURCE_FILE_PLACEHOLDER 915b6ae8-ee3c-e053-1360-df600464d389 /resources/img_20141011_092912",
         match: [link]
       })
     })
@@ -625,7 +625,7 @@ describe("helper functions", () => {
       )
       assert.equal(
         result[0].replacement,
-        'href="RESOURCE_FILE_PLACEHOLDER 365bce6e8357a07d939a271972558376 /resources/12"'
+        'href="RESOURCE_FILE_PLACEHOLDER 365bce6e-8357-a07d-939a-271972558376 /resources/12"'
       )
     })
 

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -346,7 +346,7 @@ describe("helper functions", () => {
       const fileResult = result.find(item => item.match[0] === link)
       assert.deepEqual(fileResult, {
         replacement:
-          "{{< resource_file 915b6ae8-ee3c-e053-1360-df600464d389 >}}",
+          "RESOURCE_FILE_PLACEHOLDER 915b6ae8ee3ce0531360df600464d389 resources/img_20141011_092912",
         match: [link]
       })
     })
@@ -614,7 +614,7 @@ describe("helper functions", () => {
       assert.equal(result[0].replacement, `href="${link}"`)
     })
 
-    it("handles relative links to static assets by adding an S3 link", () => {
+    it("handles relative links to images by inserting a resource_file placeholder with uid and path", () => {
       const text = `<p><a href="/courses/aeronautics-and-astronautics/${singleCourseId}/labs/12.jpg">Table Organization</a></p> `
       const result = helpers.resolveRelativeLinkMatches(
         text,
@@ -625,7 +625,7 @@ describe("helper functions", () => {
       )
       assert.equal(
         result[0].replacement,
-        'href="{{< resource_file 365bce6e-8357-a07d-939a-271972558376 >}}"'
+        'href="RESOURCE_FILE_PLACEHOLDER 365bce6e8357a07d939a271972558376 resources/12"'
       )
     })
 

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -5,10 +5,7 @@ const stripHtml = require("string-strip-html")
 const helpers = require("./helpers")
 const loggers = require("./loggers")
 const { html2markdown } = require("./turndown")
-const {
-  RESOURCE_TYPE_IMAGE,
-  RESOURCE_TYPE_VIDEO
-} = require("./constants")
+const { RESOURCE_TYPE_IMAGE, RESOURCE_TYPE_VIDEO } = require("./constants")
 
 const fixLinks = (
   htmlStr,

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -6,8 +6,6 @@ const helpers = require("./helpers")
 const loggers = require("./loggers")
 const { html2markdown } = require("./turndown")
 const {
-  RESOURCE_TYPE_OTHER,
-  RESOURCE_TYPE_DOCUMENT,
   RESOURCE_TYPE_IMAGE,
   RESOURCE_TYPE_VIDEO
 } = require("./constants")
@@ -212,21 +210,6 @@ const generateCourseSectionMarkdown = (page, courseData, pathLookup) => {
   }
 }
 
-const getResourceType = mimeType => {
-  switch (mimeType) {
-  case "application/pdf":
-    return RESOURCE_TYPE_DOCUMENT
-  case "image/gif":
-  case "image/jpeg":
-  case "image/png":
-  case "image/svg+xml":
-  case "image/tiff":
-    return RESOURCE_TYPE_IMAGE
-  default:
-    return RESOURCE_TYPE_OTHER
-  }
-}
-
 const generateResourceMarkdownForFile = (file, courseData, pathLookup) => {
   /**
   Generate the front matter metadata for a PDF file
@@ -236,7 +219,7 @@ const generateResourceMarkdownForFile = (file, courseData, pathLookup) => {
     title:        file["title"],
     description:  file["description"],
     uid:          uid,
-    resourcetype: getResourceType(file["file_type"]),
+    resourcetype: helpers.getResourceType(file["file_type"]),
     file_type:    file["file_type"],
     file:         helpers.stripS3(file["file_location"])
   }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -9,7 +9,8 @@ const {
   EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
   IRREGULAR_WHITESPACE_REGEX,
   BASEURL_PLACEHOLDER_REGEX,
-  DIV_WITH_CLASS_CLASSES_REGEXES
+  DIV_WITH_CLASS_CLASSES_REGEXES,
+  RESOURCE_FILE_PLACEHOLDER
 } = require("./constants")
 const helpers = require("./helpers")
 const loggers = require("./loggers")
@@ -246,8 +247,24 @@ turndownService.addRule("baseurlshortcode", {
       if (node.getAttribute("href").match(BASEURL_PLACEHOLDER_REGEX)) {
         return true
       }
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    return `[${content}](${node
+      .getAttribute("href")
+      .replace(BASEURL_PLACEHOLDER_REGEX, "{{< baseurl >}}")})`
+  }
+})
+
+turndownService.addRule("resourcefileshortcode", {
+  filter: (node, options) => {
+    if (node.nodeName === "A" && node.getAttribute("href")) {
+      if (node.getAttribute("href").match(RESOURCE_FILE_PLACEHOLDER)) {
+        return true
+      }
     } else if (node.nodeName === "IMG" && node.getAttribute("src")) {
-      if (node.getAttribute("src").match(BASEURL_PLACEHOLDER_REGEX)) {
+      if (node.getAttribute("src").match(RESOURCE_FILE_PLACEHOLDER)) {
         return true
       }
     }
@@ -255,14 +272,14 @@ turndownService.addRule("baseurlshortcode", {
   },
   replacement: (content, node, options) => {
     if (node.nodeName === "A") {
-      return `[${content}](${node
-        .getAttribute("href")
-        .replace(BASEURL_PLACEHOLDER_REGEX, "{{< baseurl >}}")})`
+      const parts = node.getAttribute("href").split(" ")
+      const resourceUrl = parts[2]
+      return `[${content}]({{< baseurl >}}${resourceUrl})`
     } else if (node.nodeName === "IMG") {
       const altText = node.getAttribute("alt") ? node.getAttribute("alt") : ""
-      return `![${altText}](${node
-        .getAttribute("src")
-        .replace(BASEURL_PLACEHOLDER_REGEX, "{{< baseurl >}}")})`
+      const parts = node.getAttribute("src").split(" ")
+      const uid = parts[1]
+      return `![${altText}]({{< resource_file ${uid} >}})`
     }
   }
 })

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -143,10 +143,19 @@ describe("turndown", () => {
     assert.equal(markdown, "[link text]({{< baseurl >}}/test-section/page)")
   })
 
-  it("should return a baseurl shortcode in an img src if the placeholder is there", async () => {
-    const inputHTML = `<img src="BASEURL_PLACEHOLDER/resources/image" alt="test image" />`
+  it("should return a path to an image resource prefixed with the baseurl shortcode if it's linked in an a tag", async () => {
+    const inputHTML = `<a href="RESOURCE_FILE_PLACEHOLDER 05e36cd1-b32f-4b27-9fda-6173ec926253 /resources/image"" >test image</a>`
     const markdown = await html2markdown(inputHTML)
-    assert.equal(markdown, "![test image]({{< baseurl >}}/resources/image)")
+    assert.equal(markdown, "[test image]({{< baseurl >}}/resources/image)")
+  })
+
+  it("should return a resource_file shortcode in an img src if the placeholder is there", async () => {
+    const inputHTML = `<img src="RESOURCE_FILE_PLACEHOLDER 05e36cd1-b32f-4b27-9fda-6173ec926253 /resources/image" alt="test image" />`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(
+      markdown,
+      "![test image]({{< resource_file 05e36cd1-b32f-4b27-9fda-6173ec926253 >}})"
+    )
   })
 
   it("should return a quote shortcode for instructor insights quotes", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/352

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/337, we changed `ocw-to-hugo` to generate an `ocw-studio` style resource under `content/resources` for each item in `course_files`.  This had the side effect of generating links to the HTML page representing a resource and putting those links inside of the `src` tags on image elements.  This PR instead generates a `resource_file` shortcode, keyed on the UUID of the resource in its place for images.  This new shortcode is being implemented in https://github.com/mitodl/ocw-hugo-themes/pull/273.o

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and ensure you are set up to download courses from S3
 - Create a file at `private/courses.json` and place the following in it:
```
{
    "courses": [
        "1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012"
    ]
}
```
 - Run `node . -i private/input -o private/output -c private/courses.json --download --rm`
 - Clone `ocw-hugo-themes` on the `cg/resource-file-shortcode` branch
 - In the `.env` file there, set:
   - `COURSE_CONTENT_PATH=/path/to/ocw-to-hugo/private/output`
   - `OCW_TEST_COURSE=12-744-marine-isotope-chemistry-fall-2012`
 - Spin up the course site with `npm run start:course`
 - Visit http://localhost:3000/pages/study-materials/ and verify that the images load properly
 - Change `OCW_TEST_COURSE` to `11-123-big-plans-and-mega-urban-landscapes-spring-2014`
 - Restart the local site by killing and re-running `npm run start:course`
 - Visit http://localhost:3000/pages/assignments/ and verify that the "Illustrator Workshop Materials: Base Map (JPG)" link in the first table row links to a resource page and not directly to the JPG file