### PR TITLE
fix overzealous turndown filter on quiz rule

### DIFF
--- a/src/turndown.js
+++ b/src/turndown.js
@@ -488,7 +488,7 @@ turndownService.addRule("multiple_choice_question", {
     if (node.nodeName === "DIV" && node.getAttribute("class")) {
       if (
         node.getAttribute("class") === "problem_question" &&
-        node.getElementsByClassName("problem_radio_input")
+        node.getElementsByClassName("problem_radio_input").length > 0
       ) {
         return true
       }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -504,7 +504,7 @@ turndownService.addRule("multiple_choice_question", {
         if (
           child.nodeName === "DIV" &&
           child.getAttribute("class").includes("choice") &&
-          child.getElementsByClassName("problem_radio_input") > 0
+          child.getElementsByClassName("problem_radio_input").length > 0
         ) {
           return true
         }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -750,8 +750,7 @@ function html2markdown(text) {
   let markdown = ""
   try {
     markdown = turndownService.turndown(text)
-  }
-  catch (err) {
+  } catch (err) {
     loggers.fileLogger.error(`Error converting html to markdown: ${err}`)
   }
   return markdown

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -504,7 +504,7 @@ turndownService.addRule("multiple_choice_question", {
         if (
           child.nodeName === "DIV" &&
           child.getAttribute("class").includes("choice") &&
-          child.getElementsByClassName("problem_radio_input")
+          child.getElementsByClassName("problem_radio_input") > 0
         ) {
           return true
         }

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -747,7 +747,14 @@ turndownService.addRule("superscript", {
 })
 
 function html2markdown(text) {
-  return turndownService.turndown(text)
+  let markdown = ""
+  try {
+    markdown = turndownService.turndown(text)
+  }
+  catch (err) {
+    loggers.fileLogger.error(`Error converting html to markdown: ${err}`)
+  }
+  return markdown
 }
 
 function hasParentNodeRecursive(node, parentNodeName) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/493

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/418 we added support for parsing multiple choice type quizzes embedded in legacy OCW courses.  One of the turndown rules that does this, `multiple_choice_question`, was filtering on:

```
        node.getAttribute("class") === "problem_question" &&
        node.getElementsByClassName("problem_radio_input")
```

The issue with this is that even if `getElementsByClassName` doesn't find anything, it still returns an object.  This means that HTML that shouldn't have been matching that rule was being matched and processed as if it were an multiple choice question.  I corrected this by changing it to:

```
        node.getAttribute("class") === "problem_question" &&
        node.getElementsByClassName("problem_radio_input").length > 0
```

A try / catch statement with Winston file logging was also added to the `html2markdown` function so any errors converting html to markdown are logged.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and make sure you're set up to download courses from S3
 - Place the following in `private/courses.json`:
```
{
    "courses": [
        "6-042j-mathematics-for-computer-science-spring-2015",
        "16-90-computational-methods-in-aerospace-engineering-spring-2014",
        "15-071-the-analytics-edge-spring-2017",
        "14-01sc-principles-of-microeconomics-fall-2011"
    ]
}
```
 - Run `node . -i private/input -o private/output -c private/courses.json --download --rm`
 - Inspect the following pages and make sure there is no raw HTML:
```
 - 6-042j-mathematics-for-computer-science-spring-2015/content/pages/proofs/tp2-2/vertical-a28e46f96fa1.md
 - 6-042j-mathematics-for-computer-science-spring-2015/content/pages/proofs/tp4-3/set-theory-axioms-optional-0.md
 - 16-90-computational-methods-in-aerospace-engineering-spring-2014/content/pages/numerical-integration-of-ordinary-differential-equations/discretizing-odes/_index.md
 - 15-071-the-analytics-edge-spring-2017/content/pages/logistic-regression/modeling-the-expert-an-introduction-to-logistic-regression/quick-question-152.md
 - 14-01sc-principles-of-microeconomics-fall-2011/content/pages/unit-6-topics-in-intermediate-microeconomics/international-trade.md
```
