### PR TITLE
convert rowspan attribute

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -76,7 +76,13 @@ turndownService.addRule("caption", {
 turndownService.addRule("th", {
   filter:      node => node.nodeName === "TH",
   replacement: (content, node, options) => {
-    return `{{< thopen >}}\n${content}\n{{< thclose >}}\n`
+    const colspan = node.getAttribute("colspan")
+      ? ` colspan="${node.getAttribute("colspan")}"`
+      : ""
+    const rowspan = node.getAttribute("rowspan")
+      ? ` rowspan="${node.getAttribute("rowspan")}"`
+      : ""
+    return `{{< thopen${colspan}${rowspan} >}}\n${content}\n{{< thclose >}}\n`
   }
 })
 
@@ -93,7 +99,10 @@ turndownService.addRule("td", {
     const colspan = node.getAttribute("colspan")
       ? ` colspan="${node.getAttribute("colspan")}"`
       : ""
-    return `{{< tdopen${colspan} >}}\n${content}\n{{< tdclose >}}\n`
+    const rowspan = node.getAttribute("rowspan")
+      ? ` rowspan="${node.getAttribute("rowspan")}"`
+      : ""
+    return `{{< tdopen${colspan}${rowspan} >}}\n${content}\n{{< tdclose >}}\n`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -13,6 +13,9 @@ describe("turndown", () => {
         <th scope="col">READINGS&nbsp;(3D&nbsp;ED.)</th>
         <th scope="col">READINGS&nbsp;(4TH&nbsp;ED.)</th>
       </tr>
+      <tr>
+        <th colspan="2" rowspan="4">full colspan double rowspan test</th>
+      </tr>
     </thead> <!-- END TABLE HEADER -->
     <tbody>
       <tr class="row">
@@ -32,6 +35,9 @@ describe("turndown", () => {
         <td>Test table section 2</td>
         <td><h1>TEST</h1></td>
         <td><h2>TEST 2</h2></td>
+      </tr>
+      <tr>
+        <td colspan="2" rowspan="4">full colspan double rowspan test</td>
       </tr>
       <tr class="alt-row">
         <td><p><em>italics wrapped in a paragraph</em></p></td>
@@ -55,6 +61,12 @@ READINGS (3D ED.)
 {{< thclose >}}
 {{< thopen >}}
 READINGS (4TH ED.)
+{{< thclose >}}
+
+{{< trclose >}}
+{{< tropen >}}
+{{< thopen colspan="2" rowspan="4" >}}
+full colspan double rowspan test
 {{< thclose >}}
 
 {{< trclose >}}
@@ -113,6 +125,12 @@ TEST 2
 ------
 
 
+{{< tdclose >}}
+
+{{< trclose >}}
+{{< tropen >}}
+{{< tdopen colspan="2" rowspan="4" >}}
+full colspan double rowspan test
 {{< tdclose >}}
 
 {{< trclose >}}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/442

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/429, we altered `ocw-to-hugo` to convert HTML tables to a structure using our table element shortcodes we created in `ocw-hugo-themes` rather than using the markdown table syntax.  In that PR, support was added for passing on the `colspan` attribute on `td` elements to the `tdopen` shortcode.  What was missing from that PR was code for also processing the `rowspan` attribute, as well as both `colspan` and `rowspan` on `th` elements.  This PR adds support for all of the above.

#### How should this be manually tested?
 - Read the readme if you've never run `ocw-to-hugo` before and make sure you are set up for S3 access
 - Put the following in `private/courses.json`:
```
{
  "courses": [
    "15-s21-nuts-and-bolts-of-business-plans-january-iap-2014"
  ]
}
```
 - Run `node . -i private/input -o private/output -c private/courses.json --download --rm`
 - Inspect the file at `private/output/15-s21-nuts-and-bolts-of-business-plans-january-iap-2014/content/pages/readings.md`
 - Make sure that the proper shortcodes contain the `rowspan` elements

![image](https://user-images.githubusercontent.com/12089658/152244557-c11cd24e-58c6-47e6-aa6c-8ecdb528c304.png)
