### PR TITLE
shortcode table delimiters

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -27,6 +27,15 @@ turndownService.addRule("table", {
   }
 })
 
+turndownService.addRule("caption", {
+  filter: node =>
+    hasParentNodeRecursive(node, "TABLE") && node.nodeName === "CAPTION",
+  replacement: (content, node, options) => {
+    // TODO: implement actual handling of table captions
+    return ""
+  }
+})
+
 turndownService.addRule("th", {
   filter:      node => node.nodeName === "TH",
   replacement: (content, node, options) => {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -53,18 +53,10 @@ turndownService.addRule("tr", {
 turndownService.addRule("td", {
   filter:      node => node.nodeName === "TD",
   replacement: (content, node, options) => {
-    return `{{< tdopen >}}\n${content}\n{{< tdclose >}}\n`
-  }
-})
-
-/**
- * Catch cells with a colspan attribute and rewrite them with a shortcode
- **/
-turndownService.addRule("colspan", {
-  filter:      node => node.nodeName === "TD" && node.getAttribute("colspan"),
-  replacement: (content, node, options) => {
-    const totalColumns = parseInt(node.getAttribute("colspan"))
-    return `{{< td-colspan ${totalColumns} >}}\n${content}{{< tdclose >}}`
+    const colspan = node.getAttribute("colspan")
+      ? ` colspan="${node.getAttribute("colspan")}"`
+      : ""
+    return `{{< tdopen${colspan} >}}\n${content}\n{{< tdclose >}}\n`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -151,9 +151,14 @@ _italics wrapped in a div_
 {{< tableclose >}}`
 
     it("should properly transform a table into a shortcode representation", async () => {
-      const markdown = await html2markdown(tableHTML)
-      // strip whitespace for proper comparison
-      assert.equal(markdown.replace(/\s+/g), tableMarkdown.replace(/\s+/g))
+      /**
+       * Turndown seems to insert some strange whitespace characters,
+       * so here we're replacing them with normal spaces.  If you run this
+       * comparison without the .replace, the test will fail but the strings
+       * are identical
+       */
+      const markdown = await html2markdown(tableHTML).replace(/[^\S\r\n]/g, " ")
+      assert.equal(markdown, tableMarkdown)
     })
   })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -1,13 +1,9 @@
 const { assert } = require("chai").use(require("sinon-chai"))
 const { html2markdown } = require("./turndown")
-const {
-  EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS,
-  IRREGULAR_WHITESPACE_REGEX
-} = require("./constants")
+const { EMBEDDED_RESOURCE_SHORTCODE_PLACEHOLDER_CLASS } = require("./constants")
 
 describe("turndown", () => {
   describe("tables", () => {
-    let markdown
     const tableHTML = `<table summary="See table caption for summary." class="tablewidth100">
     <caption class="invisible">Course readings.</caption> <!-- BEGIN TABLE HEADER (for MIT OCW Table Template 2.51) -->
     <thead>
@@ -45,46 +41,119 @@ describe("turndown", () => {
       </tr>
     </tbody>
   </table>`
+    const tableMarkdown = `{{< tableopen >}}
+{{< theadopen >}}
+{{< tropen >}}
+{{< thopen >}}
+LEC #
+{{< thclose >}}
+{{< thopen >}}
+TOPICS
+{{< thclose >}}
+{{< thopen >}}
+READINGS (3D ED.)
+{{< thclose >}}
+{{< thopen >}}
+READINGS (4TH ED.)
+{{< thclose >}}
 
-    beforeEach(async () => {
-      markdown = await html2markdown(tableHTML)
-    })
+{{< trclose >}}
 
-    it("should include a table definition for 4 columns", () => {
-      assert.isTrue(markdown.includes("| --- | --- | --- | --- |"))
-    })
+{{< theadclose >}}
+{{< tropen >}}
+{{< tdopen colspan="4" >}}
+**Control and Scope**
+{{< tdclose >}}
 
-    it("should properly generate a header with the td-colspan shortcode", () => {
-      assert.isTrue(
-        markdown.includes(
-          "| {{< td-colspan 4 >}}**Control and Scope**{{< /td-colspan >}} ||||"
-        )
-      )
-    })
+{{< trclose >}}
+{{< tropen >}}
+{{< tdopen >}}
+L 1
+{{< tdclose >}}
+{{< tdopen >}}
+Course Overview, Introduction to Java
+{{< tdclose >}}
+{{< tdopen >}}
+—
+{{< tdclose >}}
+{{< tdopen >}}
+—
+{{< tdclose >}}
 
-    it("should handle headers properly if they're wrapped in a p tag", () => {
-      assert.isTrue(
-        markdown.includes(
-          "| {{< td-colspan 4 >}} {{< br >}}{{< br >}} **Wrapped in a paragraph** {{< br >}}{{< br >}} {{< /td-colspan >}} ||||"
-        )
-      )
-    })
+{{< trclose >}}
+{{< tropen >}}
+{{< tdopen colspan="4" >}}
 
-    it("should properly pad line breaks in cells with containers as to not break formatting", () => {
-      assert.isTrue(
-        markdown.includes(
-          "|  {{< br >}}{{< br >}} _italics wrapped in a paragraph_ {{< br >}}{{< br >}}  |  {{< br >}}{{< br >}} _italics wrapped in a div_ {{< br >}}{{< br >}}  |  {{< br >}}{{< br >}} **strong wrapped in a paragrah** {{< br >}}{{< br >}}  |  {{< br >}}{{< br >}} **strong wrapped in a div** {{< br >}}{{< br >}}"
-        )
-      )
-    })
 
-    it("should remove irregular whitespace characters", () => {
-      assert.isNull(markdown.match(IRREGULAR_WHITESPACE_REGEX))
-    })
+**Wrapped in a paragraph**
 
-    it("should transform heading tags into heading shortcodes", () => {
-      assert.isTrue(markdown.includes("{{< h 1 >}}TEST{{< /h >}}"))
-      assert.isTrue(markdown.includes("{{< h 2 >}}TEST 2{{< /h >}}"))
+
+{{< tdclose >}}
+
+{{< trclose >}}
+{{< tropen >}}
+{{< tdopen >}}
+L 2
+{{< tdclose >}}
+{{< tdopen >}}
+Test table section 2
+{{< tdclose >}}
+{{< tdopen >}}
+
+
+TEST
+====
+
+
+{{< tdclose >}}
+{{< tdopen >}}
+
+
+TEST 2
+------
+
+
+{{< tdclose >}}
+
+{{< trclose >}}
+{{< tropen >}}
+{{< tdopen >}}
+
+
+_italics wrapped in a paragraph_
+
+
+{{< tdclose >}}
+{{< tdopen >}}
+
+
+_italics wrapped in a div_
+
+
+{{< tdclose >}}
+{{< tdopen >}}
+
+
+**strong wrapped in a paragrah**
+
+
+{{< tdclose >}}
+{{< tdopen >}}
+
+
+**strong wrapped in a div**
+
+
+{{< tdclose >}}
+
+{{< trclose >}}
+
+{{< tableclose >}}`
+
+    it("should properly transform a table into a shortcode representation", async () => {
+      const markdown = await html2markdown(tableHTML)
+      // strip whitespace for proper comparison
+      assert.equal(markdown.replace(/\s+/g), tableMarkdown.replace(/\s+/g))
     })
   })
 
@@ -347,7 +416,7 @@ describe("turndown", () => {
     const inputHTML = `
       <script type="text/javascript">
 
-        $( function($){ 
+        $( function($){
           var quizMulti = {
             multiList: [
               {
@@ -371,7 +440,7 @@ describe("turndown", () => {
             showHTML: false,
             animationType: 0,
             showWrongAns: true,
-            title: "Concept test 1",   
+            title: "Concept test 1",
         };
         $("#quizArea").jQuizMe(quizMulti, options);
         });


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/428

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/744, we set up `ocw-studio` to output a shortcode based table syntax for tables contstructed in CKEditor.  This PR modifies `ocw-to-hugo` to generate tables in the same manner, removing all of the hacks we had to put in place to get the standard markdown table syntax to work with the tables coming in from legacy OCW content.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and make sure you are set up to download courses from S3
 - Run `node . -i private/input -o private/output --courses course_json_examples/example_courses.json --download --rm
 - Clone `ocw-hugo-themes` on the `cg/tdopen-colspan` branch
 - In `ocw-hugo-themes`, read the readme if you've never spun up a course locally before and set the following variables in `.env`:
   - `COURSE_CONTENT_PATH=/path/to/ocw-to-hugo/private/output/`
   - `OCW_TEST_COURSE=18-01-single-variable-calculus-fall-2006`
   - `RESOURCE_BASE_URL=https://ocw-draft-qa.global.ssl.fastly.net/courses`
 - Run `npm run start:course`
 - Browse to http://localhost:3000/pages/calendar/
 - Verify that the table renders correctly and that the title rows are correctly using the `colspan` attribute
