### PR TITLE
Don't output index.md or _index.md for resources

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -40,5 +40,7 @@ module.exports = {
   RESOURCE_TYPE_IMAGE:    "Image",
   RESOURCE_TYPE_VIDEO:    "Video",
   RESOURCE_TYPE_OTHER:    "Other",
-  RESOURCE_TYPE_DOCUMENT: "Document"
+  RESOURCE_TYPE_DOCUMENT: "Document",
+  // skip these filenames
+  FORBIDDEN_FILENAMES:    new Set(["index", "_index"])
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -19,7 +19,8 @@ const {
   COURSE_TYPE,
   RESOURCE_TYPE_OTHER,
   RESOURCE_TYPE_DOCUMENT,
-  RESOURCE_TYPE_IMAGE
+  RESOURCE_TYPE_IMAGE,
+  FORBIDDEN_FILENAMES
 } = require("./constants")
 const loggers = require("./loggers")
 const runOptions = {}
@@ -242,7 +243,7 @@ const makeResourceSlug = (originalFilename, resourceNameSet) => {
   let filename = prefix
 
   let idx = 1
-  while (resourceNameSet.has(filename)) {
+  while (resourceNameSet.has(filename) || FORBIDDEN_FILENAMES.has(filename)) {
     filename = `${prefix}-${idx}`
     idx++
   }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -988,5 +988,19 @@ describe("helper functions", () => {
         "b03952e4-bdfc-ea49-6227-1aeae1dedb3f"
       ])
     })
+
+    it("creates a resource slug unique from other slugs", () => {
+      [
+        ["Original file name1234[ ]--=", [], "original-file-name1234---"],
+        ["file", ["file", "file-1"], "file-2"],
+        ["index", [], "index-1"],
+        ["_index", [], "_index-1"]
+      ].forEach(([originalName, existingNames, expected]) => {
+        assert.equal(
+          helpers.makeResourceSlug(originalName, new Set(existingNames)),
+          expected
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-themes/pull/282

#### What's this PR do?
Changes `index.md` to `index-1.md` for generated resource markdown files. This does not change anything for other markdown files like pages since I think we already handle that case here: https://github.com/mitodl/ocw-to-hugo/blob/5c7d2fc6b69276060397f23875c8aa66033c4465/src/helpers.js#L567

#### How should this be manually tested?
Convert all courses. You should see only changes related to `resource/index` being changed to `resource/index-1`