### PR TITLE
replace irregular whitespace in titles with a regular space

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -861,6 +861,8 @@ const getNextSibling = (elem, selector) => {
   }
 }
 
+const replaceIrregularWhitespace = text => text.replace(/\s/g, " ")
+
 module.exports = {
   directoryExists,
   createOrOverwriteFile,
@@ -903,5 +905,6 @@ module.exports = {
   getVideoUidsFromPage,
   getResourceType,
   getPreviousSibling,
-  getNextSibling
+  getNextSibling,
+  replaceIrregularWhitespace
 }

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -1044,5 +1044,14 @@ describe("helper functions", () => {
       const sibling = helpers.getNextSibling(originNode, ".pick")
       assert.equal(sibling.innerHTML, "Next With Selector")
     })
+
+    it("replaceIrregularWhitespace replaces irregular whitespace characters in a string with a regular space", () => {
+      const testText =
+        "String\u00a0with\u00a0unicode\u00a0non\u00a0breaking\u00a0spaces"
+      assert.equal(
+        helpers.replaceIrregularWhitespace(testText),
+        "String with unicode non breaking spaces"
+      )
+    })
   })
 })

--- a/src/helpers_test.js
+++ b/src/helpers_test.js
@@ -1046,11 +1046,10 @@ describe("helper functions", () => {
     })
 
     it("replaceIrregularWhitespace replaces irregular whitespace characters in a string with a regular space", () => {
-      const testText =
-        "String\u00a0with\u00a0unicode\u00a0non\u00a0breaking\u00a0spaces"
+      const testText = "A\fB\nC\rD\tE\vF\u00A0G\u2028H\u2029I"
       assert.equal(
         helpers.replaceIrregularWhitespace(testText),
-        "String with unicode non breaking spaces"
+        "A B C D E F G H I"
       )
     })
   })

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -159,7 +159,7 @@ const generateCourseSectionFrontMatter = (
     */
   const courseSectionFrontMatter = {
     uid:   helpers.addDashesToUid(pageId),
-    title: title
+    title: helpers.replaceIrregularWhitespace(title)
   }
 
   if (parentUid) {
@@ -217,7 +217,7 @@ const generateResourceMarkdownForFile = (file, courseData, pathLookup) => {
   */
   const uid = helpers.addDashesToUid(file["uid"])
   const frontMatter = {
-    title:        file["title"],
+    title:        helpers.replaceIrregularWhitespace(file["title"]),
     description:  file["description"],
     uid:          uid,
     resourcetype: helpers.getResourceType(file["file_type"]),
@@ -290,7 +290,7 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
   const archiveUrl = archiveRecord ? archiveRecord.media_location : null
 
   const frontMatter = {
-    title:          media["title"],
+    title:          helpers.replaceIrregularWhitespace(media["title"]),
     description:    "",
     uid:            helpers.addDashesToUid(media["uid"]),
     resourcetype:   RESOURCE_TYPE_VIDEO,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/434
Related to https://github.com/mitodl/ocw-hugo-themes/pull/364

#### What's this PR do?
This PR adds a helper function called `replaceIrregularWhitespace` that replaces anything matching the regex `/\s/g` with a single regular space.  `\s` matches whitespace and is short for `[\f\n\r\t\v\u00A0\u2028\u2029]`.  This new helper function is applied anywhere a `title` property is being accessed, normalizing whitespace within the title.

#### How should this be manually tested?
 - Read the readme if you have never used `ocw-to-hugo` before, making sure you have AWS access to `open-learning-course-data-rc`
 - Put the following in `private/courses.json`:
```
{
  "courses": [
    "6-811-principles-and-practice-of-assistive-technology-fall-2014"
  ]
}
```
 - Run `node . -i private/input -o private/output -c private/courses.json --rm --download`
 - Inspect the file at `private/output/6-811-principles-and-practice-of-assistive-technology-fall-2014/content/resources/mit6_811f14_octdeliverbles.md` and ensure that the title looks normal and does not have `\_` instead of normal spaces
