### PR TITLE
Include thumbnails whose ids end in JPG_1

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -260,7 +260,8 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
   const thumbnailFile = media["embedded_media"].find(
     embeddedMedia =>
       embeddedMedia["type"] === "Thumbnail" &&
-      embeddedMedia["id"] === "Thumbnail-YouTube-JPG"
+      // Sometimes the id is 'Thumbnail-YouTube-JPG_1'
+      embeddedMedia["id"].startsWith("Thumbnail-YouTube-JPG")
   )
   const captionsFile = media["embedded_media"].find(
     embeddedMedia =>

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -269,6 +269,28 @@ describe("markdown generators", function() {
       })
     })
 
+    it("includes thumbnails in markdown frontmatter", () => {
+      const markdownData = markdownGenerators.generateMarkdownFromJson(
+        embeddedYoutubeVideoJsonData,
+        pathLookup
+      )
+
+      const names = [
+        "/resources/video-1-introduction-to-the-analytics-edge-0.md",
+        "/resources/welcome-to-unit-1-1.md"
+      ]
+
+      names.forEach(name => {
+        const file = markdownData.find(file => file.name === name)
+        const frontmatter = yaml.safeLoad(file.data.split("---\n")[1])
+
+        expect(frontmatter.resourcetype).to.equal("Video")
+        expect(frontmatter.video_files.video_thumbnail_file).to.match(
+          /https:\/\/img\.youtube\.com.*\.jpg/
+        )
+      })
+    })
+
     it("generates a resource page for an image", () => {
       const markdownData = markdownGenerators.generateMarkdownFromJson(
         embeddedYoutubeVideoJsonData,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #447 
Closes #447 

#### What's this PR do?
Makes thumbnail detection in `generateResourceMarkdownForVideo` a little more tolerant. Some thumbnails have ids like "Thumbnail-YouTube-JPG_1" in the parsed json... the `_1` was causing them to be missed.

#### How should this be manually tested?
Migrate some courses on master vs this branch and diff the output however you like, e.g.,

```
git checkout master
# run the script... replace with your in/out
node . -c private/courses.json -i private/in -o private/out --download
mv private/out private/out_master
mkdir private/out
node . -c private/courses.json -i private/in -o private/out --download
colordiff -br private/out_master private/out

#### Any background context you want to provide?
This could be addressed (in addition or instead) in ocw-data-parser. It seems like the plone exports generally use `-JPG` but sometimes use `-JPG_1`. See for example: https://github.com/mitodl/ocw-data-parser/blob/df06f0cca9f58b541c077ab910c1abed44c92eab/ocw_data_parser/test_json/course_dir/course-1/jsons/105.json#L82)