### PR TITLE
feat: start and end time added in frontmatter in video markdown

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -342,7 +342,9 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
     optional_text:          optionalText,
     related_resources_text: relatedResourcesText,
     optional_tab_title:     media["optional_tab_title"] || "",
-    resource_index_text:    media["resource_index_text"] || ""
+    resource_index_text:    media["resource_index_text"] || "",
+    start_time:             media["start_time"] || "",
+    end_time:               media["end_time"] || ""
   }
 
   const parents = courseData["course_pages"].filter(

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -378,6 +378,8 @@ describe("markdown generators", function() {
         resource_index_text:    "",
         uid:                    "5b89e3d0-ea34-5f02-540b-ac14b4acac9b",
         resourcetype:           "Video",
+        start_time:             "",
+        end_time:               "",
         video_metadata:         { youtube_id: "5ucfHd8FWKw" },
         video_files:            {
           archive_url:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/492

#### What's this PR do?
- Adds start and end time in the front-matter of video resource markdown

#### How should this be manually tested?
- Checkout to the branch of this [PR](https://github.com/mitodl/ocw-data-parser/pull/182) 
- Run a course, which has video resource with start and end time.
- Run the parsed json in ocw-to-hugo
- Verify that video resource markdown front-matter has start and end time

