### PR TITLE
Fix error caused by missing archive video media_url

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -323,7 +323,10 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
     ? helpers.stripS3(pathLookup.byUid[transcriptFile.uid].fileLocation)
     : null
 
-  const archiveUrl = archiveRecord ? archiveRecord.media_location : null
+  const archiveUrl =
+    archiveRecord && archiveRecord.media_location
+      ? archiveRecord.media_location
+      : null
 
   const frontMatter = {
     title:          helpers.replaceIrregularWhitespace(media["title"]),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Should fix the missing video resource for res.3-003 described in https://github.com/mitodl/ocw-to-hugo/issues/495

#### What's this PR do?
Prevents a yaml error from being thrown if an Internet Archive video doesn't have a media_location attribute.

#### How should this be manually tested?
Put this in a course.json file:
```json
{
    "courses": [
      "res-3-003-learn-to-build-your-own-videogame-with-the-unity-game-engine-and-microsoft-kinect-january-iap-2017"
    ]
}
```
Run `node . -i input -o output -c course.json --download`
Check that there is a `content/resources/long-project-1-cats-cradle.md` file in the course's output folder.


The only other course that should be affected by this bug is `esd-290-special-topics-in-supply-chain-management-spring-2005`