### PR TITLE
call page description metadata_description

### DIFF
--- a/src/markdown_generators.js
+++ b/src/markdown_generators.js
@@ -163,9 +163,9 @@ const generateCourseSectionFrontMatter = (
     Generate the front matter metadata for a course section
     */
   const courseSectionFrontMatter = {
-    uid:         helpers.addDashesToUid(pageId),
-    title:       helpers.replaceIrregularWhitespace(title),
-    description: helpers.replaceIrregularWhitespace(description)
+    uid:                  helpers.addDashesToUid(pageId),
+    title:                helpers.replaceIrregularWhitespace(title),
+    metadata_description: helpers.replaceIrregularWhitespace(description)
   }
 
   if (parentUid) {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/725
Hotfix for https://github.com/mitodl/ocw-to-hugo/pull/513

#### What's this PR do?
In https://github.com/mitodl/ocw-to-hugo/pull/513, we started pulling in the `description` property of legacy `course_pages` objects, and we put it into a front matter property called `description`.  Really we should be calling this property `metadata_description` because it is a distinct field that will be used for plain text descriptions written into the `meta` tags of course pages.

#### How should this be manually tested?
Follow the same instructions on https://github.com/mitodl/ocw-to-hugo/pull/513, but instead of `description`, the property will now be in `metadata_description`.
