### PR TITLE
pull in description property of course pages

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -165,7 +165,7 @@ const generateCourseSectionFrontMatter = (
   const courseSectionFrontMatter = {
     uid:         helpers.addDashesToUid(pageId),
     title:       helpers.replaceIrregularWhitespace(title),
-    description: description
+    description: helpers.replaceIrregularWhitespace(description)
   }
 
   if (parentUid) {

--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -126,7 +126,8 @@ const generateMarkdownRecursive = (page, courseData, pathLookup) => {
     courseData["short_url"],
     page["is_media_gallery"],
     helpers.getVideoUidsFromPage(page, courseData),
-    page["type"]
+    page["type"],
+    page["description"]
   )
   courseSectionMarkdown += generateCourseSectionMarkdown(
     page,
@@ -155,14 +156,16 @@ const generateCourseSectionFrontMatter = (
   courseId,
   isMediaGallery,
   videoUids,
-  type
+  type,
+  description
 ) => {
   /**
     Generate the front matter metadata for a course section
     */
   const courseSectionFrontMatter = {
-    uid:   helpers.addDashesToUid(pageId),
-    title: helpers.replaceIrregularWhitespace(title)
+    uid:         helpers.addDashesToUid(pageId),
+    title:       helpers.replaceIrregularWhitespace(title),
+    description: description
   }
 
   if (parentUid) {

--- a/src/markdown_generators_test.js
+++ b/src/markdown_generators_test.js
@@ -492,7 +492,8 @@ describe("markdown generators", function() {
             singleCourseJsonData["short_url"],
             false,
             [],
-            "CourseSection"
+            "CourseSection",
+            "description"
           )
           .replace(/---\n/g, "")
       )
@@ -523,7 +524,8 @@ describe("markdown generators", function() {
             false,
             singleCourseJsonData["short_url"],
             [],
-            "CourseSection"
+            "CourseSection",
+            "description"
           )
           .replace(/---\n/g, "")
       )
@@ -550,7 +552,8 @@ describe("markdown generators", function() {
               "1b0190b9-ac07-7e74-7121-3af5ae8e895a",
               "b03952e4-bdfc-ea49-6227-1aeae1dedb3f"
             ],
-            "CourseSection"
+            "CourseSection",
+            "description"
           )
           .replace(/---\n/g, "")
       )


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-to-hugo/issues/512

#### What's this PR do?
This PR pulls in the `description` property of `course_pages` items and sets it on the front matter of pages.  These are plain text descriptions that will be used for `meta` tags in the `head` for the purpose of search indexing.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and make sure you are set up to download courses from S3
 - Run `node . -i private/input -o private/output -c course_json_examples/example_courses.json --download --rm`
 - Inspect the courses output to `private/output` and ensure that the pages under `content/pages` have a `description` property, it is plain text and accurate to the page it belongs to
