### PR TITLE
fix missing youtube videos with mislabled id

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -47,6 +47,7 @@ module.exports = {
   // video embedded media id's
   VIDEO_EMBEDDED_MEDIA_IDS: new Set([
     "Video-YouTube-Stream",
+    "copy_of_Video-YouTube-Stream",
     "Video-YouTube-MP4",
     "3Play-3PlayYouTubeid-Stream"
   ])

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,9 +616,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001271"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz"
-  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
+  version "1.0.30001335"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz"
+  integrity sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==
 
 chai-as-promised@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of a fix for https://github.com/mitodl/ocw-data-parser/issues/193, doesn't completely close the issue

#### What's this PR do?
If you look at the attached issue, it's about a number of videos being missing from some courses.  Upon investigation, it was found that these videos have `embedded_media` objects for their YouTube videos with an `id` property of `copy_of_Video-YouTube-Stream`.  This PR simply adds this ID to `VIDEO_EMBEDDED_MEDIA_IDS` so that these videos aren't skipped over.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and make sure you are set up to download courses from S3
 - Place the following in `private/courses.json`:
```
{
  "courses": [
    "18-01sc-single-variable-calculus-fall-2010",
    "cms-611j-creating-video-games-fall-2014"
  ]
}
```
- Run `node . -i private/input -o private/output -c private/courses.json --download --rm`
- Search the `private/input` folder for the string `copy_of_Video-YouTube-Stream` and note the videos that this appears in
- Check to make sure a corresponding markdown file has been created in the `resources` folder of the applicable course
