### PR TITLE
Turn sub, sup tags into shortcodes

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -646,6 +646,24 @@ turndownService.addRule("resource_shortcodes", {
   }
 })
 
+turndownService.addRule("subscript", {
+  filter: (node, options) => {
+    return node.nodeName === "SUB"
+  },
+  replacement: (content, node, options) => {
+    return `{{< sub ${JSON.stringify(content)} >}}`
+  }
+})
+
+turndownService.addRule("superscript", {
+  filter: (node, options) => {
+    return node.nodeName === "SUP"
+  },
+  replacement: (content, node, options) => {
+    return `{{< sup ${JSON.stringify(content)} >}}`
+  }
+})
+
 function html2markdown(text) {
   return turndownService.turndown(text)
 }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -651,7 +651,8 @@ turndownService.addRule("subscript", {
     return node.nodeName === "SUB"
   },
   replacement: (content, node, options) => {
-    return `{{< sub ${JSON.stringify(content)} >}}`
+    const quotesEscaped = JSON.stringify(content)
+    return `{{< sub ${quotesEscaped} >}}`
   }
 })
 
@@ -660,7 +661,8 @@ turndownService.addRule("superscript", {
     return node.nodeName === "SUP"
   },
   replacement: (content, node, options) => {
-    return `{{< sup ${JSON.stringify(content)} >}}`
+    const quotesEscaped = JSON.stringify(content)
+    return `{{< sup ${quotesEscaped} >}}`
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -578,7 +578,54 @@ The section should live on.
 2.  b \\\\\\<
 3.  \`x < y\` code is not escaped
 `.trim()
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, expectedMarkdown)
+  })
 
+  it("converts superscript tags to superscript shortcodes", async () => {
+    const inputHTML = `
+    <div>
+    <p>The 25<sup>th</sup> annual Jabberwocky<sup>&reg;</sup></p>
+    
+    Some more
+      <ol>
+        <li>nesting won't work well cats<sup>me<sup>ow</sup></sup> </li>
+        <li>quotes dog<sup><strong>"woof"</strong></sup> </li>
+      </ol>
+    </div>
+    `
+    const expectedMarkdown = `
+The 25{{< sup "th" >}} annual Jabberwocky{{< sup "®" >}}
+
+Some more
+
+1.  nesting won't work well cats{{< sup "me{{< sup \\"ow\\" >}}" >}}
+2.  quotes dog{{< sup "**\\"woof\\"**" >}}
+    `.trim()
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(markdown, expectedMarkdown)
+  })
+
+  it("converts subscript tags to superscript shortcodes", async () => {
+    const inputHTML = `
+    <div>
+    <p>The 25<sub>th</sub> annual Jabberwocky<sub>&reg;</sub></p>
+    
+    Some more
+      <ol>
+        <li>nesting won't work well cats<sub>me<sub>ow</sub></sub> </li>
+        <li>quotes dog<sub><strong>"woof"</strong></sub> </li>
+      </ol>
+    </div>
+    `
+    const expectedMarkdown = `
+The 25{{< sub "th" >}} annual Jabberwocky{{< sub "®" >}}
+
+Some more
+
+1.  nesting won't work well cats{{< sub "me{{< sub \\"ow\\" >}}" >}}
+2.  quotes dog{{< sub "**\\"woof\\"**" >}}
+    `.trim()
     const markdown = await html2markdown(inputHTML)
     assert.equal(markdown, expectedMarkdown)
   })

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -582,7 +582,7 @@ The section should live on.
     assert.equal(markdown, expectedMarkdown)
   })
 
-  it("converts superscript tags to superscript shortcodes", async () => {
+  it("converts sup tags to sup shortcodes", async () => {
     const inputHTML = `
     <div>
     <p>The 25<sup>th</sup> annual Jabberwocky<sup>&reg;</sup></p>
@@ -590,7 +590,8 @@ The section should live on.
     Some more
       <ol>
         <li>nesting won't work well cats<sup>me<sup>ow</sup></sup> </li>
-        <li>quotes dog<sup><strong>"woof"</strong></sup> </li>
+        <li>boldings <sup>normal text <strong>bold woof</strong> and <em>emph</em></sup> </li>
+        <li>and quotes although <sup>who puts "quotes" in</sup> superscripts though?</li>
       </ol>
     </div>
     `
@@ -600,13 +601,14 @@ The 25{{< sup "th" >}} annual Jabberwocky{{< sup "®" >}}
 Some more
 
 1.  nesting won't work well cats{{< sup "me{{< sup \\"ow\\" >}}" >}}
-2.  quotes dog{{< sup "**\\"woof\\"**" >}}
+2.  boldings {{< sup "normal text **bold woof** and _emph_" >}}
+3.  and quotes although {{< sup "who puts \\"quotes\\" in" >}} superscripts though?
     `.trim()
     const markdown = await html2markdown(inputHTML)
     assert.equal(markdown, expectedMarkdown)
   })
 
-  it("converts subscript tags to superscript shortcodes", async () => {
+  it("converts sub tags to sub shortcodes", async () => {
     const inputHTML = `
     <div>
     <p>The 25<sub>th</sub> annual Jabberwocky<sub>&reg;</sub></p>
@@ -614,7 +616,8 @@ Some more
     Some more
       <ol>
         <li>nesting won't work well cats<sub>me<sub>ow</sub></sub> </li>
-        <li>quotes dog<sub><strong>"woof"</strong></sub> </li>
+        <li>boldings <sub>normal text <strong>bold woof</strong> and <em>emph</em></sub> </li>
+        <li>and quotes although <sub>who puts "quotes" in</sub> subscripts though?</li>
       </ol>
     </div>
     `
@@ -624,7 +627,8 @@ The 25{{< sub "th" >}} annual Jabberwocky{{< sub "®" >}}
 Some more
 
 1.  nesting won't work well cats{{< sub "me{{< sub \\"ow\\" >}}" >}}
-2.  quotes dog{{< sub "**\\"woof\\"**" >}}
+2.  boldings {{< sub "normal text **bold woof** and _emph_" >}}
+3.  and quotes although {{< sub "who puts \\"quotes\\" in" >}} subscripts though?
     `.trim()
     const markdown = await html2markdown(inputHTML)
     assert.equal(markdown, expectedMarkdown)


### PR DESCRIPTION
Closes #450 

Related ocw-hugo-themes pr: https://github.com/mitodl/ocw-hugo-themes/pull/422

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #450 

#### What's this PR do?
Before, we were losing `<sup>` and `<sub>` tags. Now we turn them into `{{< sup "value" >}}` and `{{< sub "value" >}}` shortcodes. 

#### How should this be manually tested?
Migrate some courses on master vs this branch and diff the output however you like: manually search for some <sup>'s, or maybe
```
diff -bur private/out_master private/out_this_branch
```

#### Any background context you want to provide?
This definitely isn't perfect:

The current implementation will not handle rich text inside the sub/super script very well, e.g.
- nested sub/superscripts
- bold, italics etc inside sub/superscripts

But (a) at least we're not losing the tags now, and (b) the above scenarios seem not to occur within our 57 sample courses.
