### PR TITLE
Fix missing videos / thumbnails

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -47,6 +47,7 @@ module.exports = {
   // video embedded media id's
   VIDEO_EMBEDDED_MEDIA_IDS: new Set([
     "Video-YouTube-Stream",
+    "Video-YouTube-MP4",
     "3Play-3PlayYouTubeid-Stream"
   ])
 }

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -311,7 +311,9 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
 
   const videoThumbnailLocation = thumbnailFile
     ? thumbnailFile.media_location
-    : null
+    : youtubeId
+      ? `https://img.youtube.com/vi/${youtubeId}/default.jpg`
+      : null
   const captionsFileLocation = captionsFile
     ? helpers.stripS3(pathLookup.byUid[captionsFile.uid].fileLocation)
     : null

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -279,6 +279,7 @@ describe("markdown generators", function() {
 
       const names = [
         "/resources/video-1-introduction-to-the-analytics-edge-0.md",
+        "/resources/video-8-predictive-coding-today-0.md",
         "/resources/welcome-to-unit-1-1.md"
       ]
 

--- a/test_data/courses/ec-711-d-lab-energy-spring-2011/ec-711-d-lab-energy-spring-2011_parsed.json
+++ b/test_data/courses/ec-711-d-lab-energy-spring-2011/ec-711-d-lab-energy-spring-2011_parsed.json
@@ -84,10 +84,10 @@
             "about_this_resource_text": "<p><strong>Description:</strong> In the developing world, widely used cooking technologies (especially biomass) pose mounting health risks, high expense, and enviromental damage. This lecture considers alternative fuels and stove designs, with a focus on the D-Lab charcoal project.</p> <p><strong>Speaker:</strong> Amy Banzaert</p>",
             "embedded_media": [
                 {
-                    "id": "Video-YouTube-Stream",
+                    "id": "Video-YouTube-MP4",
                     "media_location": "zzePDMT2-oc",
                     "parent_uid": "12b632ef12caaccb8031afd33f06de48",
-                    "title": "Video-YouTube-Stream",
+                    "title": "Video-YouTube-MP4",
                     "type": "Video",
                     "uid": "ce0714955557c70b5e12354783fbcf1c"
                 },


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fix for #459 , #478

#### What's this PR do?
- Adds "Video-YouTube-MP4" to the VIDEO_EMBEDDED_MEDIA_IDS list.
- Populates missing video thumbnail locations for Youtube videos

#### How should this be manually tested?
- Create a `courses.json` file containing the courses listed in the issue:
```{
    "courses": [
      "res-tll-004-stem-concept-videos-fall-2013",
      "res-18-005-highlights-of-calculus-spring-2010",
      "16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006",
      "2-627-fundamentals-of-photovoltaics-fall-2013",
      "7-01sc-fundamentals-of-biology-fall-2011",
      "6-00-introduction-to-computer-science-and-programming-fall-2008"
    ]
}
```
- Run `node . -i input -o output -c courses.json --download`
- Git clone `ocw-hugo-themes` and set .env values, including:
```
COURSE_CONTENT_PATH=/path/to/ocw-to-hugo/output
OCW_TEST_COURSE=<one-of-the-courses-above>
```
- Run `npm run start:course`
- Check that the missing video for the course is no longer missing.
- For the last course `6-00-introduction-to-computer-science-and-programming-fall-2008`, make sure there is a thumbnail for the 1st video on the video gallery page.


After `ocw-to-hugo` is run again with these changes, they will need to be migrated to ocw-studio somehow without running the `import-ocw-course-sites` command.  The fix for #459 will add a new markdown file for each previously missing video, these need to be added to studio and github.  The fix for #478 changes markdown for existing video markdown files.
