### PR TITLE
replace all backticks inside code blocks with nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.13.1
+          node-version: 16.15.1
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -124,9 +124,10 @@ turndownService.addRule("tfoot", {
  * fix some strangely formatted code blocks in OCW
  * see https://github.com/mitodl/hugo-course-publisher/issues/154
  * for discussion
- * also turns <pre> elements into code blocks
+ * 
+ * also turns <pre> elements into code blocks and makes sure
+ * that there are no backticks inside
  */
-
 turndownService.addRule("codeblockfix", {
   filter:      node => node.nodeName === "PRE",
   replacement: (content, node, options) => {
@@ -141,7 +142,7 @@ turndownService.addRule("codeblockfix", {
     if (content.startsWith("\t") || content.startsWith("    ")) {
       return content
     }
-    return `\n\n\`\`\`\n${helpers.removeLeadingBackslash(content)}\n\`\`\`\n\n`
+    return `\n\n\`\`\`\n${helpers.removeLeadingBackslash(content).replaceAll("`", "")}\n\`\`\`\n\n`
   }
 })
 

--- a/src/turndown.js
+++ b/src/turndown.js
@@ -124,7 +124,7 @@ turndownService.addRule("tfoot", {
  * fix some strangely formatted code blocks in OCW
  * see https://github.com/mitodl/hugo-course-publisher/issues/154
  * for discussion
- * 
+ *
  * also turns <pre> elements into code blocks and makes sure
  * that there are no backticks inside
  */
@@ -142,7 +142,9 @@ turndownService.addRule("codeblockfix", {
     if (content.startsWith("\t") || content.startsWith("    ")) {
       return content
     }
-    return `\n\n\`\`\`\n${helpers.removeLeadingBackslash(content).replaceAll("`", "")}\n\`\`\`\n\n`
+    return `\n\n\`\`\`\n${helpers
+      .removeLeadingBackslash(content)
+      .replaceAll("`", "")}\n\`\`\`\n\n`
   }
 })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/704

#### What's this PR do?
This PR adds functionality to the `codeblockfix` rule to ensure that elements that normally produce inline code blocks (`code`, `kbd`, `tt`, `samp`) do not do so when included inside an element that produces a multi-line code block.  This is done by simply replacing backticks inside multi-line code blocks with nothing.  This PR also updates the version of Node used in the CI Github Actions runner as it was causing a test to fail.

#### How should this be manually tested?
 - Read the readme if you've never used `ocw-to-hugo` before and make sure you're set up to download courses from S3
 - Place the following in `private/courses.json`:
```
{
    "courses": [
        "15-071-the-analytics-edge-spring-2017",
        "2-s998-marine-autonomy-sensing-and-communications-spring-2012",
        "6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016",
        "6-828-operating-system-engineering-fall-2012",
        "6-s096-effective-programming-in-c-and-c-january-iap-2014"
    ]
}
```
 - Run `node . -i private/ -o private/output --courses private/courses.json --download --rm` on `master`
 - Run `node . -i private/ -o private/test--courses private/courses.json --download --rm` on `cg/remove-nested-code-blocks`
 - Use a diff tool such as [Meld](https://meldmerge.org/) to compare `private/output` and `private/test` and verify that backticks inside code blocks have been properly removed
