### PR TITLE
Remove the classroom section

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -353,7 +353,7 @@ turndownService.addRule("edu_breakdown", {
 })
 
 /**
- * Remove semester breakdown chart
+ * Remove Classroom section
  **/
 turndownService.addRule("remove_the_classroom", {
   filter: (node, options) => {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -353,6 +353,23 @@ turndownService.addRule("edu_breakdown", {
 })
 
 /**
+ * Remove semester breakdown chart
+ **/
+turndownService.addRule("remove_the_classroom", {
+  filter: (node, options) => {
+    if (node.nodeName !== "DIV") return false
+    const children = Array.from(node.childNodes)
+    return children.some(node => {
+      if (node.nodeName !== "A") return false
+      return node.getAttribute("name") === "classroom"
+    })
+  },
+  replacement: (content, node, options) => {
+    return ""
+  }
+})
+
+/**
  * Catch "approx" images and render as HTML instead
  */
 turndownService.addRule("approx_img", {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -360,8 +360,7 @@ turndownService.addRule("remove_the_classroom", {
     if (node.nodeName !== "DIV") return false
     const children = Array.from(node.childNodes)
     return children.some(node => {
-      if (node.nodeName !== "A") return false
-      return node.getAttribute("name") === "classroom"
+      return node.nodeName === "A" && node.getAttribute("name") === "classroom"
     })
   },
   replacement: (content, node, options) => {

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -348,6 +348,56 @@ _italics wrapped in a div_
     assert.equal(markdown, "")
   })
 
+  it("removes the classroom section", async () => {
+    const inputHTML = `
+    <div class="onethird alpha">
+        <h2 class="title">Curriculum Information</h2>
+        <div>Foo bar baz</div>
+    </div>
+    <div class="twothirds omega anythingSlider anythingSlider-default activeSlider">
+        <a name="classroom"></a>
+        <h2 class="title">The Classroom</h2>
+        <div>Lots of pictures of desks</div>
+    </div>
+    <div class="clear">&nbsp;</div>
+    <div class="onehalf alpha"><a name="assessment"></a>
+        <h2 class="title">Assessment</h2>
+        <a name="not-a-classroom">meow</a>
+        <p>The students' grades were based on the following activities:</p>
+    </div>
+    <div>
+        <h2>If classroom is a child</h2>
+        <div>
+            <a name="classroom"></a>
+        </div>
+        The section should live on.
+    </div>
+    `.trim()
+    const expectedMarkdown = `
+Curriculum Information
+----------------------
+
+Foo bar baz
+
+{{< anchor "assessment" >}}{{< /anchor >}}
+
+Assessment
+----------
+
+{{< anchor "not-a-classroom" >}}meow{{< /anchor >}}
+
+The students' grades were based on the following activities:
+
+If classroom is a child
+-----------------------
+
+The section should live on.
+    `.trim()
+
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, expectedMarkdown)
+  })
+
   it("should properly create youtube shortcodes from placeholder divs", async () => {
     const uid = "d1eb865e-ba7f-9989-0be1-348ba7cad5bd"
 


### PR DESCRIPTION
As far as I can tell, the classroom section:
1. is always a div with a direct child anchor with `<a name="classroom">`
2. is the only div satisfying (1)

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #431

#### What's this PR do?
Removes any `div` that has a direct child anchor tag whose `name` attribute is `name="classroom"`.

#### How should this be manually tested?
Migrate some courses on master vs this branch; search for "The Classroom" in the output files and observe that the section is present on master but missing in this branch.
