### PR TITLE
fix HTML embedded in quizzes

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -21,7 +21,7 @@ class TurndownService extends OriginalTurndownService {
    * https://github.com/mixmark-io/turndown#escaping-markdown-characters
    *
    * That's good. But it does NOT (usually) escape angle brackets in the output,
-   * e.g. "&lta dog&gt"" turns into "<a dog>", which can be erroneously
+   * e.g. "&lt;a dog&gt;"" turns into "<a dog>", which can be erroneously
    * interpretted as an anchor tag. [Aside: Turndown does escape angle brackets
    * at the beginning of a line, since those are markdown block quotes.]
    *
@@ -182,7 +182,7 @@ turndownService.addRule("inlinecodeblockfix", {
 turndownService.addRule("one_line_code", {
   filter: node =>
     node.nodeName === "SPAN" &&
-    node.getAttribute("style") === "font-family: Courier New,Courier",
+    node.getAttribute("style") === "font-family: Courier New,Courier;",
   replacement: (content, node, options) => {
     return `\`${content}\`\n`
   }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -575,7 +575,6 @@ turndownService.addRule("multiple_choice_questions_widget", {
         dataSubstring = dataSubstring.replace(
           RegExp(`${key}:`, "g"),
           `"${key}":`
-          
         )
 
         // some values are surrounded by single quotes, which isn't valid JSON

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -21,7 +21,7 @@ class TurndownService extends OriginalTurndownService {
    * https://github.com/mixmark-io/turndown#escaping-markdown-characters
    *
    * That's good. But it does NOT (usually) escape angle brackets in the output,
-   * e.g. "&lt;a dog&gt;"" turns into "<a dog>", which can be erroneously
+   * e.g. "&lta dog&gt"" turns into "<a dog>", which can be erroneously
    * interpretted as an anchor tag. [Aside: Turndown does escape angle brackets
    * at the beginning of a line, since those are markdown block quotes.]
    *
@@ -182,7 +182,7 @@ turndownService.addRule("inlinecodeblockfix", {
 turndownService.addRule("one_line_code", {
   filter: node =>
     node.nodeName === "SPAN" &&
-    node.getAttribute("style") === "font-family: Courier New,Courier;",
+    node.getAttribute("style") === "font-family: Courier New,Courier",
   replacement: (content, node, options) => {
     return `\`${content}\`\n`
   }
@@ -544,76 +544,138 @@ turndownService.addRule("multiple_choice_questions_widget", {
     return false
   },
   replacement: (content, node, options) => {
-    const jsParser = require("acorn")
-    const walk = require("acorn-walk")
-    const nodeText = node.textContent.replace(
-      "// There was an extra comma at the end of multiList array.",
-      ""
-    )
-
-    const quizData = jsParser.parse(nodeText, { ecmaVersion: 11 })
-
-    const dataNode = walk.findNodeAt(quizData, null, null, function(
-      type,
-      node
-    ) {
-      return (
-        type === "VariableDeclarator" && node.id && node.id.name === "quizMulti"
+    try {
+      const jsParser = require("acorn")
+      const walk = require("acorn-walk")
+      const nodeText = node.textContent.replace(
+        "// There was an extra comma at the end of multiList array.",
+        ""
       )
-    })
 
-    let dataSubstring = String(
-      nodeText.substring(dataNode.node.init.start, dataNode.node.init.end)
-    )
+      const quizData = jsParser.parse(nodeText, { ecmaVersion: 11 })
 
-    for (const key of ["multiList", "ques", "ans", "ansSel", "ansInfo"]) {
-      dataSubstring = dataSubstring.replace(RegExp(`${key}:`, "g"), `"${key}":`)
+      const dataNode = walk.findNodeAt(quizData, null, null, function(
+        type,
+        node
+      ) {
+        return (
+          type === "VariableDeclarator" &&
+          node.id &&
+          node.id.name === "quizMulti"
+        )
+      })
+
+      let dataSubstring = String(
+        nodeText.substring(dataNode.node.init.start, dataNode.node.init.end)
+      )
+
+      // this block of code attempts to sanitize the quiz JSON data
+      for (const key of ["multiList", "ques", "ans", "ansSel", "ansInfo"]) {
+        // the keys aren't in double quotes, which isn't valid JSON
+        dataSubstring = dataSubstring.replace(
+          RegExp(`${key}:`, "g"),
+          `"${key}":`
+          
+        )
+
+        // some values are surrounded by single quotes, which isn't valid JSON
+        // this is usually HTML, so pass it through turndown
+        const singleQuoteValueRegex = new RegExp(`"${key}": ('[^']*?')`, "g")
+        let valueHtmlMatch
+        while (
+          (valueHtmlMatch = singleQuoteValueRegex.exec(dataSubstring)) !== null
+        ) {
+          const originalMatch = valueHtmlMatch[1]
+          const htmlRegex = new RegExp("'([^']*?)'")
+          const valueHtml = valueHtmlMatch[1].match(htmlRegex)[1]
+          const valueMarkdown = turndownService.turndown(valueHtml)
+          dataSubstring = dataSubstring.replace(
+            `"${key}": ${originalMatch}`,
+            `"${key}": ${JSON.stringify(valueMarkdown)}`
+          )
+        }
+        // some values are arrays that contain all the same problems
+        if (key !== "multiList") {
+          const htmlArrayRegex = new RegExp(
+            `"${key}": (\\[['|"].*?['|"]\\])`,
+            "g"
+          )
+          let htmlArrayMatch
+          while (
+            (htmlArrayMatch = htmlArrayRegex.exec(dataSubstring)) !== null
+          ) {
+            let arrayMatch = htmlArrayMatch[1]
+            const singleQuoteItemRegex = new RegExp("('.*?')", "g")
+            let singleQuoteItemMatch
+            while (
+              (singleQuoteItemMatch = singleQuoteItemRegex.exec(arrayMatch)) !==
+              null
+            ) {
+              arrayMatch = arrayMatch.replace(
+                singleQuoteItemMatch[1],
+                singleQuoteItemMatch[1].replace(/"/g, '\\"').replace(/'/g, '"')
+              )
+            }
+            let quizArray = JSON.parse(arrayMatch)
+            quizArray = quizArray.map(quizArrayItem => {
+              return turndownService.turndown(quizArrayItem)
+            })
+            dataSubstring = dataSubstring.replace(
+              htmlArrayMatch[1],
+              JSON.stringify(quizArray)
+            )
+          }
+        }
+      }
+
+      const data = JSON.parse(dataSubstring)
+      let markdown = ""
+      data["multiList"].forEach((question, index) => {
+        markdown = markdown.concat(
+          "\n",
+          turndownService.turndown(`<h4>Question ${index + 1}</h4>`),
+          "\n"
+        )
+        markdown = markdown.concat(
+          " ",
+          `{{< quiz_multiple_choice questionId="MCQ${index + 1}" >}}`
+        )
+
+        markdown = markdown.concat(" ", question["ques"])
+
+        markdown = markdown.concat(" ", `{{< quiz_choices >}}`)
+
+        const options = question["ansSel"]
+        options.push(question["ans"])
+        options.sort()
+
+        for (const option of options) {
+          markdown = markdown.concat(
+            " ",
+            `{{< quiz_choice isCorrect="${option ===
+              question["ans"]}" >}}${option}{{< /quiz_choice >}}`
+          )
+        }
+
+        markdown = markdown.concat(" ", `{{< /quiz_choices >}}`)
+
+        if (question["ansInfo"]) {
+          markdown = markdown.concat(
+            " ",
+            `{{< quiz_solution >}}${question["ansInfo"]}{{< /quiz_solution >}}`
+          )
+        } else {
+          markdown = markdown.concat(" ", "{{< quiz_solution / >}}")
+        }
+
+        markdown = markdown.concat(" ", `{{< /quiz_multiple_choice >}}`)
+      })
+
+      return markdown
+    } catch (err) {
+      loggers.fileLogger.info(`error parsing multiple choice quiz json: ${err}`)
     }
-
-    const data = JSON.parse(dataSubstring)
-    let markdown = ""
-    data["multiList"].forEach((question, index) => {
-      markdown = markdown.concat(
-        "\n",
-        turndownService.turndown(`<h4>Question ${index + 1}</h4>`),
-        "\n"
-      )
-      markdown = markdown.concat(
-        " ",
-        `{{< quiz_multiple_choice questionId="MCQ${index + 1}" >}}`
-      )
-
-      markdown = markdown.concat(" ", question["ques"])
-
-      markdown = markdown.concat(" ", `{{< quiz_choices >}}`)
-
-      const options = question["ansSel"]
-      options.push(question["ans"])
-      options.sort()
-
-      for (const option of options) {
-        markdown = markdown.concat(
-          " ",
-          `{{< quiz_choice isCorrect="${option ===
-            question["ans"]}" >}}${option}{{< /quiz_choice >}}`
-        )
-      }
-
-      markdown = markdown.concat(" ", `{{< /quiz_choices >}}`)
-
-      if (question["ansInfo"]) {
-        markdown = markdown.concat(
-          " ",
-          `{{< quiz_solution >}}${question["ansInfo"]}{{< /quiz_solution >}}`
-        )
-      } else {
-        markdown = markdown.concat(" ", "{{< quiz_solution / >}}")
-      }
-
-      markdown = markdown.concat(" ", `{{< /quiz_multiple_choice >}}`)
-    })
-
-    return markdown
+    return content
   }
 })
 

--- a/src/turndown_test.js
+++ b/src/turndown_test.js
@@ -518,8 +518,8 @@ The section should live on.
             multiList: [
               {
                 ques: "If you compare the elasticity of short-run supply in the markets for two different goods and one market has more firms than the other, which will have a more elastic supply curve?",
-                ans: "The market with more firms.",
-                ansSel: ["The market with fewer firms.", "There is no difference.", "It depends on the specific production function."],
+                ans: '<span class="test">The market with more firms.</span>',
+                ansSel: ["The market with fewer firms.", "There is no difference.", "It depends on the specific production function.", '<span>whoops this one is HTML</span>'],
                 ansInfo: "The supply curve becomes flatter (more elastic) with more firms in the market, because a given increase in price calls forth more production when there are many firms rather than one."
               },
               {
@@ -556,6 +556,7 @@ The section should live on.
         `{{< quiz_choice isCorrect="false" >}}The market with fewer firms.{{< /quiz_choice >}} ` +
         `{{< quiz_choice isCorrect="true" >}}The market with more firms.{{< /quiz_choice >}} ` +
         `{{< quiz_choice isCorrect="false" >}}There is no difference.{{< /quiz_choice >}} ` +
+        `{{< quiz_choice isCorrect="false" >}}whoops this one is HTML{{< /quiz_choice >}} ` +
         `{{< /quiz_choices >}} ` +
         `{{< quiz_solution >}}The supply curve becomes flatter (more elastic) with more firms` +
         ` in the market, because a given increase in price calls forth more production when` +


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/473

#### What's this PR do?
This PR introduces some extra code to the `multiple_choice_questions_widget` turndown rule that adds support for parsing arbitrary HTML inserted into the question and answer data.  Previously, if there was HTML in the quiz data with double quotes in it, it would cause the turndown rule to throw a hard error because a call to `JSON.parse` would fail.  This happened because the data was not valid JSON.  This PR corrects that by finding the HTML, transforming it to markdown and correcting any places where single quotes are used to encapsulate the HTML.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and make sure you are set up to download courses from S3
 - Place the following in `private/courses.json`:
```
{
  "courses": [
      "7-01sc-fundamentals-of-biology-fall-2011"
  ]
}
```
 - Run `node . -i private/input -o private/test --rm --courses private/courses.json --download`
 - Inspect the output and / or spin up the course using `ocw-hugo-themes` (follow directions in the readme if you've never used it before) and ensure that the pages with quizzes on them render properly

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/157153342-cf6b6298-08ef-4610-9e8b-93991993c434.png)
