### PR TITLE
prepend video resource markdown body with `text`

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -359,11 +359,15 @@ const generateResourceMarkdownForVideo = (media, courseData, pathLookup) => {
     frontMatter["parent_title"] = parents[0]["title"]
   }
 
-  const body = formatHTMLMarkDown(
+  const body = `${formatHTMLMarkDown(
+    media["text"],
+    courseData,
+    pathLookup
+  )}\n\n${formatHTMLMarkDown(
     media["about_this_resource_text"],
     courseData,
     pathLookup
-  )
+  )}`
 
   return `---\n${yaml.safeDump(frontMatter)}---\n${body}`
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/504

#### What's this PR do?
This PR prepends `text` before `about_this_resource_text` on video resources, because a number of courses were found to have their description set there as HTML.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and make sure you are set up to download courses from S3
 - Place the following in `private/courses.json`:
```
{
  "courses": [
    "11-382-water-diplomacy-spring-2021",
    "15-071-the-analytics-edge-spring-2017",
    "16-346-astrodynamics-fall-2008",
    "21m-542-interdisciplinary-approaches-to-musical-time-january-iap-2010",
    "22-091-nuclear-reactor-safety-spring-2008",
    "24-263-the-nature-of-creativity-fall-2005",
    "3-091-introduction-to-solid-state-chemistry-fall-2018",
    "5-112-principles-of-chemical-science-fall-2005",
    "5-60-thermodynamics-kinetics-spring-2008",
    "5-80-small-molecule-spectroscopy-and-dynamics-fall-2008",
    "6-231-dynamic-programming-and-stochastic-control-fall-2015",
    "9-40-introduction-to-neural-computation-spring-2018",
    "cms-611j-creating-video-games-fall-2014",
    "cms-701-current-debates-in-media-spring-2015",
    "cms-s63-playful-augmented-reality-audio-design-exploration-fall-2019",
    "ec-701j-d-lab-i-development-fall-2009",
    "ec-710-d-lab-medical-technologies-for-the-developing-world-spring-2010",
    "ec-711-d-lab-energy-spring-2011",
    "ec-715-d-lab-disseminating-innovations-for-the-common-good-spring-2007",
    "ec-720j-d-lab-ii-design-spring-2010",
    "ec-721-wheelchair-design-in-developing-countries-spring-2009",
    "es-010-chemistry-of-sports-spring-2013",
    "es-287-kitchen-chemistry-spring-2009",
    "es-s41-speak-italian-with-your-mouth-full-spring-2012",
    "esd-051j-engineering-innovation-and-design-fall-2012",
    "esd-172j-x-prize-workshop-grand-challenges-in-energy-fall-2009",
    "esd-290-special-topics-in-supply-chain-management-spring-2005",
    "esd-932-engineering-ethics-spring-2006",
    "esd-s43-green-supply-chain-management-spring-2014",
    "hst-921-information-technology-in-the-health-care-system-of-the-future-spring-2009",
    "hst-s14-health-information-systems-to-improve-quality-of-care-in-resource-poor-settings-spring-2012",
    "mas-771-autism-theory-and-technology-spring-2011",
    "mas-961-networks-complexity-and-its-applications-spring-2011",
    "mas-962-special-topics-new-textiles-spring-2010",
    "mas-965-nextlab-i-designing-mobile-technologies-for-the-next-billion-users-fall-2008",
    "mas-s62-cryptocurrency-engineering-and-design-spring-2018",
    "res-10-001-making-science-and-engineering-pictures-a-practical-guide-to-presenting-your-work-spring-2016",
    "res-10-s95-physics-of-covid-19-transmission-fall-2020",
    "res-11-002-intentional-public-disruptions-art-responsibility-and-pedagogy-fall-2017",
    "res-14-001-abdul-latif-jameel-poverty-action-lab-executive-training-evaluating-social-programs-2009-spring-2009",
    "res-15-004-system-dynamics-systems-thinking-and-modeling-for-a-complex-world-january-iap-2020",
    "res-16-001-lean-enterprise-en-espanol-january-iap-2012",
    "res-18-005-highlights-of-calculus-spring-2010",
    "res-18-006-calculus-revisited-single-variable-calculus-fall-2010",
    "res-18-007-calculus-revisited-multivariable-calculus-fall-2011",
    "res-18-008-calculus-revisited-complex-variables-differential-equations-and-linear-algebra-fall-2011",
    "res-18-009-learn-differential-equations-up-close-with-gilbert-strang-and-cleve-moler-fall-2015",
    "res-18-010-a-2020-vision-of-linear-algebra-spring-2020",
    "res-2-002-finite-element-procedures-for-solids-and-structures-spring-2010",
    "res-2-005-girls-who-build-make-your-own-wearables-workshop-spring-2015",
    "res-2-006-girls-who-build-cameras-summer-2016",
    "res-21g-001-the-user-friendly-classroom-fall-2020",
    "res-3-002-collaborative-design-and-creative-expression-with-arduino-microcontrollers-january-iap-2017",
    "res-3-003-learn-to-build-your-own-videogame-with-the-unity-game-engine-and-microsoft-kinect-january-iap-2017",
    "res-5-0001-digital-lab-techniques-manual-spring-2007",
    "res-6-005-understanding-lasers-and-fiberoptics-spring-2008",
    "res-6-006-video-demonstrations-in-lasers-and-optics-spring-2008",
    "res-6-007-signals-and-systems-spring-2011",
    "res-6-008-digital-signal-processing-spring-2011",
    "res-6-010-electronic-feedback-systems-spring-2013",
    "res-6-012-introduction-to-probability-spring-2018",
    "res-8-004-reducing-the-danger-of-nuclear-weapons-and-proliferation-january-iap-2015",
    "res-9-003-brains-minds-and-machines-summer-course-summer-2015",
    "res-cms-501-envisioning-the-graduate-of-the-future-spring-2020",
    "res-ec-001-exploring-fairness-in-machine-learning-for-international-development-spring-2020",
    "res-env-003-earthdnas-climate-101-fall-2019",
    "res-ll-005-mathematics-of-big-data-and-machine-learning-january-iap-2020",
    "res-tll-004-stem-concept-videos-fall-2013",
    "res-tll-005-how-to-speak-january-iap-2018",
    "sts-081-innovation-systems-for-science-technology-energy-manufacturing-and-health-spring-2017"
  ]
}
```
 - Convert the courses with `node . -i private/input -o private/output -c private/courses.json --download --rm`
 - Search your output folder for files with `resourcetype: Video`
 - Look through the search results and ensure that the markdown body has the description matching the video it represents by finding it on https://old.ocw.mit.edu
