### PR TITLE
fix: turndown rules added for code snippets

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -698,6 +698,8 @@ const escapeDoubleQuotes = text => text.replace(/"/g, "&quot;")
 
 const unescapeBackticks = text => text.replace(/\\`/g, "&grave;")
 
+const removeLeadingBackslash = text => text.replace(/^\\/, "")
+
 const isCoursePublished = courseData => {
   const lastPublishedToProduction = moment(
     courseData["last_published_to_production"],
@@ -886,6 +888,7 @@ module.exports = {
   stripS3,
   escapeDoubleQuotes,
   unescapeBackticks,
+  removeLeadingBackslash,
   isCoursePublished,
   getOtherVersions,
   getArchivedVersions,

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -136,7 +136,7 @@ turndownService.addRule("codeblockfix", {
       }
       return content
     }
-    return `\`\`\`${content}\`\`\`\n`
+    return `\n\n\`\`\`${content}\n\`\`\`\n\n`
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -170,6 +170,29 @@ turndownService.addRule("inlinecodeblockfix", {
 })
 
 /**
+ * turn <pre> elements into code blocks
+ */
+turndownService.addRule("code_block", {
+  filter:      node => node.nodeName === "PRE",
+  replacement: (content, node, options) => {
+    return `\`\`\`${content}\`\`\`\n`
+  }
+})
+
+/**
+ * In legacy course, 1 liner code snippets are <span> elements having a particular inline style
+ * For details, see https://github.com/mitodl/ocw-to-hugo/issues/464
+ */
+turndownService.addRule("one_liner_code", {
+  filter: node =>
+    node.nodeName === "SPAN" &&
+    node.getAttribute("style") === "font-family: Courier New,Courier;",
+  replacement: (content, node, options) => {
+    return `\`${content}\`\n`
+  }
+})
+
+/**
  * Build anchor link shortcodes
  **/
 turndownService.addRule("anchorshortcode", {

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -136,7 +136,12 @@ turndownService.addRule("codeblockfix", {
       }
       return content
     }
-    return `\n\n\`\`\`${content}\n\`\`\`\n\n`
+    // if string starts with a 'tab' then it is converted into a code block while MD to HTML 
+    // so no need to make it a code block here
+    if (content.startsWith("\t") || content.startsWith("    ")) {
+      return content
+    }
+    return `\n\n\`\`\`\n${helpers.removeLeadingBackslash(content)}\n\`\`\`\n\n`
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -136,7 +136,7 @@ turndownService.addRule("codeblockfix", {
       }
       return content
     }
-    // if string starts with a 'tab' then it is converted into a code block while MD to HTML 
+    // if string starts with a 'tab' then it is converted into a code block while MD to HTML
     // so no need to make it a code block here
     if (content.startsWith("\t") || content.startsWith("    ")) {
       return content

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -124,18 +124,19 @@ turndownService.addRule("tfoot", {
  * fix some strangely formatted code blocks in OCW
  * see https://github.com/mitodl/hugo-course-publisher/issues/154
  * for discussion
+ * also turns <pre> elements into code blocks
  */
+
 turndownService.addRule("codeblockfix", {
-  filter: node =>
-    node.nodeName === "PRE" &&
-    node.firstChild &&
-    node.firstChild.nodeName === "SPAN",
+  filter:      node => node.nodeName === "PRE",
   replacement: (content, node, options) => {
-    if (content.match(/\r?\n/)) {
-      return `\n\n\`\`\`\n${content.replace(/`/g, "")}\n\`\`\`\n\n`
-    } else {
+    if (node.firstChild && node.firstChild.nodeName === "SPAN") {
+      if(content.match(/\r?\n/)){
+        return `\n\n\`\`\`\n${content.replace(/`/g, "")}\n\`\`\`\n\n`
+      }
       return content
     }
+    return `\`\`\`${content}\`\`\`\n`
   }
 })
 
@@ -170,20 +171,10 @@ turndownService.addRule("inlinecodeblockfix", {
 })
 
 /**
- * turn <pre> elements into code blocks
- */
-turndownService.addRule("code_block", {
-  filter:      node => node.nodeName === "PRE",
-  replacement: (content, node, options) => {
-    return `\`\`\`${content}\`\`\`\n`
-  }
-})
-
-/**
  * In legacy course, 1 liner code snippets are <span> elements having a particular inline style
  * For details, see https://github.com/mitodl/ocw-to-hugo/issues/464
  */
-turndownService.addRule("one_liner_code", {
+ turndownService.addRule("one_line_code", {
   filter: node =>
     node.nodeName === "SPAN" &&
     node.getAttribute("style") === "font-family: Courier New,Courier;",

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -131,7 +131,7 @@ turndownService.addRule("codeblockfix", {
   filter:      node => node.nodeName === "PRE",
   replacement: (content, node, options) => {
     if (node.firstChild && node.firstChild.nodeName === "SPAN") {
-      if(content.match(/\r?\n/)){
+      if (content.match(/\r?\n/)) {
         return `\n\n\`\`\`\n${content.replace(/`/g, "")}\n\`\`\`\n\n`
       }
       return content
@@ -174,7 +174,7 @@ turndownService.addRule("inlinecodeblockfix", {
  * In legacy course, 1 liner code snippets are <span> elements having a particular inline style
  * For details, see https://github.com/mitodl/ocw-to-hugo/issues/464
  */
- turndownService.addRule("one_line_code", {
+turndownService.addRule("one_line_code", {
   filter: node =>
     node.nodeName === "SPAN" &&
     node.getAttribute("style") === "font-family: Courier New,Courier;",

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -180,11 +180,29 @@ _italics wrapped in a div_
     })
   })
 
+  it("should properly convert 1 liner code snippet into its correct markdown", async () => {
+    const inputHTML = `<span style="font-family: Courier New,Courier;">sudo apt-get install -y python2.7 python-profiler</span>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(
+      markdown,
+      "`sudo apt-get install -y python2.7 python-profiler`"
+    )
+  })
+
+  it("should properly convert code block into its correct markdown", async () => {
+    const inputHTML = `<pre>import time<br>print('I am going to sleep :)')<br>time.sleep(1000)</pre>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(
+      markdown,
+      "```import time  \nprint('I am going to sleep :)')  \ntime.sleep(1000)```"
+    )
+  })
+
   it("should not get tripped up on problematic code blocks", async () => {
     const problematicHTML =
       "<pre><span><code>stuff\nin\nthe\nblock</span></pre>"
     const markdown = await html2markdown(problematicHTML)
-    assert.equal(markdown, "```\nstuff\nin\nthe\nblock\n```")
+    assert.equal(markdown, "````stuff\nin\nthe\nblock````")
   })
 
   it("should properly escape square brackets inside link text", async () => {

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -194,7 +194,7 @@ _italics wrapped in a div_
     const markdown = await html2markdown(inputHTML)
     assert.equal(
       markdown,
-      "```import time  \nprint(\'I am going to sleep :)\')  \ntime.sleep(1000)\n```"
+      "```import time  \nprint('I am going to sleep :)')  \ntime.sleep(1000)\n```"
     )
   })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -194,7 +194,16 @@ _italics wrapped in a div_
     const markdown = await html2markdown(inputHTML)
     assert.equal(
       markdown,
-      "```import time  \nprint('I am going to sleep :)')  \ntime.sleep(1000)\n```"
+      "```\nimport time  \nprint('I am going to sleep :)')  \ntime.sleep(1000)\n```"
+    )
+  })
+
+  it("code that starts with tab should not be converted into code block", async () => {
+    const inputHTML = `<pre>    L = L1 + L2</pre>`
+    const markdown = await html2markdown(inputHTML)
+    assert.equal(
+      markdown,
+      "    L = L1 + L2"
     )
   })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -202,7 +202,7 @@ _italics wrapped in a div_
     const problematicHTML =
       "<pre><span><code>stuff\nin\nthe\nblock</span></pre>"
     const markdown = await html2markdown(problematicHTML)
-    assert.equal(markdown, "````stuff\nin\nthe\nblock````")
+    assert.equal(markdown, "```\nstuff\nin\nthe\nblock\n```")
   })
 
   it("should properly escape square brackets inside link text", async () => {

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -194,7 +194,7 @@ _italics wrapped in a div_
     const markdown = await html2markdown(inputHTML)
     assert.equal(
       markdown,
-      "```import time  \nprint('I am going to sleep :)')  \ntime.sleep(1000)```"
+      "```import time  \nprint(\'I am going to sleep :)\')  \ntime.sleep(1000)\n```"
     )
   })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -201,10 +201,7 @@ _italics wrapped in a div_
   it("code that starts with tab should not be converted into code block", async () => {
     const inputHTML = `<pre>    L = L1 + L2</pre>`
     const markdown = await html2markdown(inputHTML)
-    assert.equal(
-      markdown,
-      "    L = L1 + L2"
-    )
+    assert.equal(markdown, "    L = L1 + L2")
   })
 
   it("should not get tripped up on problematic code blocks", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
- Closes https://github.com/mitodl/ocw-to-hugo/issues/464

#### What's this PR do?
- Adds `turndown rule` for code blocks that are wrapped in `<pre>` element.
- Adds `turndown rule` for 1 liner code snippet. 

#### How should this be manually tested?
- Setup `ocw-to-hugo` locally. 
    - Detailed explanation is in the [documentation](https://github.com/mitodl/ocw-to-hugo) but here are few points. 
    - I created a `course.json` file in `private/input` directory so it is ignored by git.
    - Place any course which has code snippets/code blocks in an array named `courses` in `course.json`. (Course example: [6-006-introduction-to-algorithms-fall-2011](https://ocwnext.odl.mit.edu/courses/6-006-introduction-to-algorithms-fall-2011/pages/syllabus/software/#ide))
- Run the command `node . -i private/input -o *output directory*  -c private/input/courses.json`
- Build and run this course in `ocw-hugo-themes`
- Verify that all the code snippets are properly wrapped in their respective elements. i.e: `<pre>`, `<code>`
- Verify that there is no side-effect on any other content.

#### Screenshots (if appropriate)
- Note: Styling of `code blocks` might need to be changed in `ocw-hugo-themes`

![image](https://user-images.githubusercontent.com/93309234/155144009-9f30ed85-b6e7-45ee-9ea9-437499df63cb.png)

![image](https://user-images.githubusercontent.com/93309234/155144048-cdd71346-a1d4-41bb-91ee-db7c9a509fbc.png)

![image](https://user-images.githubusercontent.com/93309234/155144125-4ba66b41-352a-4739-9c37-2d634c958e7f.png)

