### PR TITLE
make turndown escape angle brackets

### DIFF
--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -487,4 +487,31 @@ _italics wrapped in a div_
         `{{< /quiz_multiple_choice >}}`
     )
   })
+
+  it("should preserve escaped angle brackets", async () => {
+    const inputHTML = `
+&gt; Initial &gt; are escaped by turndown since they are markdown blockquotes.
+<ol>
+  <li>
+    a &lt;a second&gt;
+  </li>
+  <li>
+    b \\&lt;
+  </li>
+  <li>
+    <code>x &lt; y</code> code is not escaped
+  </li>
+<ol>
+`
+    const expectedMarkdown = `
+\\> Initial > are escaped by turndown since they are markdown blockquotes.
+
+1.  a \\<a second>
+2.  b \\\\\\<
+3.  \`x < y\` code is not escaped
+`.trim()
+
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, expectedMarkdown)
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/894

#### What's this PR do?
Some courses contain `&lt;` and `&gt;` entities in their HTML. Turndown does not, by default, escape these. This results in problems for rendering, especially in cases like `&lt;a dog &gt; where the resulting text (`<a dog>`) might be interpretted as a tag.

With this commit, we monkey-patch turndown's escpaing method to escape **opening** angle brackets. (Monkey-patching `TurndownService.prototype.escape` seems like the quasi-endorsed way to do this. See https://github.com/mixmark-io/turndown#escaping-markdown-characters.)

Only escape opening angle brackets (not closing) because Showdown treats escaped closing brackets as literal `\>`.

#### How should this be manually tested?
Using `ocw-to-hugo`, migrate a course containing `&lt;`  in the HTML text and observe that on master they become `"<"` but on this branch they become `\<`.

I used Ancient Philosophy from 2004...
```
# private/courses.json
{
    "courses": [
        "24-200-ancient-philosophy-fall-2004"
    ]
}
# Then
node . -c private/courses.json --download -i private/in -o private/out
```
Then
```
private/out/24-200-ancient-philosophy-fall-2004/content/pages/assignments.md
```
contains some angle brackets. 
