### PR TITLE
include parent_uid on resources

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -243,6 +243,7 @@ const generateResourceMarkdownForFile = (file, courseData, pathLookup) => {
   if (parents.length > 0) {
     frontMatter["parent_type"] = parents[0]["type"]
     frontMatter["parent_title"] = parents[0]["title"]
+    frontMatter["parent_uid"] = helpers.addDashesToUid(parents[0]["uid"])
   }
 
   if (frontMatter.resourcetype === RESOURCE_TYPE_IMAGE) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -320,6 +320,7 @@ describe("markdown generators", function() {
         parent_title:
           "7.2 Visualizing the World: An Introduction to Visualization",
         parent_type: "CourseSection",
+        parent_uid:  "bcd276c5-4387-e04d-4149-dfe97b763b3f",
         ocw_type:    "OCWImage"
       })
     })
@@ -465,6 +466,7 @@ describe("markdown generators", function() {
           "https://open-learning-course-data-production.s3.amazonaws.com/8-02-physics-ii-electricity-and-magnetism-spring-2007/a1bfc34ccf08ddf8474627b9a13d6ca8_summary_w12d2.pdf",
         parent_title: "Readings",
         parent_type:  "CourseSection",
+        parent_uid:   "0daf4987-1459-8983-aa85-5689f242c83b",
         ocw_type:     "OCWFile"
       })
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #320 

#### What's this PR do?
Includes `parent_uid` in resource frontmatter. Previously we were including the parent_type and parent_title, but not the uid.

#### How should this be manually tested?

1. Run `ocw-to-hugo` with `mas-962-special-topics-new-textiles-spring-2010` in `courses.json`
2. Open `privoate/out/content/resources/process.md`
3. Verify that `parent_uid` is included along with `parent_title` and `parent_type`

#### Any background context you want to provide?
This info will be helpful in fixing root-relative URLs when there are duplicate filenames. See #320 for an example.
