### PR TITLE
div-with-class

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -22,7 +22,10 @@ module.exports = {
       getID:         url => url.pathname.replace("/", "")
     }
   },
-
+  DIV_WITH_CLASS_CLASSES_REGEXES: new Array(
+    new RegExp("toggle[0-9]"),
+    new RegExp("reveal[0-9]")
+  ),
   // These are internal values for keeping track of uids.
   // None of these are used by the plone source data and none should be present in the output JSON.
   EMBEDDED_MEDIA_PAGE_TYPE: "embedded-media-page-type",

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -8,7 +8,8 @@ const {
   SUPPORTED_IFRAME_EMBEDS,
   EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
   IRREGULAR_WHITESPACE_REGEX,
-  BASEURL_PLACEHOLDER_REGEX
+  BASEURL_PLACEHOLDER_REGEX,
+  DIV_WITH_CLASS_CLASSES_REGEXES
 } = require("./constants")
 const helpers = require("./helpers")
 const loggers = require("./loggers")
@@ -383,6 +384,23 @@ turndownService.addRule("h4", {
   filter:      ["h4"],
   replacement: (content, node, options) => {
     return `##### ${content}`
+  }
+})
+
+turndownService.addRule("div_with_class", {
+  filter: (node, options) => {
+    if (node.nodeName === "DIV" && node.getAttribute("class")) {
+      for (const classRegex of DIV_WITH_CLASS_CLASSES_REGEXES) {
+        if (classRegex.test(node.getAttribute("class"))) {
+          return true
+        }
+      }
+    }
+    return false
+  },
+  replacement: (content, node, options) => {
+    const name = JSON.stringify(node.getAttribute("class"))
+    return `{{< div-with-class ${name}>}}${content}{{< /div-with-class >}}`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -284,4 +284,22 @@ describe("turndown", () => {
     const markdown = await html2markdown(inputHTML)
     assert.equal(markdown, "{{< approx-students 300 >}}")
   })
+
+  it(`replaces divs with "toggle" in the class name with a shortcode`, async () => {
+    const inputHTML = `<div class="toggle1">Click Me</div>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(
+      markdown,
+      `{{< div-with-class "toggle1">}}Click Me{{< /div-with-class >}}`
+    )
+  })
+
+  it(`replaces divs with "reveal" in the class name with a shortcode`, async () => {
+    const inputHTML = `<div class="reveal1">Show Me</div>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(
+      markdown,
+      `{{< div-with-class "reveal1">}}Show Me{{< /div-with-class >}}`
+    )
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/259

#### What's this PR do?
This adds a div-with-class shortcode for divs with classes that match "toggle" and "reveal".

Legacy ocw dives with classes with "toggle" and "reveal"  for short answer quiz questions, and sometimes large blocks of text part of which is hidden until the user clicks "Read More". The pairs are matched with a number  after "toggle" or "reveal",  for example "toggle3" and "reveal3". 

This PR introduces a shortcode to preserve the class of a divs that  match  an array of regexes. Currently this just  matches for "toggle" and "reveal"

#### How should this be manually tested?
Set example_courses.json to
```
{
    "courses": [
        "6-00sc-introduction-to-computer-science-and-programming-spring-2011",
    ]
}
```
Run
```
node . -i private/input -o private/output -c course_json_examples/example_courses.json --download
```

Got to
private/output/6-00sc-introduction-to-computer-science-and-programming-spring-2011/content/pages/unit-1/6-00sc-introduction-to-computer-science-and-programming-spring-2011

and verify that you see `div-with-class` shortcode blocks

Then, follow the steps for testing https://github.com/mitodl/ocw-hugo-themes/pull/274

